### PR TITLE
Fix erroneously added members due to misuse of a script

### DIFF
--- a/data/Mainline_mods/Mods/Magiclysm/vehicles/summoned_vehicles.json
+++ b/data/Mainline_mods/Mods/Magiclysm/vehicles/summoned_vehicles.json
@@ -21,8 +21,7 @@
     "symbol": "]",
     "color": "light_gray",
     "diameter": 20,
-    "width": 10,
-    "parts": [  ]
+    "width": 10
   },
   {
     "id": "magic_motorcycle",
@@ -69,15 +68,13 @@
       "repair": { "skills": [ [ "mechanics", 20 ], [ "spellcraft", 1 ] ], "time": "60 m", "using": [ [ "welding_standard", 5 ] ] }
     },
     "flags": [ "INITIAL_PART", "ENGINE", "STABLE", "E_STARTS_INSTANTLY", "STEERABLE", "WHEEL", "OBSTACLE", "CARGO", "MAGIC_FOLLOW" ],
-    "damage_reduction": { "all": 12 },
-    "parts": [  ]
+    "damage_reduction": { "all": 12 }
   },
   {
     "id": "mana",
     "name": "mana energy",
     "default": "mana",
-    "type": "ammunition_type",
-    "parts": [  ]
+    "type": "ammunition_type"
   },
   {
     "id": "mana",
@@ -94,7 +91,6 @@
     "symbol": "?",
     "color": "magenta",
     "count": 1,
-    "ammo_type": "mana",
-    "parts": [  ]
+    "ammo_type": "mana"
   }
 ]

--- a/data/Unleash_The_Mods/mods/Custom_Bandit_King_Start/vehicles.json
+++ b/data/Unleash_The_Mods/mods/Custom_Bandit_King_Start/vehicles.json
@@ -34,7 +34,6 @@
       { "charges": 500, "item": "belt223", "ammo-item": "556_incendiary" },
       { "charges": 500, "item": "belt223", "ammo-item": "556_incendiary" }
     ],
-    "parts": [  ]
   },
   {
     "id": "Kraken",

--- a/data/Unleash_The_Mods/mods/Custom_Bandit_King_Start/vehicles.json
+++ b/data/Unleash_The_Mods/mods/Custom_Bandit_King_Start/vehicles.json
@@ -33,7 +33,7 @@
       { "charges": 500, "item": "belt223", "ammo-item": "556_incendiary" },
       { "charges": 500, "item": "belt223", "ammo-item": "556_incendiary" },
       { "charges": 500, "item": "belt223", "ammo-item": "556_incendiary" }
-    ],
+    ]
   },
   {
     "id": "Kraken",


### PR DESCRIPTION
When I ran `run_vehicle_reformatter.py`, it accidentally added `"parts": [  ]` members to objects where they really don't belong.
