### PR TITLE
Use `"armor"` instead of separate values (2)

### DIFF
--- a/data/Legacy_mods/mods/Medieval_Stuff/shields.json
+++ b/data/Legacy_mods/mods/Medieval_Stuff/shields.json
@@ -13,12 +13,10 @@
     "material": [ "wood" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 40,
-    "encumbrance": 12,
     "material_thickness": 2,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ]
+    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ],
+    "armor": { "coverage": 40, "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 12 }
   },
   {
     "id": "shield_wooden_large",
@@ -34,12 +32,10 @@
     "material": [ "wood" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 70,
-    "encumbrance": 28,
     "material_thickness": 2,
     "techniques": [ "WBLOCK_3" ],
-    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ]
+    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ],
+    "armor": { "coverage": 70, "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 28 }
   },
   {
     "id": "shield_heater",
@@ -55,12 +51,10 @@
     "material": [ "wood" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 40,
-    "encumbrance": 12,
     "material_thickness": 3,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ]
+    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ],
+    "armor": { "coverage": 40, "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 12 }
   },
   {
     "id": "shield_kite",
@@ -77,12 +71,10 @@
     "material": [ "wood" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 60,
-    "encumbrance": 24,
     "material_thickness": 3,
     "techniques": [ "WBLOCK_3" ],
-    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ]
+    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ],
+    "armor": { "coverage": 60, "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 24 }
   },
   {
     "id": "shield_round",
@@ -97,12 +89,10 @@
     "material": [ "wood", "iron" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 45,
-    "encumbrance": 16,
     "material_thickness": 3,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ]
+    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ],
+    "armor": { "coverage": 45, "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 16 }
   },
   {
     "id": "shield_hoplon",
@@ -118,12 +108,10 @@
     "material": [ "wood", "bronze" ],
     "symbol": "[",
     "color": "yellow",
-    "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 50,
-    "encumbrance": 20,
     "material_thickness": 4,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ]
+    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ],
+    "armor": { "coverage": 50, "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 20 }
   },
   {
     "id": "shield_scutum",
@@ -139,12 +127,10 @@
     "material": [ "wood", "iron" ],
     "symbol": "[",
     "color": "red",
-    "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 70,
-    "encumbrance": 28,
     "material_thickness": 4,
     "techniques": [ "WBLOCK_3" ],
-    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ]
+    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ],
+    "armor": { "coverage": 70, "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 28 }
   },
   {
     "id": "shield_buckler",
@@ -159,11 +145,9 @@
     "material": [ "steel" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 30,
-    "encumbrance": 8,
     "material_thickness": 3,
     "techniques": [ "WBLOCK_2" ],
-    "flags": [ "OVERSIZE", "STURDY", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ]
+    "flags": [ "OVERSIZE", "STURDY", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ],
+    "armor": { "coverage": 30, "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 8 }
   }
 ]

--- a/data/Legacy_mods/mods/More_Survival_Tools/armor.json
+++ b/data/Legacy_mods/mods/More_Survival_Tools/armor.json
@@ -10,13 +10,11 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "head" ],
-    "coverage": 95,
-    "encumbrance": 10,
     "warmth": 10,
     "material_thickness": 1,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "SUN_GLASSES", "WATERPROOF" ]
+    "flags": [ "VARSIZE", "SUN_GLASSES", "WATERPROOF" ],
+    "armor": { "coverage": 95, "covers": [ "head" ], "encumbrance": 10 }
   },
   {
     "id": "javelin_bag",

--- a/data/Mainline_mods/Mods/Aftershock/items/armor.json
+++ b/data/Mainline_mods/Mods/Aftershock/items/armor.json
@@ -13,15 +13,12 @@
     "material": [ "glass", "superalloy", "platinum" ],
     "symbol": "[",
     "color": "cyan",
-    "covers": [ "torso" ],
     "looks_like": "molle_pack",
-    "coverage": 30,
-    "encumbrance": 5,
-    "max_encumbrance": 10,
     "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "100 L", "max_contains_weight": "500 kg", "moves": 300 } ],
     "warmth": 5,
     "material_thickness": 2,
-    "flags": [ "BELTED", "ONLY_ONE", "LEAK_DAM" ]
+    "flags": [ "BELTED", "ONLY_ONE", "LEAK_DAM" ],
+    "armor": { "coverage": 30, "covers": [ "torso" ], "encumbrance": [ 5, 10 ] }
   },
   {
     "id": "afs_titanium_vest",
@@ -36,10 +33,8 @@
     "symbol": "[",
     "looks_like": "armor_scrapsuit",
     "color": "white",
-    "covers": [ "torso" ],
-    "coverage": 80,
-    "encumbrance": 4,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 80, "covers": [ "torso" ], "encumbrance": 4 }
   },
   {
     "id": "afs_holo_cloak_mk2",
@@ -64,13 +59,11 @@
     "material": [ "graphene_weave" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "torso", "head", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 85,
-    "encumbrance": 4,
     "warmth": 30,
     "material_thickness": 3,
     "flags": [ "OVERSIZE", "HOOD", "OUTER", "NO_REPAIR", "SUPER_FANCY", "STURDY" ],
-    "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "BONUS_DODGE", "add": 1 } ] } ] }
+    "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "BONUS_DODGE", "add": 1 } ] } ] },
+    "armor": { "coverage": 85, "covers": [ "torso", "head", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 4 }
   },
   {
     "id": "xl_jeans",
@@ -131,12 +124,10 @@
     "material": [ "glass", "steel" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "torso" ],
-    "coverage": 40,
-    "encumbrance": 12,
     "material_thickness": 3,
     "use_action": [ "SOLARPACK" ],
-    "flags": [ "FRAGILE", "OUTER", "ONLY_ONE", "SOLARPACK" ]
+    "flags": [ "FRAGILE", "OUTER", "ONLY_ONE", "SOLARPACK" ],
+    "armor": { "coverage": 40, "covers": [ "torso" ], "encumbrance": 12 }
   },
   {
     "id": "q_solarpack_on",
@@ -152,13 +143,11 @@
     "material": [ "glass", "steel" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "torso" ],
-    "coverage": 40,
-    "encumbrance": 20,
     "material_thickness": 1,
     "use_action": [ "SOLARPACK_OFF" ],
     "solar_efficiency": 0.3,
-    "flags": [ "FRAGILE", "OUTER", "ONLY_ONE", "SOLARPACK_ON" ]
+    "flags": [ "FRAGILE", "OUTER", "ONLY_ONE", "SOLARPACK_ON" ],
+    "armor": { "coverage": 40, "covers": [ "torso" ], "encumbrance": 20 }
   },
   {
     "id": "xlswat_armor",
@@ -177,9 +166,6 @@
     "symbol": "[",
     "looks_like": "touring_suit",
     "color": "dark_gray",
-    "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r" ],
-    "coverage": 95,
-    "encumbrance": 25,
     "warmth": 35,
     "material_thickness": 9,
     "valid_mods": [ "steel_padded" ],
@@ -188,7 +174,8 @@
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "750 ml", "max_contains_weight": "2 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "750 ml", "max_contains_weight": "2 kg", "moves": 80 }
-    ]
+    ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "xlballistic_vest_empty",
@@ -203,12 +190,10 @@
     "material": [ "nylon" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "torso" ],
-    "coverage": 85,
-    "encumbrance": 6,
     "warmth": 15,
     "material_thickness": 8,
-    "flags": [ "OVERSIZE", "STURDY", "OUTER", "WATER_FRIENDLY" ]
+    "flags": [ "OVERSIZE", "STURDY", "OUTER", "WATER_FRIENDLY" ],
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": 6 }
   },
   {
     "id": "xlballistic_vest_esapi",
@@ -222,12 +207,10 @@
     "material": [ "nylon", "ceramic" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "torso" ],
-    "coverage": 85,
-    "encumbrance": 10,
     "warmth": 15,
     "material_thickness": 26,
-    "flags": [ "OVERSIZE", "STURDY", "OUTER", "WATER_FRIENDLY", "NO_REPAIR" ]
+    "flags": [ "OVERSIZE", "STURDY", "OUTER", "WATER_FRIENDLY", "NO_REPAIR" ],
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": 10 }
   },
   {
     "id": "xlboots_combat",
@@ -246,13 +229,11 @@
     "symbol": "[",
     "looks_like": "boots",
     "color": "dark_gray",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 25,
     "warmth": 25,
     "material_thickness": 5,
     "environmental_protection": 2,
-    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "foot_l", "foot_r" ], "encumbrance": 25 }
   },
   {
     "id": "xlgloves_tactical",
@@ -269,12 +250,10 @@
     "symbol": "[",
     "looks_like": "fire_gauntlets",
     "color": "dark_gray",
-    "covers": [ "hand_l", "hand_r" ],
-    "coverage": 100,
-    "encumbrance": 13,
     "warmth": 20,
     "material_thickness": 5,
-    "flags": [ "OVERSIZE", "VARSIZE", "STURDY" ]
+    "flags": [ "OVERSIZE", "VARSIZE", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "hand_l", "hand_r" ], "encumbrance": 13 }
   },
   {
     "id": "tripaw_xlgloves_tactical",
@@ -291,12 +270,10 @@
     "symbol": "[",
     "looks_like": "fire_gauntlets",
     "color": "dark_gray",
-    "covers": [ "hand_l", "hand_r" ],
-    "coverage": 100,
-    "encumbrance": 5,
     "warmth": 20,
     "material_thickness": 3,
-    "flags": [ "OVERSIZE", "VARSIZE", "STURDY" ]
+    "flags": [ "OVERSIZE", "VARSIZE", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "hand_l", "hand_r" ], "encumbrance": 5 }
   },
   {
     "id": "xlleather_belt",
@@ -379,10 +356,6 @@
     "material": [ "steel", "plastic" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "torso" ],
-    "coverage": 20,
-    "encumbrance": 2,
-    "max_encumbrance": 15,
     "material_thickness": 2,
     "use_action": { "type": "holster", "holster_prompt": "Stash ammo", "holster_msg": "You stash your %s." },
     "pocket_data": [
@@ -425,7 +398,8 @@
         "moves": 60
       }
     ],
-    "flags": [ "WATER_FRIENDLY", "BELTED" ]
+    "flags": [ "WATER_FRIENDLY", "BELTED" ],
+    "armor": { "coverage": 20, "covers": [ "torso" ], "encumbrance": [ 2, 15 ] }
   },
   {
     "id": "wetsuit_cecalia",
@@ -441,10 +415,6 @@
     "symbol": "[",
     "looks_like": "wetsuit",
     "color": "light_gray",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 90,
-    "encumbrance": 2,
-    "max_encumbrance": 5,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "350 ml", "max_contains_weight": "1 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "350 ml", "max_contains_weight": "1 kg", "moves": 80 },
@@ -454,7 +424,8 @@
     "warmth": 30,
     "material_thickness": 1,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "WATER_FRIENDLY", "SKINTIGHT" ]
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "SKINTIGHT" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": [ 2, 5 ] }
   },
   {
     "id": "combat_wetsuit_cecalia",
@@ -470,10 +441,6 @@
     "symbol": "[",
     "looks_like": "wetsuit",
     "color": "light_gray",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 90,
-    "encumbrance": 2,
-    "max_encumbrance": 5,
     "use_action": { "type": "holster", "holster_prompt": "Stash ammo", "holster_msg": "You stash your %s." },
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "350 ml", "max_contains_weight": "1 kg", "moves": 80 },
@@ -509,6 +476,7 @@
     "warmth": 30,
     "material_thickness": 2,
     "environmental_protection": 3,
-    "flags": [ "VARSIZE", "WATER_FRIENDLY", "SKINTIGHT" ]
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "SKINTIGHT" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": [ 2, 5 ] }
   }
 ]

--- a/data/Mainline_mods/Mods/Aftershock/items/cast_spell_items.json
+++ b/data/Mainline_mods/Mods/Aftershock/items/cast_spell_items.json
@@ -10,11 +10,10 @@
     "material": [ "superalloy" ],
     "symbol": "[",
     "color": "light_red",
-    "covers": [ "torso" ],
     "charges_per_use": 1,
-    "coverage": 0,
     "warmth": 0,
-    "flags": [ "WATER_FRIENDLY", "ALLOWS_NATURAL_ATTACKS", "ONLY_ONE", "NO_UNLOAD", "NO_RELOAD" ]
+    "flags": [ "WATER_FRIENDLY", "ALLOWS_NATURAL_ATTACKS", "ONLY_ONE", "NO_UNLOAD", "NO_RELOAD" ],
+    "armor": { "coverage": 0, "covers": [ "torso" ] }
   },
   {
     "id": "afs_holo_transposition_caster",

--- a/data/Mainline_mods/Mods/Aftershock/items/ethereal.json
+++ b/data/Mainline_mods/Mods/Aftershock/items/ethereal.json
@@ -9,9 +9,11 @@
     "price": "3646 cent",
     "symbol": "o",
     "color": "green",
-    "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r", "mouth", "eyes" ],
     "flags": [ "AURA", "SEMITANGIBLE", "OVERSIZE", "ONLY_ONE", "TRADER_AVOID", "NO_TAKEOFF", "NONCONDUCTIVE" ],
-    "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "mutations": [ "AFS_CRYOADAPTATION" ] } ] }
+    "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "mutations": [ "AFS_CRYOADAPTATION" ] } ] },
+    "armor": {
+      "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r", "mouth", "eyes" ]
+    }
   },
   {
     "id": "cold_res_cream_greater",
@@ -23,10 +25,12 @@
     "price": "3646 cent",
     "symbol": "o",
     "color": "green",
-    "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r", "mouth", "eyes" ],
     "flags": [ "AURA", "SEMITANGIBLE", "OVERSIZE", "ONLY_ONE", "TRADER_AVOID", "NO_TAKEOFF", "NONCONDUCTIVE" ],
     "relic_data": {
       "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "ARMOR_COLD", "multiply": -0.25 } ] } ]
+    },
+    "armor": {
+      "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r", "mouth", "eyes" ]
     }
   }
 ]

--- a/data/Mainline_mods/Mods/Aftershock/items/items.json
+++ b/data/Mainline_mods/Mods/Aftershock/items/items.json
@@ -182,10 +182,9 @@
     "material": [ "titanium" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "hand_l", "hand_r" ],
     "sided": true,
-    "coverage": 5,
-    "flags": [ "WATCH", "STURDY", "BELTED", "ALLOWS_NATURAL_ATTACKS", "WATER_FRIENDLY", "OVERSIZE" ]
+    "flags": [ "WATCH", "STURDY", "BELTED", "ALLOWS_NATURAL_ATTACKS", "WATER_FRIENDLY", "OVERSIZE" ],
+    "armor": { "coverage": 5, "covers": [ "hand_l", "hand_r" ] }
   },
   {
     "id": "afs_titanium_ring",

--- a/data/Mainline_mods/Mods/Aftershock/items/obsolete.json
+++ b/data/Mainline_mods/Mods/Aftershock/items/obsolete.json
@@ -298,11 +298,7 @@
     "price": "1000 kUSD",
     "price_postapoc": "500 USD",
     "material": [ "superalloy", "kevlar" ],
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 100,
     "material_thickness": 2,
-    "encumbrance": 4,
-    "max_encumbrance": 9,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1 L", "max_contains_weight": "3 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1 L", "max_contains_weight": "3 kg", "moves": 80 }
@@ -320,7 +316,12 @@
       "OUTER",
       "STURDY"
     ],
-    "looks_like": "depowered_armor"
+    "looks_like": "depowered_armor",
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": [ 4, 9 ]
+    }
   },
   {
     "id": "afs_hev_helmet",
@@ -334,10 +335,7 @@
     "price": "100 kUSD",
     "price_postapoc": "50 USD",
     "material": [ "superalloy", "plastic" ],
-    "covers": [ "head", "eyes", "mouth" ],
-    "coverage": 100,
     "material_thickness": 2,
-    "encumbrance": 15,
     "warmth": 20,
     "environmental_protection": 11,
     "qualities": [ [ "GLARE", 3 ] ],
@@ -369,7 +367,8 @@
           "light_disposable_cell"
         ]
       }
-    ]
+    ],
+    "armor": { "coverage": 100, "covers": [ "head", "eyes", "mouth" ], "encumbrance": 15 }
   },
   {
     "id": "afs_hev_helmet_on",
@@ -396,12 +395,10 @@
     "symbol": "[",
     "looks_like": "quiver",
     "color": "dark_gray",
-    "covers": [ "torso" ],
-    "coverage": 20,
-    "encumbrance": 5,
     "material_thickness": 1,
     "pocket_data": [ { "ammo_restriction": { "arrow": 40, "bolt": 40 }, "moves": 20 } ],
-    "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY" ]
+    "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY" ],
+    "armor": { "coverage": 20, "covers": [ "torso" ], "encumbrance": 5 }
   },
   {
     "id": "afs_survivor_belt",
@@ -430,12 +427,10 @@
     "symbol": "[",
     "looks_like": "armor_blarmor",
     "color": "brown",
-    "covers": [ "torso" ],
-    "coverage": 100,
-    "encumbrance": 16,
     "warmth": 25,
     "material_thickness": 3,
-    "flags": [ "RAINPROOF", "STURDY", "OUTER", "ONLY_ONE", "VARSIZE" ]
+    "flags": [ "RAINPROOF", "STURDY", "OUTER", "ONLY_ONE", "VARSIZE" ],
+    "armor": { "coverage": 100, "covers": [ "torso" ], "encumbrance": 16 }
   },
   {
     "id": "afs_mbr_titanium",
@@ -452,10 +447,6 @@
     "symbol": "[",
     "looks_like": "kevlar",
     "color": "light_gray",
-    "covers": [ "torso" ],
-    "coverage": 85,
-    "encumbrance": 3,
-    "max_encumbrance": 7,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1 L", "max_contains_weight": "3 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1 L", "max_contains_weight": "3 kg", "moves": 80 }
@@ -463,7 +454,8 @@
     "warmth": 15,
     "material_thickness": 3,
     "use_action": { "type": "holster", "holster_prompt": "Stash ammo", "holster_msg": "You stash your %s." },
-    "flags": [ "STURDY", "OUTER" ]
+    "flags": [ "STURDY", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": [ 3, 7 ] }
   },
   {
     "id": "afs_sunesthesia",
@@ -634,12 +626,10 @@
     "symbol": "[",
     "looks_like": "armor_blarmor",
     "color": "white",
-    "covers": [ "torso" ],
-    "coverage": 95,
-    "encumbrance": 14,
     "warmth": 20,
     "material_thickness": 2,
-    "flags": [ "OUTER", "VARSIZE" ]
+    "flags": [ "OUTER", "VARSIZE" ],
+    "armor": { "coverage": 95, "covers": [ "torso" ], "encumbrance": 14 }
   },
   {
     "id": "broken_milbot_flame",

--- a/data/Mainline_mods/Mods/Aftershock/items/tool_armor.json
+++ b/data/Mainline_mods/Mods/Aftershock/items/tool_armor.json
@@ -33,13 +33,15 @@
       "need_charges": 5,
       "need_charges_msg": "The %s's batteries are dead."
     },
-    "covers": [ "head", "mouth", "eyes", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
     "warmth": 20,
     "environmental_protection": 10,
-    "coverage": 100,
     "material_thickness": 1,
-    "encumbrance": 5,
-    "flags": [ "VARSIZE", "SKINTIGHT", "RAINPROOF", "STURDY", "WATERPROOF", "HYGROMETER" ]
+    "flags": [ "VARSIZE", "SKINTIGHT", "RAINPROOF", "STURDY", "WATERPROOF", "HYGROMETER" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "head", "mouth", "eyes", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 5
+    }
   },
   {
     "id": "afs_cryopod_bodyglove_on",

--- a/data/Mainline_mods/Mods/Aftershock/items/tools.json
+++ b/data/Mainline_mods/Mods/Aftershock/items/tools.json
@@ -184,13 +184,11 @@
     "copy-from": "UPS_off",
     "name": { "str": "UPS", "str_pl": "UPS's" },
     "description": "This is a unified power supply, or UPS.  It is a device developed jointly by military and scientific interests for use in combat and the field.  The UPS is designed to power armor and some guns, but drains batteries quickly.  It can be worn strapped to either leg for ease of access, and it's been waterproofed to protect the delicate electronics.  Has its own custom battery, rechargeable and with higher capacity, but not removable",
-    "coverage": 5,
     "ammo": [ "battery" ],
-    "encumbrance": 2,
-    "covers": [ "leg_l", "leg_r" ],
     "sided": true,
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 1500 } } ],
-    "flags": [ "RECHARGE", "WAIST", "FRAGILE", "OVERSIZE", "WATERPROOF", "IS_UPS" ]
+    "flags": [ "RECHARGE", "WAIST", "FRAGILE", "OVERSIZE", "WATERPROOF", "IS_UPS" ],
+    "armor": { "coverage": 5, "covers": [ "leg_l", "leg_r" ], "encumbrance": 2 }
   },
   {
     "id": "adv_UPS_off",
@@ -198,11 +196,9 @@
     "copy-from": "adv_UPS_off",
     "name": { "str": "advanced UPS", "str_pl": "advanced UPS's" },
     "description": "This is an advanced version of the unified power supply, or UPS.  This device has been significantly redesigned to provide better efficiency as well as to consume plutonium fuel cells rather than batteries, and is both slimmer and lighter to wear.  Sadly, its plutonium reactor can't be charged in UPS charging station.",
-    "coverage": 5,
-    "encumbrance": 1,
-    "covers": [ "leg_l", "leg_r" ],
     "sided": true,
-    "flags": [ "WAIST", "FRAGILE", "OVERSIZE", "IS_UPS" ]
+    "flags": [ "WAIST", "FRAGILE", "OVERSIZE", "IS_UPS" ],
+    "armor": { "coverage": 5, "covers": [ "leg_l", "leg_r" ], "encumbrance": 1 }
   },
   {
     "id": "bionic_maintenance_toolkit",
@@ -290,7 +286,6 @@
     "color": "dark_gray",
     "material": [ "glass", "titanium" ],
     "copy-from": "fancy_sunglasses",
-    "covers": [ "eyes", "torso" ],
     "ammo": [ "battery" ],
     "charges_per_use": 2,
     "use_action": [
@@ -316,7 +311,8 @@
         "max_contains_weight": "20 kg",
         "item_restriction": [ "medium_battery_cell", "medium_plus_battery_cell", "medium_atomic_battery_cell", "medium_disposable_cell" ]
       }
-    ]
+    ],
+    "armor": { "covers": [ "eyes", "torso" ] }
   },
   {
     "id": "vr_laptop_holosuite",

--- a/data/Mainline_mods/Mods/CRT_EXPANSION/deadspace/deadspaceitems.json
+++ b/data/Mainline_mods/Mods/CRT_EXPANSION/deadspace/deadspaceitems.json
@@ -12,8 +12,6 @@
     "material": [ "plastic", "steel" ],
     "symbol": "[",
     "color": "light_green",
-    "coverage": 0,
-    "encumbrance": 0,
     "warmth": 0,
     "//": "Legacy artifact data is set for all stats +2",
     "relic_data": {
@@ -32,7 +30,8 @@
     },
     "material_thickness": 10,
     "environmental_protection": 0,
-    "flags": [ "ONLY_ONE", "TRADER_AVOID", "BELTED", "NO_TAKEOFF" ]
+    "flags": [ "ONLY_ONE", "TRADER_AVOID", "BELTED", "NO_TAKEOFF" ],
+    "armor": { "coverage": 0, "encumbrance": 0 }
   },
   {
     "id": "ds_armor",
@@ -48,9 +47,6 @@
     "material": [ "superalloy", "nomex", "kevlar" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "head", "eyes", "mouth", "torso", "leg_l", "leg_r", "arm_l", "arm_r", "hand_l", "hand_r", "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 25,
     "warmth": 15,
     "pocket_data": [
       {
@@ -65,6 +61,11 @@
     "material_thickness": 3,
     "environmental_protection": 18,
     "use_action": [ "WEATHER_TOOL" ],
-    "flags": [ "ELECTRIC_IMMUNE", "GAS_PROOF", "VARSIZE", "OVERSIZE", "STURDY", "ONLY_ONE", "WATERPROOF", "CLIMATE_CONTROL" ]
+    "flags": [ "ELECTRIC_IMMUNE", "GAS_PROOF", "VARSIZE", "OVERSIZE", "STURDY", "ONLY_ONE", "WATERPROOF", "CLIMATE_CONTROL" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "head", "eyes", "mouth", "torso", "leg_l", "leg_r", "arm_l", "arm_r", "hand_l", "hand_r", "foot_l", "foot_r" ],
+      "encumbrance": 25
+    }
   }
 ]

--- a/data/Mainline_mods/Mods/CRT_EXPANSION/items/crt_armor.json
+++ b/data/Mainline_mods/Mods/CRT_EXPANSION/items/crt_armor.json
@@ -12,14 +12,12 @@
     "material": [ "neoprene", "kevlar" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "eyes", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 20,
     "warmth": 30,
     "material_thickness": 2,
     "environmental_protection": 10,
     "qualities": [ [ "GLARE", 1 ] ],
-    "flags": [ "WATERPROOF", "STURDY", "SUN_GLASSES", "VARSIZE", "WATCH", "THERMOMETER" ]
+    "flags": [ "WATERPROOF", "STURDY", "SUN_GLASSES", "VARSIZE", "WATCH", "THERMOMETER" ],
+    "armor": { "coverage": 100, "covers": [ "eyes", "mouth" ], "encumbrance": 20 }
   },
   {
     "id": "crt_boots",
@@ -31,9 +29,9 @@
     "weight": "1500 g",
     "price": "2500 USD",
     "warmth": 40,
-    "encumbrance": 17,
     "material_thickness": 5,
-    "environmental_protection": 5
+    "environmental_protection": 5,
+    "armor": { "encumbrance": 17 }
   },
   {
     "id": "crt_la_boots",
@@ -49,13 +47,11 @@
     "material": [ "rubber", "superalloy", "nomex" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 10,
     "warmth": 25,
     "material_thickness": 3,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "foot_l", "foot_r" ], "encumbrance": 10 }
   },
   {
     "id": "crt_gloves",
@@ -63,12 +59,11 @@
     "type": "ARMOR",
     "name": { "str": "pair of C.R.I.T fingertip-less gloves", "str_pl": "pairs of C.R.I.T fingertip-less gloves" },
     "description": "A pair of standard-issue gloves.  Made with superalloy mesh for those with gene-modding and/or mutations while still allowing greater manipulation of items and moderate protection.",
-    "encumbrance": 12,
-    "coverage": 85,
     "warmth": 20,
     "material": [ "kevlar", "superalloy" ],
     "material_thickness": 2,
-    "flags": [ "ALLOWS_NATURAL_ATTACKS", "STURDY", "WATERPROOF" ]
+    "flags": [ "ALLOWS_NATURAL_ATTACKS", "STURDY", "WATERPROOF" ],
+    "armor": { "coverage": 85, "encumbrance": 12 }
   },
   {
     "id": "crt_gloves_liner",
@@ -76,12 +71,11 @@
     "type": "ARMOR",
     "name": { "str": "pair of C.R.I.T fingertip-less liners", "str_pl": "pairs of C.R.I.T fingertip-less liners" },
     "description": "A pair of standard-issue glove liners.  Made with neoprene and rubber mesh for warmth and fingertip-less for those with gene-modding and/or mutations while still allowing greater manipulation of items and moderate protection.",
-    "encumbrance": 3,
-    "coverage": 85,
     "warmth": 15,
     "material": [ "neoprene", "rubber" ],
     "material_thickness": 1,
-    "flags": [ "ALLOWS_NATURAL_ATTACKS", "SKINTIGHT" ]
+    "flags": [ "ALLOWS_NATURAL_ATTACKS", "SKINTIGHT" ],
+    "armor": { "coverage": 85, "encumbrance": 3 }
   },
   {
     "id": "crt_backpack",
@@ -91,10 +85,10 @@
     "description": "A standard-issue pack.  Based on the MOLLE backpack's design, this smaller pack strikes a fine balance between storage space and encumbrance and allows a larger weapon to be holstered, drawing and holstering is still rather awkward even with the magnetized clips, but practice helps.",
     "color": "dark_gray",
     "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "9 L", "max_contains_weight": "27 kg", "moves": 200 } ],
-    "encumbrance": 3,
     "material_thickness": 3,
     "material": [ "leather", "kevlar" ],
-    "flags": [ "BELTED", "OVERSIZE", "NO_QUICKDRAW", "STURDY", "WATERPROOF" ]
+    "flags": [ "BELTED", "OVERSIZE", "NO_QUICKDRAW", "STURDY", "WATERPROOF" ],
+    "armor": { "encumbrance": 3 }
   },
   {
     "id": "crt_chestrig",
@@ -134,13 +128,11 @@
     "material": [ "superalloy", "neoprene", "rubber" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "arm_l", "arm_r" ],
-    "coverage": 100,
-    "encumbrance": 20,
     "warmth": 17,
     "material_thickness": 4,
     "environmental_protection": 3,
-    "flags": [ "STURDY", "BELTED", "BLOCK_WHILE_WORN", "WATER_FRIENDLY" ]
+    "flags": [ "STURDY", "BELTED", "BLOCK_WHILE_WORN", "WATER_FRIENDLY" ],
+    "armor": { "coverage": 100, "covers": [ "arm_l", "arm_r" ], "encumbrance": 20 }
   },
   {
     "id": "crt_belt",
@@ -165,10 +157,6 @@
     "material": [ "neoprene", "rubber", "kevlar" ],
     "symbol": "[",
     "color": "black_green",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 100,
-    "encumbrance": 10,
-    "max_encumbrance": 20,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1 L", "max_contains_weight": "3 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1 L", "max_contains_weight": "3 kg", "moves": 80 },
@@ -178,7 +166,8 @@
     "warmth": 20,
     "material_thickness": 3,
     "environmental_protection": 9,
-    "flags": [ "POCKETS", "OUTER", "COLLAR", "STURDY", "WATERPROOF", "RAINPROOF" ]
+    "flags": [ "POCKETS", "OUTER", "COLLAR", "STURDY", "WATERPROOF", "RAINPROOF" ],
+    "armor": { "coverage": 100, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": [ 10, 20 ] }
   },
   {
     "id": "crt_aarmor",
@@ -194,10 +183,6 @@
     "material": [ "kevlar", "nomex", "plastic" ],
     "symbol": "[",
     "color": "light_green",
-    "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ],
-    "coverage": 100,
-    "encumbrance": 17,
-    "max_encumbrance": 25,
     "warmth": 25,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1 L", "max_contains_weight": "3 kg", "moves": 80 },
@@ -205,7 +190,8 @@
     ],
     "material_thickness": 5,
     "environmental_protection": 25,
-    "flags": [ "VARSIZE", "WATERPROOF", "HOOD", "COLLAR", "RAINPROOF", "STURDY", "RAD_RESIST", "OUTER" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "HOOD", "COLLAR", "RAINPROOF", "STURDY", "RAD_RESIST", "OUTER" ],
+    "armor": { "coverage": 100, "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ], "encumbrance": [ 17, 25 ] }
   },
   {
     "id": "crt_legrig",
@@ -218,16 +204,13 @@
     "material": [ "plastic", "cotton", "rubber" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 30,
-    "encumbrance": 1,
-    "max_encumbrance": 3,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1 L", "max_contains_weight": "3 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1 L", "max_contains_weight": "3 kg", "moves": 80 }
     ],
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "WATER_FRIENDLY", "BELTED", "RAINPROOF", "ALLOWS_TAIL" ]
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "BELTED", "RAINPROOF", "ALLOWS_TAIL" ],
+    "armor": { "coverage": 30, "covers": [ "leg_l", "leg_r" ], "encumbrance": [ 1, 3 ] }
   },
   {
     "id": "crt_earmor",
@@ -243,10 +226,6 @@
     "material": [ "steel", "kevlar" ],
     "symbol": "[",
     "color": "cyan",
-    "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ],
-    "coverage": 90,
-    "encumbrance": 27,
-    "max_encumbrance": 35,
     "warmth": 20,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1 L", "max_contains_weight": "3 kg", "moves": 80 },
@@ -254,7 +233,8 @@
     ],
     "material_thickness": 4,
     "environmental_protection": 5,
-    "flags": [ "VARSIZE", "STURDY", "BELTED" ]
+    "flags": [ "VARSIZE", "STURDY", "BELTED" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ], "encumbrance": [ 27, 35 ] }
   },
   {
     "id": "crt_earmor_boots",
@@ -270,13 +250,11 @@
     "material": [ "kevlar", "superalloy" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 30,
     "warmth": 5,
     "material_thickness": 3,
     "environmental_protection": 4,
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY", "OUTER", "OVERSIZE" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY", "OUTER", "OVERSIZE" ],
+    "armor": { "coverage": 100, "covers": [ "foot_l", "foot_r" ], "encumbrance": 30 }
   },
   {
     "id": "crt_sarmor",
@@ -290,10 +268,6 @@
     "material": [ "neoprene", "kevlar", "superalloy" ],
     "symbol": "[",
     "color": "light_blue",
-    "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ],
-    "coverage": 100,
-    "encumbrance": 3,
-    "max_encumbrance": 7,
     "warmth": 20,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1 L", "max_contains_weight": "3 kg", "moves": 80 },
@@ -301,7 +275,8 @@
     ],
     "material_thickness": 2,
     "environmental_protection": 3,
-    "flags": [ "VARSIZE", "STURDY" ]
+    "flags": [ "VARSIZE", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ], "encumbrance": [ 3, 7 ] }
   },
   {
     "id": "crt_warmor",
@@ -315,10 +290,6 @@
     "material": [ "hardsteel", "kevlar" ],
     "symbol": "[",
     "color": "light_green",
-    "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ],
-    "coverage": 100,
-    "encumbrance": 24,
-    "max_encumbrance": 40,
     "warmth": 25,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "3 kg", "moves": 80 },
@@ -326,6 +297,7 @@
     ],
     "material_thickness": 3,
     "environmental_protection": 10,
-    "flags": [ "VARSIZE", "WATERPROOF", "OUTER", "OVERSIZE", "COLLAR", "STURDY", "NO_QUICKDRAW" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "OUTER", "OVERSIZE", "COLLAR", "STURDY", "NO_QUICKDRAW" ],
+    "armor": { "coverage": 100, "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ], "encumbrance": [ 24, 40 ] }
   }
 ]

--- a/data/Mainline_mods/Mods/CRT_EXPANSION/items/crt_clothes.json
+++ b/data/Mainline_mods/Mods/CRT_EXPANSION/items/crt_clothes.json
@@ -19,8 +19,8 @@
     "color": "light_gray",
     "material": [ "neoprene", "kevlar" ],
     "warmth": 35,
-    "coverage": 100,
-    "flags": [ "WATERPROOF", "VARSIZE", "STURDY" ]
+    "flags": [ "WATERPROOF", "VARSIZE", "STURDY" ],
+    "armor": { "coverage": 100 }
   },
   {
     "id": "crt_dress_pants",
@@ -32,11 +32,9 @@
     "symbol": "[",
     "material": [ "cotton", "neoprene" ],
     "warmth": 17,
-    "covers": [ "leg_l", "leg_r" ],
-    "encumbrance": 10,
-    "coverage": 100,
     "material_thickness": 2,
-    "flags": [ "WATERPROOF", "VARSIZE", "FANCY" ]
+    "flags": [ "WATERPROOF", "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 100, "covers": [ "leg_l", "leg_r" ], "encumbrance": 10 }
   },
   {
     "id": "crt_helmet_liner",
@@ -62,13 +60,11 @@
     "material": [ "cotton", "plastic", "rubber" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 65,
-    "encumbrance": 15,
     "warmth": 15,
     "material_thickness": 1,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "WATERPROOF", "FANCY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "FANCY" ],
+    "armor": { "coverage": 65, "covers": [ "foot_l", "foot_r" ], "encumbrance": 15 }
   },
   {
     "id": "crt_rec_gloves",
@@ -82,13 +78,11 @@
     "material": [ "cotton", "neoprene" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "hand_l", "hand_r" ],
-    "coverage": 90,
-    "encumbrance": 4,
     "warmth": 10,
     "material_thickness": 1,
     "environmental_protection": 2,
-    "flags": [ "SKINTIGHT", "WATER_FRIENDLY" ]
+    "flags": [ "SKINTIGHT", "WATER_FRIENDLY" ],
+    "armor": { "coverage": 90, "covers": [ "hand_l", "hand_r" ], "encumbrance": 4 }
   },
   {
     "id": "crt_belt",
@@ -123,10 +117,6 @@
     "material": [ "cotton", "neoprene", "rubber" ],
     "symbol": "[",
     "color": "black_green",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 100,
-    "encumbrance": 6,
-    "max_encumbrance": 13,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1 L", "max_contains_weight": "3 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1 L", "max_contains_weight": "3 kg", "moves": 80 },
@@ -136,7 +126,8 @@
     "warmth": 15,
     "material_thickness": 1,
     "environmental_protection": 2,
-    "flags": [ "POCKETS", "OUTER", "OVERSIZE", "COLLAR", "WATERPROOF", "RAINPROOF", "FANCY" ]
+    "flags": [ "POCKETS", "OUTER", "OVERSIZE", "COLLAR", "WATERPROOF", "RAINPROOF", "FANCY" ],
+    "armor": { "coverage": 100, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": [ 6, 13 ] }
   },
   {
     "id": "crt_rec_hat",
@@ -149,12 +140,10 @@
     "material": [ "cotton", "neoprene", "rubber" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "head" ],
-    "coverage": 50,
-    "encumbrance": 10,
     "warmth": 15,
     "material_thickness": 1,
     "environmental_protection": 1,
-    "flags": [ "FANCY", "VARSIZE", "RAINPROOF", "WATERPROOF" ]
+    "flags": [ "FANCY", "VARSIZE", "RAINPROOF", "WATERPROOF" ],
+    "armor": { "coverage": 50, "covers": [ "head" ], "encumbrance": 10 }
   }
 ]

--- a/data/Mainline_mods/Mods/CRT_EXPANSION/items/crt_makeshift_survival.json
+++ b/data/Mainline_mods/Mods/CRT_EXPANSION/items/crt_makeshift_survival.json
@@ -12,12 +12,10 @@
     "material": [ "dry_plant" ],
     "symbol": "[",
     "color": "black_green",
-    "covers": [ "torso", "leg_l", "leg_r" ],
-    "coverage": 50,
-    "encumbrance": 15,
     "warmth": 7,
     "material_thickness": 3,
-    "flags": [ "OVERSIZE" ]
+    "flags": [ "OVERSIZE" ],
+    "armor": { "coverage": 50, "covers": [ "torso", "leg_l", "leg_r" ], "encumbrance": 15 }
   },
   {
     "id": "crt_plant_band",
@@ -32,10 +30,9 @@
     "material": [ "dry_plant" ],
     "symbol": "[",
     "color": "black_green",
-    "coverage": 0,
-    "encumbrance": 0,
     "warmth": 7,
     "material_thickness": 1,
-    "flags": [ "OVERSIZE" ]
+    "flags": [ "OVERSIZE" ],
+    "armor": { "coverage": 0, "encumbrance": 0 }
   }
 ]

--- a/data/Mainline_mods/Mods/CRT_EXPANSION/items/crt_toolarmor.json
+++ b/data/Mainline_mods/Mods/CRT_EXPANSION/items/crt_toolarmor.json
@@ -22,9 +22,6 @@
     "material": [ "plastic", "kevlar" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "eyes", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 50,
     "warmth": 20,
     "material_thickness": 5,
     "environmental_protection": 16,
@@ -39,7 +36,8 @@
       "USE_UPS",
       "NO_UNLOAD",
       "SLEEP_IGNORE"
-    ]
+    ],
+    "armor": { "coverage": 100, "covers": [ "eyes", "mouth" ], "encumbrance": 50 }
   },
   {
     "id": "crt_gasmask_on",
@@ -59,9 +57,6 @@
     "material": [ "plastic", "kevlar" ],
     "symbol": "[",
     "color": "light_green",
-    "covers": [ "eyes", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 5,
     "warmth": 75,
     "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "PERCEPTION", "add": 2 } ] } ] },
     "material_thickness": 5,
@@ -81,7 +76,8 @@
       "USE_UPS",
       "NO_UNLOAD",
       "SLEEP_IGNORE"
-    ]
+    ],
+    "armor": { "coverage": 100, "covers": [ "eyes", "mouth" ], "encumbrance": 5 }
   },
   {
     "id": "crt_em_vest",
@@ -97,7 +93,6 @@
     "material": [ "kevlar", "superalloy" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "torso" ],
     "max_charges": 300,
     "initial_charges": 300,
     "charges_per_use": 1,
@@ -110,8 +105,6 @@
       "need_charges_msg": "Power levels too low for safe bootup…"
     },
     "//": "Artifact data is charge_type solar",
-    "coverage": 85,
-    "encumbrance": 50,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "6 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "6 kg", "moves": 80 }
@@ -119,7 +112,8 @@
     "warmth": 10,
     "material_thickness": 4,
     "environmental_protection": 4,
-    "flags": [ "WATER_FRIENDLY", "STURDY", "VARSIZE", "USE_UPS", "NO_UNLOAD", "OUTER" ]
+    "flags": [ "WATER_FRIENDLY", "STURDY", "VARSIZE", "USE_UPS", "NO_UNLOAD", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": 50 }
   },
   {
     "id": "crt_em_vest_on",
@@ -135,9 +129,6 @@
     "material": [ "kevlar", "superalloy" ],
     "symbol": "[",
     "color": "light_green",
-    "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ],
-    "coverage": 100,
-    "encumbrance": 5,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "6 kg", "moves": 40 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "6 kg", "moves": 40 }
@@ -170,7 +161,8 @@
       "USE_UPS",
       "NO_UNLOAD",
       "OUTER"
-    ]
+    ],
+    "armor": { "coverage": 100, "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ], "encumbrance": 5 }
   },
   {
     "id": "crt_helmet",
@@ -250,9 +242,6 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "mouth" ],
-    "coverage": 95,
-    "encumbrance": 7,
     "warmth": 0,
     "material_thickness": 1,
     "environmental_protection": 3,
@@ -261,6 +250,7 @@
     "initial_charges": 50,
     "charges_per_use": 1,
     "turns_per_charge": 5,
-    "flags": [ "WET" ]
+    "flags": [ "WET" ],
+    "armor": { "coverage": 95, "covers": [ "mouth" ], "encumbrance": 7 }
   }
 ]

--- a/data/Mainline_mods/Mods/Dark-Skies-Above/items/clothing+armor.json
+++ b/data/Mainline_mods/Mods/Dark-Skies-Above/items/clothing+armor.json
@@ -16,9 +16,6 @@
     "symbol": "[",
     "looks_like": "power_armor",
     "color": "light_gray",
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r", "head" ],
-    "coverage": 95,
-    "encumbrance": 40,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "2500 g", "moves": 85 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "2500 g", "moves": 85 }
@@ -26,7 +23,12 @@
     "warmth": 50,
     "material_thickness": 4,
     "environmental_protection": 6,
-    "flags": [ "WATERPROOF", "STURDY" ]
+    "flags": [ "WATERPROOF", "STURDY" ],
+    "armor": {
+      "coverage": 95,
+      "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r", "head" ],
+      "encumbrance": 40
+    }
   },
   {
     "id": "dks_riotshield",
@@ -41,12 +43,10 @@
     "material": [ "plastic" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ],
-    "coverage": 85,
-    "encumbrance": 16,
     "material_thickness": 3,
     "techniques": [ "WBLOCK_2" ],
-    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ]
+    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ],
+    "armor": { "coverage": 85, "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ], "encumbrance": 16 }
   },
   {
     "id": "dks_battleshield",
@@ -61,11 +61,9 @@
     "material": [ "steel" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ],
-    "coverage": 90,
-    "encumbrance": 20,
     "material_thickness": 3,
     "techniques": [ "WBLOCK_3" ],
-    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ]
+    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ],
+    "armor": { "coverage": 90, "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ], "encumbrance": 20 }
   }
 ]

--- a/data/Mainline_mods/Mods/Dark-Skies-Above/obsolete.json
+++ b/data/Mainline_mods/Mods/Dark-Skies-Above/obsolete.json
@@ -57,10 +57,6 @@
     "symbol": "[",
     "looks_like": "power_armor",
     "color": "light_gray",
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r", "head" ],
-    "coverage": 95,
-    "encumbrance": 24,
-    "max_encumbrance": 40,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "4 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "4 kg", "moves": 80 }
@@ -68,7 +64,12 @@
     "warmth": 50,
     "material_thickness": 4,
     "environmental_protection": 6,
-    "flags": [ "WATERPROOF", "STURDY" ]
+    "flags": [ "WATERPROOF", "STURDY" ],
+    "armor": {
+      "coverage": 95,
+      "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r", "head" ],
+      "encumbrance": [ 24, 40 ]
+    }
   },
   {
     "id": "dks_riotshield",
@@ -83,13 +84,11 @@
     "material": [ "plastic" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ],
     "sided": true,
-    "coverage": 85,
-    "encumbrance": 16,
     "material_thickness": 3,
     "techniques": [ "WBLOCK_2" ],
-    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ]
+    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ],
+    "armor": { "coverage": 85, "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ], "encumbrance": 16 }
   },
   {
     "id": "dks_battleshield",
@@ -104,12 +103,10 @@
     "material": [ "steel" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ],
     "sided": true,
-    "coverage": 90,
-    "encumbrance": 20,
     "material_thickness": 3,
     "techniques": [ "WBLOCK_3" ],
-    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ]
+    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ],
+    "armor": { "coverage": 90, "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ], "encumbrance": 20 }
   }
 ]

--- a/data/Mainline_mods/Mods/Magiclysm/Spells/attunements/Force_Mage.json
+++ b/data/Mainline_mods/Mods/Magiclysm/Spells/attunements/Force_Mage.json
@@ -34,9 +34,6 @@
     "to_hit": -10,
     "symbol": "[",
     "color": "brown",
-    "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r", "mouth", "eyes" ],
-    "coverage": 100,
-    "encumbrance": 0,
     "environmental_protection": 2,
     "relic_data": {
       "passive_effects": [
@@ -52,7 +49,12 @@
         }
       ]
     },
-    "flags": [ "WATERPROOF", "TRADER_AVOID", "SEMITANGIBLE", "ONLY_ONE", "OVERSIZE", "AURA" ]
+    "flags": [ "WATERPROOF", "TRADER_AVOID", "SEMITANGIBLE", "ONLY_ONE", "OVERSIZE", "AURA" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r", "mouth", "eyes" ],
+      "encumbrance": 0
+    }
   },
   {
     "id": "force_magical_armor",

--- a/data/Mainline_mods/Mods/Magiclysm/enchantments/Soulfire.json
+++ b/data/Mainline_mods/Mods/Magiclysm/enchantments/Soulfire.json
@@ -32,10 +32,10 @@
     "relic_data": {
       "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "MAX_HP", "multiply": -0.4 } ] } ]
     },
-    "covers": [ "torso" ],
     "symbol": "~",
     "color": "red",
     "weight": "1 g",
-    "volume": "1 ml"
+    "volume": "1 ml",
+    "armor": { "covers": [ "torso" ] }
   }
 ]

--- a/data/Mainline_mods/Mods/Magiclysm/items/alchemy_items.json
+++ b/data/Mainline_mods/Mods/Magiclysm/items/alchemy_items.json
@@ -61,13 +61,11 @@
     "material": [ "copper", "wood" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "head" ],
-    "coverage": 5,
-    "encumbrance": 1,
     "warmth": 0,
     "material_thickness": 1,
     "flags": [ "BELTED" ],
-    "qualities": [ [ "MANA_FOCUS", 1 ] ]
+    "qualities": [ [ "MANA_FOCUS", 1 ] ],
+    "armor": { "coverage": 5, "covers": [ "head" ], "encumbrance": 1 }
   },
   {
     "id": "potion_starter",

--- a/data/Mainline_mods/Mods/Magiclysm/items/black_dragon_items.json
+++ b/data/Mainline_mods/Mods/Magiclysm/items/black_dragon_items.json
@@ -84,13 +84,11 @@
     "material": [ "black_dragon_hide" ],
     "symbol": "[",
     "color": "black_white",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 30,
     "warmth": 20,
     "material_thickness": 4,
     "environmental_protection": 3,
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "foot_l", "foot_r" ], "encumbrance": 30 }
   },
   {
     "id": "boots_black_dragon_hide",
@@ -106,13 +104,11 @@
     "material": [ "black_dragon_hide" ],
     "symbol": "[",
     "color": "black_white",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 18,
     "warmth": 20,
     "material_thickness": 2,
     "environmental_protection": 3,
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "foot_l", "foot_r" ], "encumbrance": 18 }
   },
   {
     "id": "helmet_black_dragon_scale",
@@ -128,14 +124,12 @@
     "material": [ "black_dragon_hide" ],
     "symbol": "[",
     "color": "black_white",
-    "covers": [ "head", "eyes", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 32,
     "warmth": 15,
     "material_thickness": 6,
     "environmental_protection": 3,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "head", "eyes", "mouth" ], "encumbrance": 32 }
   },
   {
     "id": "helmet_black_dragon_hide",
@@ -151,14 +145,12 @@
     "material": [ "black_dragon_hide" ],
     "symbol": "[",
     "color": "black_white",
-    "covers": [ "head" ],
-    "coverage": 100,
-    "encumbrance": 32,
     "warmth": 15,
     "material_thickness": 2,
     "environmental_protection": 1,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "head" ], "encumbrance": 32 }
   },
   {
     "id": "suit_black_dragon_scale",
@@ -174,13 +166,11 @@
     "material": [ "black_dragon_hide" ],
     "symbol": "[",
     "color": "black_white",
-    "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r" ],
-    "coverage": 100,
-    "encumbrance": 25,
     "warmth": 15,
     "material_thickness": 4,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "suit_black_dragon_hide",
@@ -196,13 +186,11 @@
     "material": [ "black_dragon_hide" ],
     "symbol": "[",
     "color": "black_white",
-    "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r" ],
-    "coverage": 100,
-    "encumbrance": 18,
     "warmth": 15,
     "material_thickness": 4,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r" ], "encumbrance": 18 }
   },
   {
     "id": "gauntlets_black_dragon_scale",
@@ -217,13 +205,11 @@
     "material": [ "black_dragon_hide" ],
     "symbol": "[",
     "color": "black_white",
-    "covers": [ "hand_l", "hand_r" ],
-    "coverage": 100,
-    "encumbrance": 20,
     "warmth": 15,
     "material_thickness": 3,
     "environmental_protection": 3,
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "hand_l", "hand_r" ], "encumbrance": 20 }
   },
   {
     "id": "gloves_black_dragon_hide",
@@ -238,13 +224,11 @@
     "material": [ "black_dragon_hide" ],
     "symbol": "[",
     "color": "black_white",
-    "covers": [ "hand_l", "hand_r" ],
-    "coverage": 100,
-    "encumbrance": 8,
     "warmth": 15,
     "material_thickness": 2,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "hand_l", "hand_r" ], "encumbrance": 8 }
   },
   {
     "id": "boots_xlblack_dragon_scale",
@@ -254,8 +238,8 @@
     "description": "Massive boots made of black dragonscale, modified to fit even the strangest of bodies.  Very protective, and surprisingly light.",
     "weight": "1545 g",
     "volume": "6250 ml",
-    "encumbrance": 40,
-    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "encumbrance": 40 }
   },
   {
     "id": "boots_xlblack_dragon_hide",
@@ -265,8 +249,8 @@
     "description": "Massive boots made of black dragonhide, modified to fit even the strangest of bodies.  Very protective, and surprisingly light.",
     "weight": "955 g",
     "volume": "6250 ml",
-    "encumbrance": 28,
-    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "encumbrance": 28 }
   },
   {
     "id": "gauntlets_xlblack_dragon_scale",
@@ -276,8 +260,8 @@
     "description": "A pair of heavy-duty gauntlets made of black dragonscale that covers your hands, or whatever you use as hands.",
     "weight": "680 g",
     "volume": "2 L",
-    "encumbrance": 30,
-    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "encumbrance": 30 }
   },
   {
     "id": "gloves_xlblack_dragon_hide",
@@ -287,8 +271,8 @@
     "description": "A pair of customized, Kevlar armored leather gloves, modified to be easy to wear while providing maximum protection under extreme conditions.  Sized to fit even the strangest of anatomy.",
     "weight": "430 g",
     "volume": "1500 ml",
-    "encumbrance": 18,
-    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "encumbrance": 18 }
   },
   {
     "id": "boots_xlblack_dragon_scale",
@@ -298,8 +282,8 @@
     "description": "Massive boots made of black dragonscale, modified to fit even the strangest of bodies.  Very protective, and surprisingly light.",
     "weight": "1545 g",
     "volume": "6250 ml",
-    "encumbrance": 40,
-    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "encumbrance": 40 }
   },
   {
     "id": "boots_xlblack_dragon_hide",
@@ -309,8 +293,8 @@
     "description": "Massive boots made of black dragonhide, modified to fit even the strangest of bodies.  Very protective, and surprisingly light.",
     "weight": "955 g",
     "volume": "6250 ml",
-    "encumbrance": 28,
-    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "encumbrance": 28 }
   },
   {
     "id": "helmet_xlblack_dragon_scale",
@@ -320,8 +304,8 @@
     "description": "A massive helmet made from black dragonscale, held together with black dragonhide.  It comes equipped with a full face visor and is large enough to fit even the strangest of heads.",
     "weight": "1256 g",
     "volume": "4500 ml",
-    "encumbrance": 42,
-    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "encumbrance": 42 }
   },
   {
     "id": "helmet_xlblack_dragon_hide",
@@ -331,8 +315,8 @@
     "description": "A massive helmet made from black dragonhide.  It protects your head well, and doesn't cover your face, but is large enough to fit even the strangest of heads.",
     "weight": "815 g",
     "volume": "4500 ml",
-    "encumbrance": 42,
-    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "encumbrance": 42 }
   },
   {
     "id": "helmet_xlblack_dragon_scale",
@@ -342,8 +326,8 @@
     "description": "A massive helmet made from black dragonscale, held together with black dragonhide.  It comes equipped with a full face visor and is large enough to fit even the strangest of heads.",
     "weight": "1256 g",
     "volume": "4500 ml",
-    "encumbrance": 42,
-    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "encumbrance": 42 }
   },
   {
     "id": "helmet_xlblack_dragon_hide",
@@ -353,8 +337,8 @@
     "description": "A massive helmet made from black dragonhide.  It protects your head well, and doesn't cover your face, but is large enough to fit even the strangest of heads.",
     "weight": "815 g",
     "volume": "4500 ml",
-    "encumbrance": 42,
-    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "encumbrance": 42 }
   },
   {
     "id": "suit_xlblack_dragon_scale",
@@ -364,8 +348,8 @@
     "description": "A massive full suit of black dragon scale mail.  It comes with all the accoutrements that cover your torso, legs, and arms; sized to fit even the strangest of bodies.",
     "weight": "6250 g",
     "volume": "18 L",
-    "encumbrance": 35,
-    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "RAINPROOF", "STURDY" ]
+    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "RAINPROOF", "STURDY" ],
+    "armor": { "encumbrance": 35 }
   },
   {
     "id": "suit_xlblack_dragon_hide",
@@ -375,7 +359,7 @@
     "description": "A massive full suit of black dragonhide armor.  It comes with all the accoutrements that cover your torso, legs, and arms; sized to fit even the strangest of bodies.",
     "weight": "5500 g",
     "volume": "18 L",
-    "encumbrance": 28,
-    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "RAINPROOF", "STURDY" ]
+    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "RAINPROOF", "STURDY" ],
+    "armor": { "encumbrance": 28 }
   }
 ]

--- a/data/Mainline_mods/Mods/Magiclysm/items/enchanted.json
+++ b/data/Mainline_mods/Mods/Magiclysm/items/enchanted.json
@@ -92,16 +92,14 @@
     "material": [ "cotton" ],
     "symbol": "^",
     "color": "light_blue",
-    "covers": [ "head" ],
-    "coverage": 50,
-    "encumbrance": 12,
     "warmth": 7,
     "material_thickness": 2,
     "environmental_protection": 2,
     "relic_data": {
       "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "MAX_MANA", "multiply": 0.2, "add": 500 } ] } ]
     },
-    "flags": [ "VARSIZE" ]
+    "flags": [ "VARSIZE" ],
+    "armor": { "coverage": 50, "covers": [ "head" ], "encumbrance": 12 }
   },
   {
     "id": "debug_fireball_hammer",
@@ -131,13 +129,11 @@
     "material": [ "black_dragon_hide" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "torso", "head", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 85,
-    "encumbrance": 4,
     "warmth": 30,
     "material_thickness": 3,
     "flags": [ "OVERSIZE", "HOOD", "OUTER", "NO_REPAIR", "SUPER_FANCY", "STURDY", "TRADER_KEEP_EQUIPPED" ],
-    "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "BONUS_DODGE", "add": 1 } ] } ] }
+    "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "BONUS_DODGE", "add": 1 } ] } ] },
+    "armor": { "coverage": 85, "covers": [ "torso", "head", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 4 }
   },
   {
     "id": "wolfshead_cufflinks",

--- a/data/Mainline_mods/Mods/Magiclysm/items/enchanted_belts.json
+++ b/data/Mainline_mods/Mods/Magiclysm/items/enchanted_belts.json
@@ -11,14 +11,13 @@
     "material": [ "leather" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso" ],
-    "coverage": 5,
     "material_thickness": 2,
     "pocket_data": [
       { "max_contains_volume": "500 ml", "max_contains_weight": "400 g", "moves": 60, "flag_restriction": [ "BELT_CLIP" ] }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Stick what into your belt", "holster_msg": "You tuck your %s into your %s" },
-    "flags": [ "WAIST", "WATER_FRIENDLY", "STURDY" ]
+    "flags": [ "WAIST", "WATER_FRIENDLY", "STURDY" ],
+    "armor": { "coverage": 5, "covers": [ "torso" ] }
   },
   {
     "type": "TOOL_ARMOR",
@@ -50,9 +49,6 @@
     "id": "mbelt_pockets_lesser",
     "name": { "str": "lesser dimensional toolbelt" },
     "description": "A sturdy workman's belt that fits around your waist, covered in easy to access pouches.  Like all dimensional spaces, they hold more than they should with a fair weight reduction.",
-    "coverage": 10,
-    "encumbrance": 4,
-    "max_encumbrance": 10,
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -90,7 +86,8 @@
         "weight_multiplier": 0.5,
         "volume_multiplier": 0.35
       }
-    ]
+    ],
+    "armor": { "coverage": 10, "encumbrance": [ 4, 10 ] }
   },
   {
     "type": "TOOL_ARMOR",
@@ -98,9 +95,6 @@
     "id": "mbelt_pockets_greater",
     "name": { "str": "greater dimensional toolbelt" },
     "description": "A heavy duty workman's belt that fits around your waist, covered in easy to access pouches.  Like all dimensional spaces, they hold far more than they should with a substantial weight reduction.",
-    "coverage": 10,
-    "encumbrance": 6,
-    "max_encumbrance": 8,
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -138,7 +132,8 @@
         "weight_multiplier": 0.3,
         "volume_multiplier": 0.2
       }
-    ]
+    ],
+    "armor": { "coverage": 10, "encumbrance": [ 6, 8 ] }
   },
   {
     "type": "TOOL_ARMOR",
@@ -146,9 +141,6 @@
     "id": "mbelt_weaponry",
     "name": { "str": "Belt of Weaponry", "str_pl": "Belts of Weaponry" },
     "description": "A wide girdle that fits around your waist, you can sheath or holster any weapon into it in the blink of an eye, and it seemingly stores them somewhere else.",
-    "coverage": 10,
-    "encumbrance": 3,
-    "max_encumbrance": 3,
     "pocket_data": [
       {
         "holster": true,
@@ -183,7 +175,8 @@
         "weight_multiplier": 0.0
       }
     ],
-    "use_action": { "type": "holster", "holster_prompt": "Stick what into your belt", "holster_msg": "You tuck your %s into your %s" }
+    "use_action": { "type": "holster", "holster_prompt": "Stick what into your belt", "holster_msg": "You tuck your %s into your %s" },
+    "armor": { "coverage": 10, "encumbrance": [ 3, 3 ] }
   },
   {
     "id": "mbelt_technomancer_toolbelt",
@@ -191,7 +184,6 @@
     "name": { "str": "technomancer's toolbelt" },
     "weight": "2000 g",
     "color": "brown",
-    "covers": [ "torso" ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -208,8 +200,6 @@
     "material": [ "leather", "steel" ],
     "volume": "4 L",
     "flags": [ "VARSIZE", "WATER_FRIENDLY", "STURDY", "WAIST", "OVERSIZE" ],
-    "coverage": 10,
-    "encumbrance": 4,
     "material_thickness": 4,
     "use_action": [ { "type": "holster", "holster_prompt": "Sheath blade", "holster_msg": "You sheath your %s" }, "CROWBAR" ],
     "qualities": [
@@ -224,7 +214,8 @@
       [ "SAW_M_FINE", 1 ],
       [ "WRENCH_FINE", 1 ],
       [ "SCREW_FINE", 1 ]
-    ]
+    ],
+    "armor": { "coverage": 10, "covers": [ "torso" ], "encumbrance": 4 }
   },
   {
     "type": "TOOL_ARMOR",

--- a/data/Mainline_mods/Mods/Magiclysm/items/enchanted_boots.json
+++ b/data/Mainline_mods/Mods/Magiclysm/items/enchanted_boots.json
@@ -8,11 +8,11 @@
     "price_postapoc": "750 USD",
     "description": "Rugged yet extremely comfortable and well fitting boots of worn leather and steel, they look like they've seen a lot of use and will likely see a lot more.  They make your movement a lot less work.",
     "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "MOVE_COST", "add": -30 } ] } ] },
-    "encumbrance": 8,
     "warmth": 30,
     "material_thickness": 3,
     "environmental_protection": 3,
-    "flags": [ "WATERPROOF", "STURDY" ]
+    "flags": [ "WATERPROOF", "STURDY" ],
+    "armor": { "encumbrance": 8 }
   },
   {
     "id": "mboots_haste",
@@ -28,11 +28,11 @@
         { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "SPEED", "add": 10 } ] }
       ]
     },
-    "encumbrance": 8,
     "warmth": 30,
     "material_thickness": 3,
     "environmental_protection": 3,
-    "flags": [ "WATERPROOF", "STURDY" ]
+    "flags": [ "WATERPROOF", "STURDY" ],
+    "armor": { "encumbrance": 8 }
   },
   {
     "id": "mboots_escape",
@@ -46,11 +46,11 @@
     "relic_data": { "charge_info": { "recharge_type": "periodic", "time": "24 h", "regenerate_ammo": true } },
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "crystallized_mana": 1 } } ],
     "use_action": { "type": "cast_spell", "spell_id": "magus_escape", "no_fail": true, "level": 10, "need_worn": true },
-    "encumbrance": 8,
     "warmth": 30,
     "material_thickness": 3,
     "environmental_protection": 3,
-    "flags": [ "WATERPROOF", "STURDY", "NO_UNLOAD", "NO_RELOAD" ]
+    "flags": [ "WATERPROOF", "STURDY", "NO_UNLOAD", "NO_RELOAD" ],
+    "armor": { "encumbrance": 8 }
   },
   {
     "id": "mboots_freerunner",
@@ -65,11 +65,11 @@
         { "has": "WORN", "condition": "ALWAYS", "mutations": [ "PARKOUR" ], "values": [ { "value": "MOVE_COST", "add": -5 } ] }
       ]
     },
-    "encumbrance": 8,
     "warmth": 15,
     "material_thickness": 3,
     "environmental_protection": 3,
-    "flags": [ "WATERPROOF", "STURDY" ]
+    "flags": [ "WATERPROOF", "STURDY" ],
+    "armor": { "encumbrance": 8 }
   },
   {
     "id": "mboots_grounding",
@@ -79,11 +79,11 @@
     "looks_like": "boots_hiking",
     "price_postapoc": "350 USD",
     "description": "Rugged yet extremely comfortable and well fitting boots of leather with small engraved runes seemingly filled with rubber.  When worn, you are immune to damage from electricity.",
-    "encumbrance": 8,
     "warmth": 30,
     "material_thickness": 3,
     "environmental_protection": 3,
     "flags": [ "WATERPROOF", "STURDY" ],
-    "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "ARMOR_ELEC", "add": -20 } ] } ] }
+    "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "ARMOR_ELEC", "add": -20 } ] } ] },
+    "armor": { "encumbrance": 8 }
   }
 ]

--- a/data/Mainline_mods/Mods/Magiclysm/items/enchanted_bracers.json
+++ b/data/Mainline_mods/Mods/Magiclysm/items/enchanted_bracers.json
@@ -12,12 +12,10 @@
     "material": [ "steel", "leather" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "arm_l", "arm_r" ],
-    "coverage": 45,
-    "encumbrance": 10,
     "warmth": 10,
     "material_thickness": 5,
-    "flags": [ "BELTED", "STURDY", "BLOCK_WHILE_WORN", "WATER_FRIENDLY" ]
+    "flags": [ "BELTED", "STURDY", "BLOCK_WHILE_WORN", "WATER_FRIENDLY" ],
+    "armor": { "coverage": 45, "covers": [ "arm_l", "arm_r" ], "encumbrance": 10 }
   },
   {
     "copy-from": "mbracer_steel_pair",
@@ -26,8 +24,8 @@
     "name": { "str": "steel bracer" },
     "weight": "770 g",
     "volume": "1250 ml",
-    "covers": [ "arm_l", "arm_r" ],
-    "sided": true
+    "sided": true,
+    "armor": { "covers": [ "arm_l", "arm_r" ] }
   },
   {
     "copy-from": "mbracer_steel_single",

--- a/data/Mainline_mods/Mods/Magiclysm/items/enchanted_cloaks.json
+++ b/data/Mainline_mods/Mods/Magiclysm/items/enchanted_cloaks.json
@@ -17,11 +17,9 @@
     "price": "1 kUSD",
     "symbol": "w",
     "color": "blue",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 0,
-    "encumbrance": 0,
     "flags": [ "OUTER", "OVERSIZE", "NONCONDUCTIVE", "WATER_FRIENDLY", "RAINPROOF" ],
-    "relic_data": { "passive_effects": [ { "id": "ench_fishform" } ] }
+    "relic_data": { "passive_effects": [ { "id": "ench_fishform" } ] },
+    "armor": { "coverage": 0, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 0 }
   },
   {
     "id": "ench_bearform",
@@ -55,11 +53,9 @@
     "price": "2 kUSD",
     "symbol": "w",
     "color": "brown",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 0,
-    "encumbrance": 0,
     "flags": [ "OUTER", "OVERSIZE", "NONCONDUCTIVE", "WATER_FRIENDLY", "RAINPROOF" ],
-    "relic_data": { "passive_effects": [ { "id": "ench_bearform" } ] }
+    "relic_data": { "passive_effects": [ { "id": "ench_bearform" } ] },
+    "armor": { "coverage": 0, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 0 }
   },
   {
     "id": "ench_deerform",
@@ -91,10 +87,8 @@
     "price": "1500 USD",
     "symbol": "w",
     "color": "green",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 0,
-    "encumbrance": 0,
     "flags": [ "OUTER", "OVERSIZE", "NONCONDUCTIVE", "WATER_FRIENDLY", "RAINPROOF" ],
-    "relic_data": { "passive_effects": [ { "id": "ench_deerform" } ] }
+    "relic_data": { "passive_effects": [ { "id": "ench_deerform" } ] },
+    "armor": { "coverage": 0, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 0 }
   }
 ]

--- a/data/Mainline_mods/Mods/Magiclysm/items/enchanted_masks.json
+++ b/data/Mainline_mods/Mods/Magiclysm/items/enchanted_masks.json
@@ -12,13 +12,11 @@
     "material": [ "steel", "leather" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "eyes", "mouth" ],
-    "coverage": 95,
-    "encumbrance": 10,
     "warmth": 10,
     "material_thickness": 2,
     "environmental_protection": 1,
-    "flags": [ "WATER_FRIENDLY", "STURDY" ]
+    "flags": [ "WATER_FRIENDLY", "STURDY" ],
+    "armor": { "coverage": 95, "covers": [ "eyes", "mouth" ], "encumbrance": 10 }
   },
   {
     "id": "mmask_disappearance",
@@ -38,14 +36,12 @@
     "name": { "str": "mask of perfect vision", "str_pl": "masks of perfect vision" },
     "description": "A decidedly steampunk-looking half mask that covers the eye area of the face, it has large lenses that correct and greatly enhance the vision of the wearer.",
     "copy-from": "mmask",
-    "covers": [ "eyes" ],
-    "coverage": 100,
-    "encumbrance": 5,
     "environmental_protection": 6,
     "flags": [ "FANCY", "WATER_FRIENDLY", "SUN_GLASSES", "FIX_NEARSIGHT", "FIX_FARSIGHT", "ZOOM" ],
     "qualities": [ [ "GLARE", 2 ] ],
     "relic_data": {
       "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "PERCEPTION", "multiply": 0.25 } ] } ]
-    }
+    },
+    "armor": { "coverage": 100, "covers": [ "eyes" ], "encumbrance": 5 }
   }
 ]

--- a/data/Mainline_mods/Mods/Magiclysm/items/enchanted_rings.json
+++ b/data/Mainline_mods/Mods/Magiclysm/items/enchanted_rings.json
@@ -11,11 +11,10 @@
     "material": [ "copper" ],
     "symbol": "[",
     "color": "light_red",
-    "covers": [ "hand_l", "hand_r" ],
     "sided": true,
-    "coverage": 0,
     "warmth": 0,
-    "flags": [ "WATER_FRIENDLY", "ALLOWS_NATURAL_ATTACKS", "FANCY", "ONLY_ONE", "SKINTIGHT" ]
+    "flags": [ "WATER_FRIENDLY", "ALLOWS_NATURAL_ATTACKS", "FANCY", "ONLY_ONE", "SKINTIGHT" ],
+    "armor": { "coverage": 0, "covers": [ "hand_l", "hand_r" ] }
   },
   {
     "abstract": "mring_silver",
@@ -29,11 +28,10 @@
     "material": [ "silver" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "hand_l", "hand_r" ],
     "sided": true,
-    "coverage": 0,
     "warmth": 0,
-    "flags": [ "WATER_FRIENDLY", "ALLOWS_NATURAL_ATTACKS", "FANCY", "ONLY_ONE", "SKINTIGHT" ]
+    "flags": [ "WATER_FRIENDLY", "ALLOWS_NATURAL_ATTACKS", "FANCY", "ONLY_ONE", "SKINTIGHT" ],
+    "armor": { "coverage": 0, "covers": [ "hand_l", "hand_r" ] }
   },
   {
     "abstract": "mring_gold",
@@ -47,11 +45,10 @@
     "material": [ "gold" ],
     "symbol": "[",
     "color": "yellow",
-    "covers": [ "hand_l", "hand_r" ],
     "sided": true,
-    "coverage": 0,
     "warmth": 0,
-    "flags": [ "WATER_FRIENDLY", "ALLOWS_NATURAL_ATTACKS", "FANCY", "ONLY_ONE", "SKINTIGHT" ]
+    "flags": [ "WATER_FRIENDLY", "ALLOWS_NATURAL_ATTACKS", "FANCY", "ONLY_ONE", "SKINTIGHT" ],
+    "armor": { "coverage": 0, "covers": [ "hand_l", "hand_r" ] }
   },
   {
     "abstract": "mring_platinum",
@@ -65,11 +62,10 @@
     "material": [ "platinum" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "hand_l", "hand_r" ],
     "sided": true,
-    "coverage": 0,
     "warmth": 0,
-    "flags": [ "WATER_FRIENDLY", "ALLOWS_NATURAL_ATTACKS", "FANCY", "ONLY_ONE", "SKINTIGHT" ]
+    "flags": [ "WATER_FRIENDLY", "ALLOWS_NATURAL_ATTACKS", "FANCY", "ONLY_ONE", "SKINTIGHT" ],
+    "armor": { "coverage": 0, "covers": [ "hand_l", "hand_r" ] }
   },
   {
     "copy-from": "mring_copper",

--- a/data/Mainline_mods/Mods/Magiclysm/items/ethereal_items.json
+++ b/data/Mainline_mods/Mods/Magiclysm/items/ethereal_items.json
@@ -51,15 +51,13 @@
     "material": [ "superalloy" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ],
-    "coverage": 100,
-    "encumbrance": 0,
     "warmth": 20,
     "material_thickness": 4,
     "environmental_protection": 10,
     "qualities": [ [ "HAMMER", 1 ] ],
     "flags": [ "VARSIZE", "STURDY", "UNARMED_WEAPON", "DURABLE_MELEE", "NONCONDUCTIVE", "MAGIC_FOCUS" ],
-    "techniques": [ "WBLOCK_3" ]
+    "techniques": [ "WBLOCK_3" ],
+    "armor": { "coverage": 100, "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ], "encumbrance": 0 }
   },
   {
     "id": "magic_lamp",
@@ -74,8 +72,8 @@
     "bashing": 8,
     "symbol": ",",
     "color": "light_green",
-    "covers": [ "head" ],
-    "flags": [ "LIGHT_300", "AURA", "SEMITANGIBLE" ]
+    "flags": [ "LIGHT_300", "AURA", "SEMITANGIBLE" ],
+    "armor": { "covers": [ "head" ] }
   },
   {
     "id": "magic_light",
@@ -88,8 +86,8 @@
     "price": "0 cent",
     "symbol": ",",
     "color": "light_green",
-    "covers": [ "head" ],
-    "flags": [ "LIGHT_8", "AURA", "SEMITANGIBLE" ]
+    "flags": [ "LIGHT_8", "AURA", "SEMITANGIBLE" ],
+    "armor": { "covers": [ "head" ] }
   },
   {
     "id": "shield_ice",
@@ -105,13 +103,11 @@
     "material": [ "steel" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ],
     "sided": true,
-    "coverage": 70,
-    "encumbrance": 15,
     "material_thickness": 3,
     "techniques": [ "WBLOCK_3" ],
-    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ]
+    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ],
+    "armor": { "coverage": 70, "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ], "encumbrance": 15 }
   },
   {
     "id": "ice_gliders",
@@ -126,14 +122,12 @@
     "material": [ "steel" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 0,
     "warmth": 30,
     "material_thickness": 3,
     "environmental_protection": 2,
     "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "MOVE_COST", "add": -5 } ] } ] },
-    "flags": [ "WATERPROOF", "ROLLER_QUAD", "BELTED" ]
+    "flags": [ "WATERPROOF", "ROLLER_QUAD", "BELTED" ],
+    "armor": { "coverage": 100, "covers": [ "foot_l", "foot_r" ], "encumbrance": 0 }
   },
   {
     "id": "stormhammer",
@@ -276,13 +270,10 @@
     "material": [ "flesh" ],
     "symbol": "[",
     "color": "green",
-    "covers": [ "torso" ],
-    "coverage": 40,
-    "encumbrance": 5,
-    "max_encumbrance": 10,
     "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "25 L", "max_contains_weight": "75 kg", "moves": 60 } ],
     "material_thickness": 3,
-    "flags": [ "BELTED", "TRADER_AVOID", "WATERPROOF", "STURDY", "NO_UNWIELD", "ONLY_ONE", "NO_REPAIR", "NO_SALVAGE" ]
+    "flags": [ "BELTED", "TRADER_AVOID", "WATERPROOF", "STURDY", "NO_UNWIELD", "ONLY_ONE", "NO_REPAIR", "NO_SALVAGE" ],
+    "armor": { "coverage": 40, "covers": [ "torso" ], "encumbrance": [ 5, 10 ] }
   },
   {
     "id": "bonespear",
@@ -385,9 +376,11 @@
     "price": "3646 cent",
     "symbol": "o",
     "color": "white",
-    "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r", "mouth", "eyes" ],
     "flags": [ "AURA", "SEMITANGIBLE", "OVERSIZE", "ONLY_ONE", "TRADER_AVOID", "NO_TAKEOFF", "NONCONDUCTIVE" ],
-    "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "BONUS_DODGE", "add": 2 } ] } ] }
+    "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "BONUS_DODGE", "add": 2 } ] } ] },
+    "armor": {
+      "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r", "mouth", "eyes" ]
+    }
   },
   {
     "id": "acid_res_aura",
@@ -399,10 +392,12 @@
     "price": "3646 cent",
     "symbol": "o",
     "color": "green",
-    "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r", "mouth", "eyes" ],
     "flags": [ "AURA", "SEMITANGIBLE", "OVERSIZE", "ONLY_ONE", "TRADER_AVOID", "NO_TAKEOFF", "NONCONDUCTIVE" ],
     "relic_data": {
       "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "ARMOR_ACID", "multiply": -0.25 } ] } ]
+    },
+    "armor": {
+      "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r", "mouth", "eyes" ]
     }
   },
   {
@@ -415,10 +410,12 @@
     "price": "3646 cent",
     "symbol": "o",
     "color": "green",
-    "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r", "mouth", "eyes" ],
     "flags": [ "AURA", "SEMITANGIBLE", "OVERSIZE", "ONLY_ONE", "TRADER_AVOID", "NO_TAKEOFF", "NONCONDUCTIVE" ],
     "relic_data": {
       "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "ARMOR_ACID", "multiply": -0.6 } ] } ]
+    },
+    "armor": {
+      "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r", "mouth", "eyes" ]
     }
   },
   {
@@ -432,13 +429,15 @@
     "material": [ "steel" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "head", "mouth", "eyes", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 10,
     "warmth": 0,
     "material_thickness": 2,
     "environmental_protection": 2,
-    "flags": [ "ONLY_ONE", "OVERSIZE", "PERSONAL", "STURDY" ]
+    "flags": [ "ONLY_ONE", "OVERSIZE", "PERSONAL", "STURDY" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "head", "mouth", "eyes", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 10
+    }
   },
   {
     "id": "aura_stoneskin",
@@ -451,13 +450,15 @@
     "material": [ "stone" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "head", "mouth", "eyes", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 20,
     "warmth": 5,
     "material_thickness": 2,
     "environmental_protection": 2,
-    "flags": [ "ONLY_ONE", "OVERSIZE", "PERSONAL", "STURDY" ]
+    "flags": [ "ONLY_ONE", "OVERSIZE", "PERSONAL", "STURDY" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "head", "mouth", "eyes", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 20
+    }
   },
   {
     "id": "burn_scar",
@@ -481,10 +482,9 @@
     "volume": "1 ml",
     "symbol": "~",
     "color": "light_red",
-    "covers": [ "eyes", "mouth" ],
-    "encumbrance": 18,
     "relic_data": { "passive_effects": [ { "id": "ench_overcharge_burn_scar" } ] },
-    "flags": [ "NO_TAKEOFF", "TRADER_AVOID", "BLIND" ]
+    "flags": [ "NO_TAKEOFF", "TRADER_AVOID", "BLIND" ],
+    "armor": { "covers": [ "eyes", "mouth" ], "encumbrance": 18 }
   },
   {
     "id": "protect_env",
@@ -496,8 +496,10 @@
     "symbol": "o",
     "color": "blue",
     "environmental_protection": 15,
-    "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r", "mouth", "eyes" ],
-    "flags": [ "AURA", "SEMITANGIBLE", "OVERSIZE", "ONLY_ONE", "TRADER_AVOID", "NO_TAKEOFF", "NONCONDUCTIVE" ]
+    "flags": [ "AURA", "SEMITANGIBLE", "OVERSIZE", "ONLY_ONE", "TRADER_AVOID", "NO_TAKEOFF", "NONCONDUCTIVE" ],
+    "armor": {
+      "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r", "mouth", "eyes" ]
+    }
   },
   {
     "id": "thorns_electric",
@@ -696,11 +698,8 @@
     "weight": "1 g",
     "volume": "1 ml",
     "material": [ "steel" ],
-    "covers": [ "head", "mouth", "eyes", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
     "symbol": "o",
     "color": "green",
-    "coverage": 100,
-    "encumbrance": 0,
     "warmth": 0,
     "material_thickness": 2,
     "environmental_protection": 2,
@@ -713,6 +712,11 @@
           "hit_me_effect": [ { "id": "dragon_shell_retaliation_black", "hit_self": false } ]
         }
       ]
+    },
+    "armor": {
+      "coverage": 100,
+      "covers": [ "head", "mouth", "eyes", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 0
     }
   },
   {

--- a/data/Maintained_mods/mods/Arcana/items/armor.json
+++ b/data/Maintained_mods/mods/Arcana/items/armor.json
@@ -200,9 +200,6 @@
     "symbol": "[",
     "looks_like": "leather_pouch",
     "color": "light_red",
-    "covers": [ "torso" ],
-    "coverage": 15,
-    "encumbrance": 15,
     "material_thickness": 1,
     "relic_data": {
       "passive_effects": [
@@ -272,6 +269,7 @@
       }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Store what magical focus?", "holster_msg": "You store your %s" },
-    "flags": [ "WAIST", "OVERSIZE", "TRADER_KEEP_EQUIPPED", "TARDIS" ]
+    "flags": [ "WAIST", "OVERSIZE", "TRADER_KEEP_EQUIPPED", "TARDIS" ],
+    "armor": { "coverage": 15, "covers": [ "torso" ], "encumbrance": 15 }
   }
 ]

--- a/data/Maintained_mods/mods/Arcana/items/tool_armor.json
+++ b/data/Maintained_mods/mods/Arcana/items/tool_armor.json
@@ -100,9 +100,6 @@
     "max_charges": 24,
     "charges_per_use": 1,
     "ammo": "essence_dull_type",
-    "covers": [ "eyes", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 10,
     "warmth": 10,
     "material_thickness": 3,
     "environmental_protection": 1,
@@ -126,7 +123,8 @@
       "need_charges_msg": "Fuel the mask with consecrated essence, to open your eyes.",
       "type": "transform"
     },
-    "flags": [ "NO_SALVAGE", "TRADER_KEEP_EQUIPPED" ]
+    "flags": [ "NO_SALVAGE", "TRADER_KEEP_EQUIPPED" ],
+    "armor": { "coverage": 100, "covers": [ "eyes", "mouth" ], "encumbrance": 10 }
   },
   {
     "id": "somen_clairvoyance_on",
@@ -197,15 +195,14 @@
     "max_charges": 6,
     "charges_per_use": 2,
     "ammo": "essence_blood_type",
-    "covers": [ "head" ],
-    "coverage": 20,
     "material_thickness": 1,
     "use_action": {
       "type": "consume_drug",
       "activation_message": "The gem shimmers with malevolent red light as you feel a strange hunger, a craving for rotting meat and stagnant water...",
       "effects": [ { "id": "revenant_hunger", "duration": 300 } ]
     },
-    "flags": [ "BELTED", "OVERSIZE", "NO_SALVAGE", "ALLOWS_NATURAL_ATTACKS", "TRADER_KEEP_EQUIPPED" ]
+    "flags": [ "BELTED", "OVERSIZE", "NO_SALVAGE", "ALLOWS_NATURAL_ATTACKS", "TRADER_KEEP_EQUIPPED" ],
+    "armor": { "coverage": 20, "covers": [ "head" ] }
   },
   {
     "type": "enchantment",
@@ -226,8 +223,6 @@
     "color": "dark_gray",
     "max_charges": 20,
     "charges_per_use": 1,
-    "encumbrance": 12,
-    "max_encumbrance": 12,
     "ammo": "essence_type",
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_type": 20 } } ],
     "relic_data": {
@@ -246,7 +241,8 @@
       }
     ],
     "relative": { "weight": 616, "volume": -1, "coverage": 5, "encumbrance": -5, "max_encumbrance": -5, "material_thickness": 1 },
-    "extend": { "flags": [ "NO_SALVAGE", "TRADER_KEEP_EQUIPPED" ] }
+    "extend": { "flags": [ "NO_SALVAGE", "TRADER_KEEP_EQUIPPED" ] },
+    "armor": { "encumbrance": [ 12, 12 ] }
   },
   {
     "id": "robe_shadow_on",
@@ -301,7 +297,6 @@
     "price_postapoc": "150 USD",
     "material": [ "iron", "copper", "leather", "cotton" ],
     "color": "light_red",
-    "coverage": 100,
     "environmental_protection": 1,
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_dull_type": 120 } } ],
     "max_charges": 120,
@@ -326,7 +321,8 @@
       }
     ],
     "relative": { "weight": 3020, "price": 55000, "material_thickness": 1, "encumbrance": 5 },
-    "extend": { "flags": [ "NO_SALVAGE", "ELECTRIC_IMMUNE", "RAINPROOF", "TRADER_KEEP_EQUIPPED" ] }
+    "extend": { "flags": [ "NO_SALVAGE", "ELECTRIC_IMMUNE", "RAINPROOF", "TRADER_KEEP_EQUIPPED" ] },
+    "armor": { "coverage": 100 }
   },
   {
     "id": "hauberk_jade_on",
@@ -365,16 +361,14 @@
     "max_charges": 30,
     "charges_per_use": 3,
     "ammo": "essence_blood_type",
-    "covers": [ "head" ],
-    "coverage": 20,
-    "encumbrance": 10,
     "material_thickness": 1,
     "use_action": {
       "type": "consume_drug",
       "activation_message": "The carvings in the stone glow red for a brief moment, and a chill passes through your spine.",
       "effects": [ { "id": "heat_ward_true", "duration": 300 } ]
     },
-    "flags": [ "BELTED", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS", "TRADER_KEEP_EQUIPPED" ]
+    "flags": [ "BELTED", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS", "TRADER_KEEP_EQUIPPED" ],
+    "armor": { "coverage": 20, "covers": [ "head" ], "encumbrance": 10 }
   },
   {
     "id": "meteoric_talisman",

--- a/data/Maintained_mods/mods/MST_Extra/items/armor.json
+++ b/data/Maintained_mods/mods/MST_Extra/items/armor.json
@@ -10,12 +10,10 @@
     "material": [ "leather" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "arm_l", "arm_r" ],
-    "coverage": 50,
-    "encumbrance": 5,
     "warmth": 15,
     "material_thickness": 1,
-    "flags": [ "OVERSIZE" ]
+    "flags": [ "OVERSIZE" ],
+    "armor": { "coverage": 50, "covers": [ "arm_l", "arm_r" ], "encumbrance": 5 }
   },
   {
     "id": "armwrap_fur",
@@ -28,12 +26,10 @@
     "material": [ "fur" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "arm_l", "arm_r" ],
-    "coverage": 50,
-    "encumbrance": 5,
     "warmth": 20,
     "material_thickness": 1,
-    "flags": [ "OVERSIZE" ]
+    "flags": [ "OVERSIZE" ],
+    "armor": { "coverage": 50, "covers": [ "arm_l", "arm_r" ], "encumbrance": 5 }
   },
   {
     "id": "legwrap_leather",
@@ -46,12 +42,10 @@
     "material": [ "leather" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 50,
-    "encumbrance": 5,
     "warmth": 15,
     "material_thickness": 1,
-    "flags": [ "OVERSIZE" ]
+    "flags": [ "OVERSIZE" ],
+    "armor": { "coverage": 50, "covers": [ "leg_l", "leg_r" ], "encumbrance": 5 }
   },
   {
     "id": "legwrap_fur",
@@ -64,12 +58,10 @@
     "material": [ "fur" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 50,
-    "encumbrance": 5,
     "warmth": 20,
     "material_thickness": 1,
-    "flags": [ "OVERSIZE" ]
+    "flags": [ "OVERSIZE" ],
+    "armor": { "coverage": 50, "covers": [ "leg_l", "leg_r" ], "encumbrance": 5 }
   },
   {
     "id": "cloak_makeshift_sheet",
@@ -86,12 +78,10 @@
     "looks_like": "sheet",
     "repairs_like": "sheet",
     "color": "white",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 85,
-    "encumbrance": 10,
     "warmth": 10,
     "material_thickness": 1,
-    "flags": [ "OVERSIZE", "OUTER", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "OVERSIZE", "OUTER", "ALLOWS_NATURAL_ATTACKS" ],
+    "armor": { "coverage": 85, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 10 }
   },
   {
     "id": "cloak_makeshift_blanket",
@@ -105,10 +95,10 @@
     "looks_like": "blanket",
     "repairs_like": "blanket",
     "color": "blue",
-    "encumbrance": 30,
     "warmth": 50,
     "material_thickness": 3,
-    "environmental_protection": 1
+    "environmental_protection": 1,
+    "armor": { "encumbrance": 30 }
   },
   {
     "id": "cloak_makeshift_down_blanket",
@@ -123,10 +113,10 @@
     "looks_like": "down_blanket",
     "repairs_like": "down_blanket",
     "color": "blue",
-    "encumbrance": 40,
     "warmth": 70,
     "material_thickness": 3,
-    "environmental_protection": 1
+    "environmental_protection": 1,
+    "armor": { "encumbrance": 40 }
   },
   {
     "id": "cloak_makeshift_fur_blanket",
@@ -142,9 +132,9 @@
     "looks_like": "fur_blanket",
     "repairs_like": "fur_blanket",
     "color": "brown",
-    "encumbrance": 50,
     "warmth": 80,
     "material_thickness": 4,
-    "environmental_protection": 1
+    "environmental_protection": 1,
+    "armor": { "encumbrance": 50 }
   }
 ]

--- a/data/Maintained_mods/mods/MST_Extra/items/tool_armor.json
+++ b/data/Maintained_mods/mods/MST_Extra/items/tool_armor.json
@@ -6,7 +6,6 @@
     "category": "tools",
     "weight": "1800 g",
     "color": "brown",
-    "covers": [ "torso" ],
     "initial_charges": 1,
     "use_action": {
       "type": "musical_instrument",
@@ -31,11 +30,10 @@
     "price": "5 USD",
     "material": [ "wood", "leather" ],
     "volume": "2500 ml",
-    "encumbrance": 10,
     "bashing": 4,
     "flags": [ "WAIST" ],
-    "coverage": 10,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 10, "covers": [ "torso" ], "encumbrance": 10 }
   },
   {
     "id": "mask_gas_makeshift",
@@ -52,9 +50,6 @@
     "material": [ "cotton", "plastic" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "head", "mouth", "eyes" ],
-    "coverage": 100,
-    "encumbrance": 20,
     "warmth": 15,
     "material_thickness": 2,
     "environmental_protection": 1,
@@ -63,6 +58,7 @@
     "max_charges": 100,
     "ammo": [ "gasfilter_m" ],
     "use_action": "GASMASK",
-    "flags": [ "OUTER", "HELMET_COMPAT" ]
+    "flags": [ "OUTER", "HELMET_COMPAT" ],
+    "armor": { "coverage": 100, "covers": [ "head", "mouth", "eyes" ], "encumbrance": 20 }
   }
 ]

--- a/data/Maintained_mods/mods/MST_Extra/obsolete.json
+++ b/data/Maintained_mods/mods/MST_Extra/obsolete.json
@@ -199,9 +199,6 @@
     "material": [ "paper" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "torso" ],
-    "coverage": 30,
-    "encumbrance": 12,
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -212,7 +209,8 @@
       }
     ],
     "material_thickness": 2,
-    "flags": [ "BELTED", "WATER_FRIENDLY" ]
+    "flags": [ "BELTED", "WATER_FRIENDLY" ],
+    "armor": { "coverage": 30, "covers": [ "torso" ], "encumbrance": 12 }
   },
   {
     "result": "pack_basket",

--- a/data/Maintained_mods/mods/No_Hope_Night_Pryanik/Items/armor.json
+++ b/data/Maintained_mods/mods/No_Hope_Night_Pryanik/Items/armor.json
@@ -14,12 +14,10 @@
     "symbol": "[",
     "looks_like": "modularvest",
     "color": "light_gray",
-    "covers": [ "torso" ],
-    "coverage": 85,
-    "encumbrance": 6,
     "warmth": 15,
     "material_thickness": 5,
-    "flags": [ "STURDY", "OUTER", "WATER_FRIENDLY" ]
+    "flags": [ "STURDY", "OUTER", "WATER_FRIENDLY" ],
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": 6 }
   },
   {
     "id": "ballistic_vest_esapi",
@@ -35,12 +33,10 @@
     "symbol": "[",
     "looks_like": "modularvestceramic",
     "color": "light_gray",
-    "covers": [ "torso" ],
-    "coverage": 85,
-    "encumbrance": 10,
     "warmth": 15,
     "material_thickness": 7,
-    "flags": [ "STURDY", "OUTER", "WATER_FRIENDLY", "NO_REPAIR" ]
+    "flags": [ "STURDY", "OUTER", "WATER_FRIENDLY", "NO_REPAIR" ],
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": 10 }
   },
   {
     "id": "depowered_armor",
@@ -59,9 +55,6 @@
     "symbol": "[",
     "looks_like": "power_armor_basic",
     "color": "light_gray",
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 95,
-    "encumbrance": 40,
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -74,7 +67,12 @@
     "warmth": 50,
     "material_thickness": 8,
     "environmental_protection": 6,
-    "flags": [ "WATERPROOF", "STURDY" ]
+    "flags": [ "WATERPROOF", "STURDY" ],
+    "armor": {
+      "coverage": 95,
+      "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 40
+    }
   },
   {
     "id": "depowered_helmet",
@@ -92,14 +90,12 @@
     "symbol": "[",
     "looks_like": "power_armor_helmet_basic",
     "color": "light_gray",
-    "covers": [ "head", "eyes", "mouth" ],
-    "coverage": 95,
-    "encumbrance": 40,
     "warmth": 50,
     "material_thickness": 8,
     "environmental_protection": 6,
     "qualities": [ [ "GLARE", 2 ] ],
-    "flags": [ "WATERPROOF", "STURDY", "SUN_GLASSES" ]
+    "flags": [ "WATERPROOF", "STURDY", "SUN_GLASSES" ],
+    "armor": { "coverage": 95, "covers": [ "head", "eyes", "mouth" ], "encumbrance": 40 }
   },
   {
     "id": "power_armor_basic",
@@ -117,9 +113,6 @@
     "symbol": "[",
     "looks_like": "depowered_armor",
     "color": "light_gray",
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 50,
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -135,7 +128,12 @@
     "environmental_protection": 16,
     "ammo": [ "battery" ],
     "use_action": { "type": "transform", "msg": "The %s engages.", "target": "power_armor_basic_on", "active": true },
-    "flags": [ "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE" ]
+    "flags": [ "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 50
+    }
   },
   {
     "id": "power_armor_basic_on",
@@ -149,7 +147,7 @@
     "power_draw": 4000000,
     "revert_to": "power_armor_basic",
     "use_action": { "type": "transform", "menu_text": "Turn off", "msg": "The %s armor disengages.", "target": "power_armor_basic" },
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
+    "armor": { "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ] }
   },
   {
     "id": "power_armor_heavy",
@@ -167,9 +165,6 @@
     "symbol": "[",
     "looks_like": "power_armor_basic",
     "color": "dark_gray",
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 60,
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -185,7 +180,12 @@
     "environmental_protection": 16,
     "ammo": [ "battery" ],
     "use_action": { "type": "transform", "msg": "The %s engages.", "target": "power_armor_heavy_on", "active": true },
-    "flags": [ "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE" ]
+    "flags": [ "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 60
+    }
   },
   {
     "id": "power_armor_heavy_on",
@@ -199,7 +199,7 @@
     "power_draw": 4000000,
     "revert_to": "power_armor_heavy",
     "use_action": { "type": "transform", "menu_text": "Turn off", "msg": "The %s armor disengages.", "target": "power_armor_heavy" },
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
+    "armor": { "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ] }
   },
   {
     "id": "power_armor_helmet_basic",
@@ -217,15 +217,13 @@
     "symbol": "[",
     "looks_like": "depowered_helmet",
     "color": "light_gray",
-    "covers": [ "head", "eyes", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 50,
     "warmth": 90,
     "power_armor": true,
     "material_thickness": 14,
     "environmental_protection": 16,
     "qualities": [ [ "GLARE", 2 ] ],
-    "flags": [ "WATCH", "WATERPROOF", "STURDY", "PARTIAL_DEAF", "THERMOMETER", "SUN_GLASSES" ]
+    "flags": [ "WATCH", "WATERPROOF", "STURDY", "PARTIAL_DEAF", "THERMOMETER", "SUN_GLASSES" ],
+    "armor": { "coverage": 100, "covers": [ "head", "eyes", "mouth" ], "encumbrance": 50 }
   },
   {
     "id": "power_armor_helmet_heavy",
@@ -243,15 +241,13 @@
     "symbol": "[",
     "looks_like": "power_armor_helmet_basic",
     "color": "dark_gray",
-    "covers": [ "head", "eyes", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 60,
     "warmth": 60,
     "power_armor": true,
     "material_thickness": 16,
     "environmental_protection": 16,
     "qualities": [ [ "GLARE", 2 ] ],
-    "flags": [ "WATCH", "WATERPROOF", "STURDY", "PARTIAL_DEAF", "THERMOMETER", "SUN_GLASSES" ]
+    "flags": [ "WATCH", "WATERPROOF", "STURDY", "PARTIAL_DEAF", "THERMOMETER", "SUN_GLASSES" ],
+    "armor": { "coverage": 100, "covers": [ "head", "eyes", "mouth" ], "encumbrance": 60 }
   },
   {
     "id": "power_armor_helmet_light",
@@ -269,15 +265,13 @@
     "symbol": "[",
     "looks_like": "power_armor_helmet_basic",
     "color": "dark_gray",
-    "covers": [ "head", "eyes", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 40,
     "warmth": 60,
     "power_armor": true,
     "material_thickness": 8,
     "environmental_protection": 16,
     "qualities": [ [ "GLARE", 1 ] ],
-    "flags": [ "WATCH", "WATERPROOF", "STURDY", "THERMOMETER", "SUN_GLASSES" ]
+    "flags": [ "WATCH", "WATERPROOF", "STURDY", "THERMOMETER", "SUN_GLASSES" ],
+    "armor": { "coverage": 100, "covers": [ "head", "eyes", "mouth" ], "encumbrance": 40 }
   },
   {
     "id": "power_armor_light",
@@ -295,9 +289,6 @@
     "symbol": "[",
     "looks_like": "depowered_armor",
     "color": "dark_gray",
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 40,
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -313,7 +304,12 @@
     "environmental_protection": 16,
     "ammo": [ "battery" ],
     "use_action": { "type": "transform", "msg": "The %s engages.", "target": "power_armor_light_on", "active": true },
-    "flags": [ "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE" ]
+    "flags": [ "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 40
+    }
   },
   {
     "id": "power_armor_light_on",
@@ -327,7 +323,7 @@
     "power_draw": 4000000,
     "revert_to": "power_armor_light",
     "use_action": { "type": "transform", "menu_text": "Turn off", "msg": "The %s armor disengages.", "target": "power_armor_light" },
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
+    "armor": { "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ] }
   },
   {
     "id": "armguard_bone",
@@ -342,13 +338,11 @@
     "material": [ "bone", "leather" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "arm_l", "arm_r" ],
-    "coverage": 95,
-    "encumbrance": 22,
     "warmth": 20,
     "material_thickness": 4,
     "environmental_protection": 1,
-    "flags": [ "STURDY", "BELTED", "BLOCK_WHILE_WORN", "WATER_FRIENDLY" ]
+    "flags": [ "STURDY", "BELTED", "BLOCK_WHILE_WORN", "WATER_FRIENDLY" ],
+    "armor": { "coverage": 95, "covers": [ "arm_l", "arm_r" ], "encumbrance": 22 }
   },
   {
     "id": "armor_bone",
@@ -364,12 +358,10 @@
     "material": [ "bone", "leather" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "torso", "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 24,
     "warmth": 20,
     "material_thickness": 4,
-    "flags": [ "VARSIZE", "STURDY" ]
+    "flags": [ "VARSIZE", "STURDY" ],
+    "armor": { "coverage": 95, "covers": [ "torso", "leg_l", "leg_r" ], "encumbrance": 24 }
   },
   {
     "id": "gauntlets_bone",
@@ -385,13 +377,11 @@
     "material": [ "bone", "leather" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "hand_l", "hand_r" ],
-    "coverage": 95,
-    "encumbrance": 15,
     "warmth": 20,
     "material_thickness": 4,
     "environmental_protection": 4,
-    "flags": [ "STURDY" ]
+    "flags": [ "STURDY" ],
+    "armor": { "coverage": 95, "covers": [ "hand_l", "hand_r" ], "encumbrance": 15 }
   },
   {
     "id": "helmet_bone",
@@ -407,12 +397,10 @@
     "material": [ "bone" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "head", "eyes", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 5,
     "environmental_protection": 3,
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "head", "eyes", "mouth" ], "encumbrance": 25 }
   }
 ]

--- a/data/Maintained_mods/mods/Nocts_cata_mod/Surv_help/c_armor.json
+++ b/data/Maintained_mods/mods/Nocts_cata_mod/Surv_help/c_armor.json
@@ -12,17 +12,14 @@
     "material": [ "leather", "cotton" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso" ],
-    "coverage": 35,
-    "encumbrance": 4,
-    "max_encumbrance": 16,
     "pocket_data": [
       { "ammo_restriction": { "arrow": 50, "bolt": 50 }, "moves": 20 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "16 L", "max_contains_weight": "32 kg", "moves": 300 }
     ],
     "warmth": 10,
     "material_thickness": 2,
-    "flags": [ "WATER_FRIENDLY", "STURDY", "BELTED" ]
+    "flags": [ "WATER_FRIENDLY", "STURDY", "BELTED" ],
+    "armor": { "coverage": 35, "covers": [ "torso" ], "encumbrance": [ 4, 16 ] }
   },
   {
     "id": "surv_suit",
@@ -39,9 +36,6 @@
     "material": [ "leather", "kevlar" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "foot_l", "foot_r", "head" ],
-    "coverage": 100,
-    "encumbrance": 35,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "6 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "6 kg", "moves": 80 },
@@ -81,7 +75,12 @@
       "WATCH",
       "NONCONDUCTIVE",
       "ALARMCLOCK"
-    ]
+    ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "foot_l", "foot_r", "head" ],
+      "encumbrance": 35
+    }
   },
   {
     "id": "surv_armor_suit",
@@ -99,9 +98,6 @@
     "material": [ "kevlar", "steel" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "foot_l", "foot_r", "head" ],
-    "coverage": 100,
-    "encumbrance": 45,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "6 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "6 kg", "moves": 80 },
@@ -141,7 +137,12 @@
       "WATCH",
       "NONCONDUCTIVE",
       "ALARMCLOCK"
-    ]
+    ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "foot_l", "foot_r", "head" ],
+      "encumbrance": 45
+    }
   },
   {
     "id": "armor_lightplate_surv",
@@ -153,12 +154,11 @@
     "weight": "12100 g",
     "price": "900 USD",
     "material": [ "steel", "kevlar", "leather" ],
-    "coverage": 100,
-    "encumbrance": 25,
     "warmth": 30,
     "environmental_protection": 3,
     "material_thickness": 5,
-    "extend": { "flags": [ "WATERPROOF" ] }
+    "extend": { "flags": [ "WATERPROOF" ] },
+    "armor": { "coverage": 100, "encumbrance": 25 }
   },
   {
     "id": "helmet_plate_surv",
@@ -169,12 +169,12 @@
     "weight": "2395 g",
     "price": "500 USD",
     "material": [ "steel", "kevlar", "leather" ],
-    "encumbrance": 35,
     "warmth": 20,
     "environmental_protection": 3,
     "material_thickness": 6,
     "qualities": [ [ "GLARE", 1 ] ],
-    "extend": { "flags": [ "WATERPROOF", "SUN_GLASSES" ] }
+    "extend": { "flags": [ "WATERPROOF", "SUN_GLASSES" ] },
+    "armor": { "encumbrance": 35 }
   },
   {
     "id": "gloves_plate_surv",
@@ -185,11 +185,11 @@
     "weight": "1080 g",
     "price": "500 USD",
     "material": [ "iron", "kevlar", "leather" ],
-    "encumbrance": 25,
     "warmth": 25,
     "material_thickness": 5,
     "environmental_protection": 3,
-    "extend": { "flags": [ "WATERPROOF" ] }
+    "extend": { "flags": [ "WATERPROOF" ] },
+    "armor": { "encumbrance": 25 }
   },
   {
     "id": "boots_plate_surv",
@@ -200,10 +200,10 @@
     "weight": "2080 g",
     "price": "600 USD",
     "material": [ "iron", "kevlar", "leather" ],
-    "encumbrance": 30,
     "warmth": 25,
     "material_thickness": 5,
-    "environmental_protection": 3
+    "environmental_protection": 3,
+    "armor": { "encumbrance": 30 }
   },
   {
     "id": "badge_bio_weapon",
@@ -253,9 +253,6 @@
     "material": [ "superalloy", "plastic" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "head" ],
-    "coverage": 75,
-    "encumbrance": 15,
     "warmth": 15,
     "material_thickness": 1,
     "environmental_protection": 4,
@@ -270,7 +267,8 @@
         }
       ]
     },
-    "flags": [ "OVERSIZE", "HOOD", "WATERPROOF", "OUTER", "VARSIZE", "ACTIVE_CLOAKING" ]
+    "flags": [ "OVERSIZE", "HOOD", "WATERPROOF", "OUTER", "VARSIZE", "ACTIVE_CLOAKING" ],
+    "armor": { "coverage": 75, "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "head" ], "encumbrance": 15 }
   },
   {
     "id": "C_MUTE_BOOTS",
@@ -297,14 +295,12 @@
     "material": [ "kevlar", "leather" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 18,
     "warmth": 25,
     "material_thickness": 3,
     "environmental_protection": 2,
     "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "mutations": [ "C_MUTE_BOOTS" ] } ] },
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "foot_l", "foot_r" ], "encumbrance": 18 }
   },
   {
     "id": "C_RADIOGENIC_GOGGLES",
@@ -329,14 +325,12 @@
     "material": [ "plastic", "steel" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "eyes" ],
-    "coverage": 100,
-    "encumbrance": 30,
     "warmth": 10,
     "material_thickness": 4,
     "environmental_protection": 5,
     "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "mutations": [ "C_RADIOGENIC_GOGGLES" ] } ] },
-    "flags": [ "GNV_EFFECT", "WATERPROOF", "STURDY", "RADIOACTIVE", "LIGHT_25" ]
+    "flags": [ "GNV_EFFECT", "WATERPROOF", "STURDY", "RADIOACTIVE", "LIGHT_25" ],
+    "armor": { "coverage": 100, "covers": [ "eyes" ], "encumbrance": 30 }
   },
   {
     "id": "lmil_armor",
@@ -352,13 +346,15 @@
     "material": [ "c_superalloy_composite" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "foot_l", "foot_r", "head" ],
-    "coverage": 100,
-    "encumbrance": 12,
     "warmth": 30,
     "material_thickness": 2,
     "environmental_protection": 4,
-    "flags": [ "STURDY", "NO_SALVAGE" ]
+    "flags": [ "STURDY", "NO_SALVAGE" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "foot_l", "foot_r", "head" ],
+      "encumbrance": 12
+    }
   },
   {
     "id": "mil_armor",
@@ -374,13 +370,15 @@
     "material": [ "c_superalloy_composite" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "foot_l", "foot_r", "head" ],
-    "coverage": 100,
-    "encumbrance": 24,
     "warmth": 40,
     "material_thickness": 4,
     "environmental_protection": 4,
-    "flags": [ "STURDY", "NO_SALVAGE" ]
+    "flags": [ "STURDY", "NO_SALVAGE" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "foot_l", "foot_r", "head" ],
+      "encumbrance": 24
+    }
   },
   {
     "id": "hmil_armor",
@@ -396,13 +394,15 @@
     "material": [ "c_superalloy_composite" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "foot_l", "foot_r", "head" ],
-    "coverage": 100,
-    "encumbrance": 36,
     "warmth": 30,
     "material_thickness": 6,
     "environmental_protection": 4,
-    "flags": [ "STURDY", "NONCONDUCTIVE", "NO_SALVAGE" ]
+    "flags": [ "STURDY", "NONCONDUCTIVE", "NO_SALVAGE" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "foot_l", "foot_r", "head" ],
+      "encumbrance": 36
+    }
   },
   {
     "id": "fancy_bra",
@@ -415,11 +415,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "torso" ],
-    "coverage": 15,
     "warmth": 5,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "SKINTIGHT", "SUPER_FANCY" ]
+    "flags": [ "VARSIZE", "SKINTIGHT", "SUPER_FANCY" ],
+    "armor": { "coverage": 15, "covers": [ "torso" ] }
   },
   {
     "id": "thong",
@@ -432,11 +431,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 12,
     "warmth": 5,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "SKINTIGHT", "FANCY" ]
+    "flags": [ "VARSIZE", "SKINTIGHT", "FANCY" ],
+    "armor": { "coverage": 12, "covers": [ "leg_l", "leg_r" ] }
   },
   {
     "id": "dress_skirt",
@@ -449,12 +447,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 50,
-    "encumbrance": 2,
     "warmth": 5,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 50, "covers": [ "leg_l", "leg_r" ], "encumbrance": 2 }
   },
   {
     "id": "microskirt",
@@ -467,9 +463,8 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "pink",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 7,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 7, "covers": [ "leg_l", "leg_r" ] }
   }
 ]

--- a/data/Maintained_mods/mods/Nocts_cata_mod/Surv_help/c_tools.json
+++ b/data/Maintained_mods/mods/Nocts_cata_mod/Surv_help/c_tools.json
@@ -630,9 +630,8 @@
     "relic_data": { "charge_info": { "recharge_type": "solar_sunny", "time": "10 m", "regenerate_ammo": true } },
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "battery": 250 } } ],
     "flags": [ "WATCH", "ALARMCLOCK", "RECHARGE" ],
-    "encumbrance": 1,
-    "coverage": 1,
-    "phase": "solid"
+    "phase": "solid",
+    "armor": { "coverage": 1, "encumbrance": 1 }
   },
   {
     "id": "stim",
@@ -814,11 +813,10 @@
     "material": [ "plastic", "steel" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "hand_l", "hand_r" ],
     "sided": true,
-    "coverage": 5,
     "use_action": [ "WEATHER_TOOL", "DISASSEMBLE" ],
-    "flags": [ "WATCH", "ALARMCLOCK", "BELTED", "FRAGILE", "ALLOWS_NATURAL_ATTACKS", "THERMOMETER" ]
+    "flags": [ "WATCH", "ALARMCLOCK", "BELTED", "FRAGILE", "ALLOWS_NATURAL_ATTACKS", "THERMOMETER" ],
+    "armor": { "coverage": 5, "covers": [ "hand_l", "hand_r" ] }
   },
   {
     "id": "parabracelets",
@@ -832,11 +830,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "hand_l", "hand_r" ],
     "sided": true,
-    "coverage": 5,
     "flags": [ "BELTED", "FRAGILE", "ALLOWS_NATURAL_ATTACKS" ],
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 5, "covers": [ "hand_l", "hand_r" ] }
   },
   {
     "id": "flesh_weapon_kit",
@@ -876,20 +873,18 @@
     "description": "A prototype device giving off noticeable heat, housing a compact radioisotope thermoelectric generator.  It does not seem to accept batteries or even provide a UPS hookup, instead housing an inductive charging system designed specifically for CBM power storage.  Being an unfinished design, the only way to dump power into the inductor without electrocuting yourself requires opening up part of the mechanism, exposing you to radiation.",
     "price": "12 kUSD",
     "material": [ "plastic", "aluminum" ],
-    "covers": [ "torso" ],
     "flags": [ "LEAK_DAM", "RADIOACTIVE", "WAIST", "OVERSIZE", "NO_RELOAD", "NO_UNLOAD" ],
     "weight": "2200 g",
     "volume": "3 L",
     "bashing": 4,
-    "coverage": 25,
-    "encumbrance": 5,
     "warmth": 20,
     "material_thickness": 2,
     "ammo": [ "battery" ],
     "charges_per_use": 1,
     "relic_data": { "charge_info": { "recharge_type": "periodic", "time": "1 h", "regenerate_ammo": true } },
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "battery": 25 } } ],
-    "use_action": { "type": "cast_spell", "spell_id": "c_cbm_rtg_induction", "no_fail": true, "level": 0 }
+    "use_action": { "type": "cast_spell", "spell_id": "c_cbm_rtg_induction", "no_fail": true, "level": 0 },
+    "armor": { "coverage": 25, "covers": [ "torso" ], "encumbrance": 5 }
   },
   {
     "id": "thermal_lance_makeshift",

--- a/data/Maintained_mods/mods/expansion_tefnut/items/armor/armor_fake.json
+++ b/data/Maintained_mods/mods/expansion_tefnut/items/armor/armor_fake.json
@@ -14,12 +14,10 @@
     "symbol": "[",
     "looks_like": "armor_lorica",
     "color": "light_gray",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 90,
-    "encumbrance": 15,
     "warmth": 15,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "OUTER" ]
+    "flags": [ "VARSIZE", "OUTER" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 15 }
   },
   {
     "id": "chainmail_vest_fake",
@@ -36,11 +34,9 @@
     "symbol": "[",
     "looks_like": "chainmail_vest",
     "color": "light_red",
-    "covers": [ "torso" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "material_thickness": 1,
-    "flags": [ "VARSIZE" ]
+    "flags": [ "VARSIZE" ],
+    "armor": { "coverage": 95, "covers": [ "torso" ], "encumbrance": 20 }
   },
   {
     "id": "cuirass_lightplate_fake",
@@ -57,12 +53,10 @@
     "symbol": "[",
     "looks_like": "cuirass_lightplate",
     "color": "light_gray",
-    "covers": [ "torso" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "warmth": 20,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "OUTER" ]
+    "flags": [ "VARSIZE", "OUTER" ],
+    "armor": { "coverage": 95, "covers": [ "torso" ], "encumbrance": 20 }
   },
   {
     "id": "chainmail_legs_fake",
@@ -79,11 +73,9 @@
     "symbol": "[",
     "looks_like": "chainmail_legs",
     "color": "light_red",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "material_thickness": 1,
-    "flags": [ "VARSIZE" ]
+    "flags": [ "VARSIZE" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r" ], "encumbrance": 20 }
   },
   {
     "id": "legguard_lightplate_fake",
@@ -100,12 +92,10 @@
     "symbol": "[",
     "looks_like": "legguard_lightplate",
     "color": "light_gray",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "warmth": 20,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "BELTED" ]
+    "flags": [ "VARSIZE", "BELTED" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r" ], "encumbrance": 20 }
   },
   {
     "id": "armor_lightplate_fale",
@@ -123,12 +113,10 @@
     "symbol": "[",
     "looks_like": "armor_lightplate",
     "color": "light_gray",
-    "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "warmth": 20,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "OUTER" ]
+    "flags": [ "VARSIZE", "OUTER" ],
+    "armor": { "coverage": 95, "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ], "encumbrance": 20 }
   },
   {
     "id": "armor_plate_fake",
@@ -146,11 +134,9 @@
     "symbol": "[",
     "looks_like": "armor_plate",
     "color": "light_gray",
-    "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ],
-    "coverage": 90,
-    "encumbrance": 45,
     "warmth": 20,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "OUTER", "FANCY" ]
+    "flags": [ "VARSIZE", "OUTER", "FANCY" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ], "encumbrance": 45 }
   }
 ]

--- a/data/Maintained_mods/mods/expansion_tefnut/items/armor/boots.json
+++ b/data/Maintained_mods/mods/expansion_tefnut/items/armor/boots.json
@@ -13,14 +13,12 @@
     "symbol": "[",
     "looks_like": "sneakers",
     "color": "light_blue",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 18,
     "warmth": 15,
     "material_thickness": 5,
     "environmental_protection": 3,
     "use_action": { "type": "transform", "target": "roller_shoes_surv_on", "msg": "You pop the wheels out.", "moves": 500 },
-    "flags": [ "VARSIZE", "SUPER_FANCY", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "SUPER_FANCY", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "foot_l", "foot_r" ], "encumbrance": 18 }
   },
   {
     "id": "roller_shoes_surv_on",
@@ -35,13 +33,11 @@
     "symbol": "[",
     "looks_like": "sneakers",
     "color": "light_blue",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 18,
     "warmth": 15,
     "material_thickness": 5,
     "environmental_protection": 3,
     "use_action": { "type": "transform", "target": "roller_shoes_surv_off", "msg": "You pop the wheels back in.", "moves": 500 },
-    "flags": [ "VARSIZE", "ROLLER_ONE", "REQUIRES_BALANCE", "SUPER_FANCY", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "ROLLER_ONE", "REQUIRES_BALANCE", "SUPER_FANCY", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "foot_l", "foot_r" ], "encumbrance": 18 }
   }
 ]

--- a/data/Maintained_mods/mods/expansion_tefnut/items/armor/lewd.json
+++ b/data/Maintained_mods/mods/expansion_tefnut/items/armor/lewd.json
@@ -12,11 +12,10 @@
     "symbol": "[",
     "looks_like": "briefs",
     "color": "green",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 15,
     "warmth": 5,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "SKINTIGHT", "STURDY" ]
+    "flags": [ "VARSIZE", "SKINTIGHT", "STURDY" ],
+    "armor": { "coverage": 15, "covers": [ "leg_l", "leg_r" ] }
   },
   {
     "id": "bra_surv",
@@ -32,11 +31,10 @@
     "looks_like": "bra",
     "storage": "500 ml",
     "color": "green",
-    "covers": [ "torso" ],
-    "coverage": 30,
     "warmth": 5,
     "material_thickness": 3,
-    "flags": [ "VARSIZE", "SKINTIGHT", "STURDY" ]
+    "flags": [ "VARSIZE", "SKINTIGHT", "STURDY" ],
+    "armor": { "coverage": 30, "covers": [ "torso" ] }
   },
   {
     "id": "surv_stockings",
@@ -51,12 +49,10 @@
     "symbol": "[",
     "looks_like": "stockings",
     "color": "green",
-    "covers": [ "foot_l", "foot_r", "leg_l", "leg_r" ],
-    "coverage": 75,
-    "encumbrance": 5,
     "warmth": 10,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "SKINTIGHT", "STURDY" ]
+    "flags": [ "VARSIZE", "SKINTIGHT", "STURDY" ],
+    "armor": { "coverage": 75, "covers": [ "foot_l", "foot_r", "leg_l", "leg_r" ], "encumbrance": 5 }
   },
   {
     "id": "surv_socks_programmer",
@@ -71,12 +67,10 @@
     "symbol": "[",
     "looks_like": "stockings",
     "color": "green",
-    "covers": [ "foot_l", "foot_r", "leg_l", "leg_r" ],
-    "coverage": 75,
-    "encumbrance": 5,
     "warmth": 10,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "SKINTIGHT", "STURDY" ]
+    "flags": [ "VARSIZE", "SKINTIGHT", "STURDY" ],
+    "armor": { "coverage": 75, "covers": [ "foot_l", "foot_r", "leg_l", "leg_r" ], "encumbrance": 5 }
   },
   {
     "id": "socks_programmer",
@@ -91,11 +85,9 @@
     "symbol": "[",
     "looks_like": "stockings",
     "color": "yellow",
-    "covers": [ "foot_l", "foot_r", "leg_l", "leg_r" ],
-    "coverage": 75,
-    "encumbrance": 5,
     "warmth": 10,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "SKINTIGHT" ]
+    "flags": [ "VARSIZE", "SKINTIGHT" ],
+    "armor": { "coverage": 75, "covers": [ "foot_l", "foot_r", "leg_l", "leg_r" ], "encumbrance": 5 }
   }
 ]

--- a/data/Maintained_mods/mods/expansion_tefnut/items/armor/maid.json
+++ b/data/Maintained_mods/mods/expansion_tefnut/items/armor/maid.json
@@ -12,13 +12,11 @@
     "symbol": "[",
     "looks_like": "maid_dress",
     "color": "black",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 70,
-    "encumbrance": 5,
     "storage": "500 ml",
     "warmth": 5,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 70, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 5 }
   },
   {
     "id": "maid_dress_victorian",
@@ -33,13 +31,11 @@
     "symbol": "[",
     "looks_like": "maid_dress",
     "color": "black",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 90,
-    "encumbrance": 10,
     "storage": "500 ml",
     "warmth": 7,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 10 }
   },
   {
     "id": "maid_hat_victorian",
@@ -54,12 +50,10 @@
     "symbol": "[",
     "looks_like": "maid_hat",
     "color": "white",
-    "covers": [ "head" ],
-    "coverage": 50,
-    "encumbrance": 10,
     "warmth": 10,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 50, "covers": [ "head" ], "encumbrance": 10 }
   },
   {
     "id": "maid_dress_steampunk",
@@ -74,13 +68,11 @@
     "symbol": "[",
     "looks_like": "maid_dress",
     "color": "black",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 90,
-    "encumbrance": 10,
     "storage": "4000 ml",
     "warmth": 10,
     "material_thickness": 3,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 10 }
   },
   {
     "id": "maid_dress_combat",
@@ -95,13 +87,11 @@
     "symbol": "[",
     "looks_like": "maid_dress",
     "color": "green",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 70,
-    "encumbrance": 7,
     "storage": "1500 ml",
     "warmth": 6,
     "material_thickness": 4,
-    "flags": [ "VARSIZE", "FANCY", "STURDY" ]
+    "flags": [ "VARSIZE", "FANCY", "STURDY" ],
+    "armor": { "coverage": 70, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 7 }
   },
   {
     "id": "maid_dress_cyberpunk",
@@ -116,14 +106,12 @@
     "symbol": "[",
     "looks_like": "maid_dress",
     "color": "black",
-    "covers": [ "torso", "leg_l", "leg_r" ],
-    "coverage": 50,
-    "encumbrance": 3,
     "storage": "500 ml",
     "warmth": 3,
     "environmental_protection": 5,
     "material_thickness": 5,
-    "flags": [ "VARSIZE", "FANCY", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "FANCY", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 50, "covers": [ "torso", "leg_l", "leg_r" ], "encumbrance": 3 }
   },
   {
     "id": "maid_boots_cyberpunk",
@@ -141,13 +129,11 @@
     "symbol": "[",
     "looks_like": "boots_larmor",
     "color": "dark_gray",
-    "covers": [ "foot_l", "foot_r", "leg_l", "leg_r" ],
-    "coverage": 80,
-    "encumbrance": 25,
     "warmth": 20,
     "material_thickness": 3,
     "environmental_protection": 5,
-    "flags": [ "VARSIZE", "WATERPROOF", "FANCY", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "FANCY", "STURDY" ],
+    "armor": { "coverage": 80, "covers": [ "foot_l", "foot_r", "leg_l", "leg_r" ], "encumbrance": 25 }
   },
   {
     "id": "maid_hat_cyberpunk",
@@ -162,12 +148,10 @@
     "symbol": "[",
     "looks_like": "maid_hat",
     "color": "white",
-    "covers": [ "head" ],
-    "coverage": 25,
-    "encumbrance": 10,
     "warmth": 10,
     "material_thickness": 1,
     "environmental_protection": 5,
-    "flags": [ "VARSIZE", "FANCY", "STURDY" ]
+    "flags": [ "VARSIZE", "FANCY", "STURDY" ],
+    "armor": { "coverage": 25, "covers": [ "head" ], "encumbrance": 10 }
   }
 ]

--- a/data/Maintained_mods/mods/expansion_tefnut/items/armor/misc.json
+++ b/data/Maintained_mods/mods/expansion_tefnut/items/armor/misc.json
@@ -14,13 +14,15 @@
     "symbol": "[",
     "looks_like": "american_flag",
     "color": "light_red",
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 60,
-    "encumbrance": 50,
     "warmth": 20,
     "material_thickness": 1,
     "environmental_protection": 1,
-    "flags": [ "OVERSIZE", "OUTER", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "OVERSIZE", "OUTER", "ALLOWS_NATURAL_ATTACKS" ],
+    "armor": {
+      "coverage": 60,
+      "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 50
+    }
   },
   {
     "id": "rebel_flag",
@@ -37,12 +39,14 @@
     "symbol": "[",
     "looks_like": "american_flag",
     "color": "light_red",
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 60,
-    "encumbrance": 50,
     "warmth": 20,
     "material_thickness": 1,
     "environmental_protection": 1,
-    "flags": [ "OVERSIZE", "OUTER", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "OVERSIZE", "OUTER", "ALLOWS_NATURAL_ATTACKS" ],
+    "armor": {
+      "coverage": 60,
+      "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 50
+    }
   }
 ]

--- a/data/Maintained_mods/mods/expansion_tefnut/items/armor/misc_survivor.json
+++ b/data/Maintained_mods/mods/expansion_tefnut/items/armor/misc_survivor.json
@@ -13,13 +13,11 @@
     "symbol": "[",
     "looks_like": "snuggie",
     "color": "green",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 85,
-    "encumbrance": 25,
     "warmth": 50,
     "material_thickness": 3,
     "environmental_protection": 2,
-    "flags": [ "OVERSIZE", "OUTER", "HOOD", "STURDY" ]
+    "flags": [ "OVERSIZE", "OUTER", "HOOD", "STURDY" ],
+    "armor": { "coverage": 85, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 25 }
   },
   {
     "id": "jedi_cloak_survivor",
@@ -36,13 +34,15 @@
     "symbol": "[",
     "looks_like": "jedi_cloak",
     "color": "brown",
-    "covers": [ "torso", "head", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r" ],
-    "coverage": 65,
-    "encumbrance": 3,
     "warmth": 50,
     "material_thickness": 2,
     "environmental_protection": 5,
-    "flags": [ "OVERSIZE", "OUTER", "HELMET_COMPAT", "STURDY" ]
+    "flags": [ "OVERSIZE", "OUTER", "HELMET_COMPAT", "STURDY" ],
+    "armor": {
+      "coverage": 65,
+      "covers": [ "torso", "head", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r" ],
+      "encumbrance": 3
+    }
   },
   {
     "id": "cloak_survivor",
@@ -58,13 +58,11 @@
     "symbol": "[",
     "looks_like": "cloak",
     "color": "green",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 65,
-    "encumbrance": 4,
     "warmth": 30,
     "material_thickness": 2,
     "environmental_protection": 3,
-    "flags": [ "OVERSIZE", "HOOD", "OUTER" ]
+    "flags": [ "OVERSIZE", "HOOD", "OUTER" ],
+    "armor": { "coverage": 65, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 4 }
   },
   {
     "id": "blanket_survivor",
@@ -80,13 +78,15 @@
     "symbol": "[",
     "looks_like": "towel",
     "color": "blue",
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 35,
     "warmth": 50,
     "material_thickness": 3,
     "environmental_protection": 1,
-    "flags": [ "OVERSIZE", "OUTER", "ALLOWS_NATURAL_ATTACKS", "STURDY" ]
+    "flags": [ "OVERSIZE", "OUTER", "ALLOWS_NATURAL_ATTACKS", "STURDY" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 35
+    }
   },
   {
     "id": "fur_blanket_survivor",
@@ -102,13 +102,15 @@
     "symbol": "[",
     "looks_like": "blanket",
     "color": "brown",
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 55,
     "warmth": 80,
     "material_thickness": 4,
     "environmental_protection": 1,
-    "flags": [ "OVERSIZE", "OUTER", "ALLOWS_NATURAL_ATTACKS", "STURDY" ]
+    "flags": [ "OVERSIZE", "OUTER", "ALLOWS_NATURAL_ATTACKS", "STURDY" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 55
+    }
   },
   {
     "id": "tophat_survivor",
@@ -125,9 +127,6 @@
     "symbol": "[",
     "looks_like": "tophat",
     "color": "black",
-    "covers": [ "head" ],
-    "coverage": 50,
-    "encumbrance": 20,
     "warmth": 5,
     "material_thickness": 2,
     "environmental_protection": 1,
@@ -139,6 +138,7 @@
       "draw_cost": 30,
       "flags": [ "SHEATH_KNIFE" ]
     },
-    "flags": [ "VARSIZE", "SUPER_FANCY", "STURDY" ]
+    "flags": [ "VARSIZE", "SUPER_FANCY", "STURDY" ],
+    "armor": { "coverage": 50, "covers": [ "head" ], "encumbrance": 20 }
   }
 ]

--- a/data/Maintained_mods/mods/expansion_tefnut/items/armor/wrist.json
+++ b/data/Maintained_mods/mods/expansion_tefnut/items/armor/wrist.json
@@ -9,7 +9,6 @@
     "weight": "112 g",
     "to_hit": -1,
     "color": "light_gray",
-    "covers": [ "HANDs" ],
     "price": "60 USD",
     "price_postapoc": "1 USD",
     "material": [ "plastic_trans" ],
@@ -25,7 +24,6 @@
       "PORTABLE_GAME"
     ],
     "flags": [ "WATCH", "ALARMCLOCK", "WATER_FRIENDLY", "BELTED", "FRAGILE", "ALLOWS_NATURAL_ATTACKS", "OVERSIZE" ],
-    "coverage": 15,
     "symbol": "[",
     "ammo": [ "battery" ],
     "magazines": [
@@ -41,7 +39,8 @@
         ]
       ]
     ],
-    "sided": true
+    "sided": true,
+    "armor": { "coverage": 15, "covers": [ "HANDs" ] }
   },
   {
     "id": "wrist_comp_bad_flashlight",
@@ -76,7 +75,6 @@
     "weight": "112 g",
     "to_hit": -1,
     "color": "light_gray",
-    "covers": [ "HANDs" ],
     "initial_charges": 500,
     "max_charges": 600,
     "charges_per_use": 1,
@@ -112,10 +110,10 @@
       "THERMOMETER",
       "FANCY"
     ],
-    "coverage": 15,
     "symbol": "[",
     "ammo": [ "battery" ],
-    "sided": true
+    "sided": true,
+    "armor": { "coverage": 15, "covers": [ "HANDs" ] }
   },
   {
     "id": "wrist_comp_budget_music",

--- a/data/Maintained_mods/mods/expansion_tefnut/items/guns/japanese/clothing.json
+++ b/data/Maintained_mods/mods/expansion_tefnut/items/guns/japanese/clothing.json
@@ -12,13 +12,11 @@
     "symbol": "[",
     "looks_like": "cowboy_hat",
     "color": "green",
-    "covers": [ "head" ],
-    "coverage": 65,
-    "encumbrance": 10,
     "warmth": 10,
     "material_thickness": 1,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "SUN_GLASSES", "FANCY" ]
+    "flags": [ "VARSIZE", "SUN_GLASSES", "FANCY" ],
+    "armor": { "coverage": 65, "covers": [ "head" ], "encumbrance": 10 }
   },
   {
     "id": "helm_type92",
@@ -37,12 +35,10 @@
     "symbol": "[",
     "looks_like": "helmet_army",
     "color": "dark_gray",
-    "covers": [ "head" ],
-    "coverage": 70,
-    "encumbrance": 20,
     "warmth": 15,
     "material_thickness": 3,
-    "flags": [ "SUN_GLASSES" ]
+    "flags": [ "SUN_GLASSES" ],
+    "armor": { "coverage": 70, "covers": [ "head" ], "encumbrance": 20 }
   },
   {
     "id": "headband_hachimaki",
@@ -57,12 +53,10 @@
     "symbol": "[",
     "looks_like": "hat_cotton",
     "color": "dark_gray",
-    "covers": [ "head" ],
-    "coverage": 5,
-    "encumbrance": 17,
     "warmth": 5,
     "material_thickness": 1,
-    "flags": [ "HELMET_COMPAT", "FANCY" ]
+    "flags": [ "HELMET_COMPAT", "FANCY" ],
+    "armor": { "coverage": 5, "covers": [ "head" ], "encumbrance": 17 }
   },
   {
     "id": "belt_senninbari",
@@ -77,8 +71,8 @@
     "symbol": "[",
     "looks_like": "leather_belt",
     "color": "red",
-    "covers": [ "torso" ],
-    "flags": [ "WAIST", "WATER_FRIENDLY", "SUPER_FANCY" ]
+    "flags": [ "WAIST", "WATER_FRIENDLY", "SUPER_FANCY" ],
+    "armor": { "covers": [ "torso" ] }
   },
   {
     "id": "fatigues_ija",
@@ -94,13 +88,11 @@
     "symbol": "[",
     "looks_like": "touring_suit",
     "color": "green",
-    "covers": [ "leg_l", "leg_r", "arm_l", "arm_r", "torso" ],
-    "coverage": 95,
-    "encumbrance": 2,
     "storage": "2 L",
     "warmth": 15,
     "material_thickness": 3,
-    "flags": [ "VARSIZE", "POCKETS" ]
+    "flags": [ "VARSIZE", "POCKETS" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r", "arm_l", "arm_r", "torso" ], "encumbrance": 2 }
   },
   {
     "id": "fatigues_redsun",
@@ -116,12 +108,10 @@
     "symbol": "[",
     "looks_like": "touring_suit",
     "color": "red",
-    "covers": [ "leg_l", "leg_r", "arm_l", "arm_r", "torso" ],
-    "coverage": 95,
-    "encumbrance": 2,
     "storage": "2 L",
     "warmth": 15,
     "material_thickness": 3,
-    "flags": [ "VARSIZE", "POCKETS" ]
+    "flags": [ "VARSIZE", "POCKETS" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r", "arm_l", "arm_r", "torso" ], "encumbrance": 2 }
   }
 ]

--- a/data/Maintained_mods/mods/expansion_tefnut/items/guns/ww2_america/american_uniforms.json
+++ b/data/Maintained_mods/mods/expansion_tefnut/items/guns/ww2_america/american_uniforms.json
@@ -13,13 +13,11 @@
     "symbol": "[",
     "looks_like": "touring_suit",
     "color": "green",
-    "covers": [ "leg_l", "leg_r", "arm_l", "arm_r", "torso" ],
-    "coverage": 95,
-    "encumbrance": 2,
     "storage": "2 L",
     "warmth": 15,
     "material_thickness": 3,
-    "flags": [ "VARSIZE", "POCKETS" ]
+    "flags": [ "VARSIZE", "POCKETS" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r", "arm_l", "arm_r", "torso" ], "encumbrance": 2 }
   },
   {
     "id": "jacket_eisenhower",
@@ -35,14 +33,12 @@
     "symbol": "[",
     "looks_like": "jacket_army",
     "color": "green",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 95,
-    "encumbrance": 15,
     "storage": "3500 ml",
     "warmth": 20,
     "material_thickness": 2,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "RAINPROOF", "COLLAR", "FANCY" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "RAINPROOF", "COLLAR", "FANCY" ],
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 15 }
   },
   {
     "id": "boots_jump",
@@ -61,12 +57,10 @@
     "symbol": "[",
     "looks_like": "boots",
     "color": "dark_gray",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 25,
     "warmth": 25,
     "material_thickness": 5,
     "environmental_protection": 3,
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "foot_l", "foot_r" ], "encumbrance": 25 }
   }
 ]

--- a/data/Maintained_mods/mods/simple_additions/items/armor/arms_armor.json
+++ b/data/Maintained_mods/mods/simple_additions/items/armor/arms_armor.json
@@ -14,10 +14,8 @@
     "symbol": "[",
     "looks_like": "armguard_hard",
     "color": "yellow",
-    "covers": [ "arm_l", "arm_r" ],
-    "coverage": 30,
-    "encumbrance": 2,
     "material_thickness": 4,
-    "flags": [ "WATER_FRIENDLY", "BELTED" ]
+    "flags": [ "WATER_FRIENDLY", "BELTED" ],
+    "armor": { "coverage": 30, "covers": [ "arm_l", "arm_r" ], "encumbrance": 2 }
   }
 ]

--- a/data/Maintained_mods/mods/simple_additions/items/armor/helmets.json
+++ b/data/Maintained_mods/mods/simple_additions/items/armor/helmets.json
@@ -15,12 +15,10 @@
     "symbol": "[",
     "looks_like": "balclava",
     "color": "green",
-    "covers": [ "head" ],
-    "coverage": 80,
-    "encumbrance": 15,
     "warmth": 30,
     "material_thickness": 5,
-    "flags": [ "VARSIZE", "STURDY" ]
+    "flags": [ "VARSIZE", "STURDY" ],
+    "armor": { "coverage": 80, "covers": [ "head" ], "encumbrance": 15 }
   },
   {
     "id": "wood_helmet",
@@ -37,12 +35,10 @@
     "symbol": "[",
     "looks_like": "hat_hard",
     "color": "yellow",
-    "covers": [ "head" ],
-    "coverage": 90,
-    "encumbrance": 20,
     "warmth": 10,
     "material_thickness": 3,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "WATERPROOF" ]
+    "flags": [ "VARSIZE", "WATERPROOF" ],
+    "armor": { "coverage": 90, "covers": [ "head" ], "encumbrance": 20 }
   }
 ]

--- a/data/Maintained_mods/mods/simple_additions/items/armor/legs_armor.json
+++ b/data/Maintained_mods/mods/simple_additions/items/armor/legs_armor.json
@@ -14,10 +14,8 @@
     "symbol": "[",
     "looks_like": "legguard_hard",
     "color": "yellow",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 30,
-    "encumbrance": 2,
     "material_thickness": 4,
-    "flags": [ "WATER_FRIENDLY", "BELTED", "ALLOWS_TAIL" ]
+    "flags": [ "WATER_FRIENDLY", "BELTED", "ALLOWS_TAIL" ],
+    "armor": { "coverage": 30, "covers": [ "leg_l", "leg_r" ], "encumbrance": 2 }
   }
 ]

--- a/data/Maintained_mods/mods/simple_additions/items/armor/suits_protection.json
+++ b/data/Maintained_mods/mods/simple_additions/items/armor/suits_protection.json
@@ -13,11 +13,13 @@
     "material": [ "cotton", "copper" ],
     "symbol": "[",
     "color": "light_red",
-    "covers": [ "torso", "head", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r", "mouth", "eyes" ],
-    "coverage": 100,
-    "encumbrance": 10,
     "warmth": 15,
     "material_thickness": 0.2,
-    "flags": [ "VARSIZE", "HELMET_COMPAT", "ELECTRIC_IMMUNE", "SKINTIGHT" ]
+    "flags": [ "VARSIZE", "HELMET_COMPAT", "ELECTRIC_IMMUNE", "SKINTIGHT" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "head", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r", "mouth", "eyes" ],
+      "encumbrance": 10
+    }
   }
 ]

--- a/data/Maintained_mods/mods/simple_additions/items/armor/torso_armor.json
+++ b/data/Maintained_mods/mods/simple_additions/items/armor/torso_armor.json
@@ -14,11 +14,9 @@
     "symbol": "[",
     "looks_like": "cuirass_lightplate",
     "color": "yellow",
-    "covers": [ "torso" ],
-    "coverage": 75,
-    "encumbrance": 15,
     "warmth": 15,
     "material_thickness": 3,
-    "flags": [ "OUTER" ]
+    "flags": [ "OUTER" ],
+    "armor": { "coverage": 75, "covers": [ "torso" ], "encumbrance": 15 }
   }
 ]

--- a/data/Maintained_mods/mods/simple_additions/recipes/armor/legs_armor.json
+++ b/data/Maintained_mods/mods/simple_additions/recipes/armor/legs_armor.json
@@ -14,10 +14,8 @@
     "symbol": "[",
     "looks_like": "legguard_hard",
     "color": "yellow",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 30,
-    "encumbrance": 2,
     "material_thickness": 4,
-    "flags": [ "WATER_FRIENDLY", "BELTED", "ALLOWS_TAIL" ]
+    "flags": [ "WATER_FRIENDLY", "BELTED", "ALLOWS_TAIL" ],
+    "armor": { "coverage": 30, "covers": [ "leg_l", "leg_r" ], "encumbrance": 2 }
   }
 ]

--- a/data/Rebalance_mods/mods/Mutation_Changes/armor.json
+++ b/data/Rebalance_mods/mods/Mutation_Changes/armor.json
@@ -7,7 +7,6 @@
     "weight": "350 g",
     "volume": "750 ml",
     "color": "brown",
-    "covers": [ "hand_l", "hand_r" ],
     "to_hit": -2,
     "symbol": "[",
     "description": "Heavy fingerless leather gloves.  Very flexible and comfortable.",
@@ -15,11 +14,10 @@
     "material": [ "leather" ],
     "warmth": 15,
     "environmental_protection": 1,
-    "encumbrance": 4,
     "bashing": 2,
     "flags": [ "VARSIZE", "STURDY", "ALLOWS_NATURAL_ATTACKS", "OVERSIZE" ],
-    "coverage": 60,
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 60, "covers": [ "hand_l", "hand_r" ], "encumbrance": 4 }
   },
   {
     "id": "gloves_fingerless",
@@ -27,7 +25,6 @@
     "name": { "str": "pair of fingerless gloves", "str_pl": "pairs of fingerless gloves" },
     "weight": "100 g",
     "color": "dark_gray",
-    "covers": [ "hand_l", "hand_r" ],
     "to_hit": 2,
     "symbol": "[",
     "description": "A pair of leather gloves with no fingers, allowing greater manual dexterity.",
@@ -35,10 +32,9 @@
     "material": [ "leather" ],
     "volume": "250 ml",
     "warmth": 10,
-    "encumbrance": 0,
     "flags": [ "VARSIZE", "WATER_FRIENDLY", "ALLOWS_NATURAL_ATTACKS", "OVERSIZE" ],
-    "coverage": 50,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 50, "covers": [ "hand_l", "hand_r" ], "encumbrance": 0 }
   },
   {
     "id": "gloves_fingerless_mod",
@@ -47,7 +43,6 @@
     "category": "armor",
     "weight": "380 g",
     "color": "dark_gray",
-    "covers": [ "hand_l", "hand_r" ],
     "to_hit": 2,
     "symbol": "[",
     "description": "A pair of leather gloves with no fingers, allowing greater manual dexterity.  These have been crudely reinforced with steel guards across the back.",
@@ -55,9 +50,8 @@
     "material": [ "steel", "leather" ],
     "volume": "500 ml",
     "warmth": 5,
-    "encumbrance": 3,
     "flags": [ "VARSIZE", "ALLOWS_NATURAL_ATTACKS", "STURDY", "OVERSIZE" ],
-    "coverage": 50,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 50, "covers": [ "hand_l", "hand_r" ], "encumbrance": 3 }
   }
 ]

--- a/data/Rebalance_mods/mods/ZSFixed_CDDAXP/CDDAXP_Armor.json
+++ b/data/Rebalance_mods/mods/ZSFixed_CDDAXP/CDDAXP_Armor.json
@@ -14,13 +14,11 @@
     "material": [ "plastic", "aluminum" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "mouth" ],
-    "coverage": 100,
-    "encumbrance": 25,
     "warmth": 17,
     "material_thickness": 3,
     "environmental_protection": 13,
-    "flags": [ "VARSIZE" ]
+    "flags": [ "VARSIZE" ],
+    "armor": { "coverage": 100, "covers": [ "mouth" ], "encumbrance": 25 }
   },
   {
     "id": "cddaxp_srtrenchcoat",
@@ -34,9 +32,6 @@
     "material": [ "cotton", "iron" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "torso" ],
-    "coverage": 90,
-    "encumbrance": 20,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "3 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "3 kg", "moves": 80 },
@@ -46,7 +41,8 @@
     "warmth": 13,
     "material_thickness": 3,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER" ],
+    "armor": { "coverage": 90, "covers": [ "torso" ], "encumbrance": 20 }
   },
   {
     "id": "cddaxp_rcpants",
@@ -59,9 +55,6 @@
     "material": [ "cotton", "iron" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1 L", "max_contains_weight": "2 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1 L", "max_contains_weight": "2 kg", "moves": 80 }
@@ -69,7 +62,8 @@
     "warmth": 13,
     "material_thickness": 3,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "POCKETS" ]
+    "flags": [ "VARSIZE", "POCKETS" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r" ], "encumbrance": 20 }
   },
   {
     "id": "cddaxp_retshield",
@@ -87,14 +81,12 @@
     "material": [ "iron" ],
     "symbol": ")",
     "color": "dark_gray",
-    "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ],
-    "coverage": 30,
-    "encumbrance": 15,
     "warmth": 0,
     "material_thickness": 3,
     "environmental_protection": 0,
     "techniques": [ "WBLOCK_2" ],
-    "flags": [ "OVERSIZE", "STURDY", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ]
+    "flags": [ "OVERSIZE", "STURDY", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ],
+    "armor": { "coverage": 30, "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ], "encumbrance": 15 }
   },
   {
     "id": "cddaxp_survsrtrenchcoat",
@@ -108,9 +100,6 @@
     "material": [ "cotton", "iron" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "torso" ],
-    "coverage": 90,
-    "encumbrance": 22,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "3500 g", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "3500 g", "moves": 80 },
@@ -129,7 +118,8 @@
     "material_thickness": 3,
     "environmental_protection": 1,
     "use_action": { "type": "holster" },
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "NO_QUICKDRAW" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "NO_QUICKDRAW" ],
+    "armor": { "coverage": 90, "covers": [ "torso" ], "encumbrance": 22 }
   },
   {
     "id": "cddaxp_survrcpants",
@@ -142,9 +132,6 @@
     "material": [ "cotton", "iron" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 22,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1175 ml", "max_contains_weight": "2 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1175 ml", "max_contains_weight": "2 kg", "moves": 80 },
@@ -171,7 +158,8 @@
     "warmth": 15,
     "material_thickness": 3,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "POCKETS" ]
+    "flags": [ "VARSIZE", "POCKETS" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r" ], "encumbrance": 22 }
   },
   {
     "id": "cddaxp_bracer",
@@ -186,13 +174,11 @@
     "material": [ "iron" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "arm_l", "arm_r" ],
-    "coverage": 40,
-    "encumbrance": 10,
     "warmth": 0,
     "material_thickness": 3,
     "environmental_protection": 0,
-    "flags": [ "BELTED", "VARSIZE", "STURDY", "BLOCK_WHILE_WORN" ]
+    "flags": [ "BELTED", "VARSIZE", "STURDY", "BLOCK_WHILE_WORN" ],
+    "armor": { "coverage": 40, "covers": [ "arm_l", "arm_r" ], "encumbrance": 10 }
   },
   {
     "id": "cddaxp_rillepack",
@@ -205,10 +191,6 @@
     "material": [ "iron", "kevlar" ],
     "symbol": "[",
     "color": "green",
-    "covers": [ "torso" ],
-    "coverage": 35,
-    "encumbrance": 10,
-    "max_encumbrance": 40,
     "warmth": 9,
     "material_thickness": 2,
     "environmental_protection": 0,
@@ -246,7 +228,8 @@
         "moves": 100
       }
     ],
-    "flags": [ "WATERPROOF", "BELTED", "TARDIS" ]
+    "flags": [ "WATERPROOF", "BELTED", "TARDIS" ],
+    "armor": { "coverage": 35, "covers": [ "torso" ], "encumbrance": [ 10, 40 ] }
   },
   {
     "id": "cddaxp_lamessrtrenchcoat",
@@ -260,9 +243,6 @@
     "material": [ "kevlar", "chitin" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "torso" ],
-    "coverage": 90,
-    "encumbrance": 26,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "3 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "3 kg", "moves": 80 },
@@ -281,7 +261,8 @@
     "material_thickness": 3,
     "environmental_protection": 2,
     "use_action": { "type": "holster" },
-    "flags": [ "STURDY", "VARSIZE", "POCKETS", "OUTER", "NO_QUICKDRAW", "FANCY", "WATERPROOF", "RAINPROOF" ]
+    "flags": [ "STURDY", "VARSIZE", "POCKETS", "OUTER", "NO_QUICKDRAW", "FANCY", "WATERPROOF", "RAINPROOF" ],
+    "armor": { "coverage": 90, "covers": [ "torso" ], "encumbrance": 26 }
   },
   {
     "id": "cddaxp_lamesrcpants",
@@ -294,9 +275,6 @@
     "material": [ "kevlar", "chitin" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 26,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1375 ml", "max_contains_weight": "2750 g", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1375 ml", "max_contains_weight": "2750 g", "moves": 80 },
@@ -323,7 +301,8 @@
     "warmth": 15,
     "material_thickness": 3,
     "environmental_protection": 2,
-    "flags": [ "STURDY", "VARSIZE", "POCKETS", "FANCY", "WATERPROOF", "RAINPROOF" ]
+    "flags": [ "STURDY", "VARSIZE", "POCKETS", "FANCY", "WATERPROOF", "RAINPROOF" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r" ], "encumbrance": 26 }
   },
   {
     "id": "cddaxp_longshirt",
@@ -336,9 +315,6 @@
     "material": [ "cotton", "iron" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 90,
-    "encumbrance": 5,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1 kg", "moves": 80 },
@@ -355,7 +331,8 @@
     "warmth": 5,
     "material_thickness": 2,
     "use_action": { "type": "holster", "holster_prompt": "Stash ammo", "holster_msg": "You stash your %s." },
-    "flags": [ "VARSIZE" ]
+    "flags": [ "VARSIZE" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 5 }
   },
   {
     "id": "cddaxp_srshirt",
@@ -368,9 +345,6 @@
     "material": [ "kevlar", "chitin" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 90,
-    "encumbrance": 7,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1 kg", "moves": 80 },
       {
@@ -387,7 +361,8 @@
     "material_thickness": 3,
     "environmental_protection": 1,
     "use_action": { "type": "holster", "holster_prompt": "Stash ammo", "holster_msg": "You stash your %s." },
-    "flags": [ "VARSIZE" ]
+    "flags": [ "VARSIZE" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 7 }
   },
   {
     "id": "cddaxp_srbshirt",
@@ -400,9 +375,6 @@
     "material": [ "kevlar", "bone" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 90,
-    "encumbrance": 6,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "750 ml", "max_contains_weight": "1 kg", "moves": 80 },
       {
@@ -419,7 +391,8 @@
     "material_thickness": 3,
     "environmental_protection": 1,
     "use_action": { "type": "holster", "holster_prompt": "Stash ammo", "holster_msg": "You stash your %s." },
-    "flags": [ "VARSIZE" ]
+    "flags": [ "VARSIZE" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 6 }
   },
   {
     "id": "cddaxp_srcshirt",
@@ -432,9 +405,6 @@
     "material": [ "kevlar", "ceramic" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 90,
-    "encumbrance": 8,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "250 ml", "max_contains_weight": "500 g", "moves": 80 },
       {
@@ -451,7 +421,8 @@
     "material_thickness": 3,
     "environmental_protection": 1,
     "use_action": { "type": "holster", "holster_prompt": "Stash ammo", "holster_msg": "You stash your %s." },
-    "flags": [ "VARSIZE" ]
+    "flags": [ "VARSIZE" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 8 }
   },
   {
     "id": "cddaxp_lamessbtrenchcoat",
@@ -465,9 +436,6 @@
     "material": [ "kevlar", "bone" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "torso" ],
-    "coverage": 90,
-    "encumbrance": 24,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "3 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "3 kg", "moves": 80 },
@@ -486,7 +454,8 @@
     "material_thickness": 3,
     "environmental_protection": 2,
     "use_action": { "type": "holster" },
-    "flags": [ "STURDY", "VARSIZE", "POCKETS", "OUTER", "NO_QUICKDRAW", "FANCY", "WATERPROOF", "RAINPROOF" ]
+    "flags": [ "STURDY", "VARSIZE", "POCKETS", "OUTER", "NO_QUICKDRAW", "FANCY", "WATERPROOF", "RAINPROOF" ],
+    "armor": { "coverage": 90, "covers": [ "torso" ], "encumbrance": 24 }
   },
   {
     "id": "cddaxp_lamesbcpants",
@@ -499,9 +468,6 @@
     "material": [ "kevlar", "bone" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 24,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1750 ml", "max_contains_weight": "2 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1750 ml", "max_contains_weight": "2 kg", "moves": 80 },
@@ -528,7 +494,8 @@
     "warmth": 15,
     "material_thickness": 3,
     "environmental_protection": 2,
-    "flags": [ "STURDY", "VARSIZE", "POCKETS", "FANCY", "WATERPROOF", "RAINPROOF" ]
+    "flags": [ "STURDY", "VARSIZE", "POCKETS", "FANCY", "WATERPROOF", "RAINPROOF" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r" ], "encumbrance": 24 }
   },
   {
     "id": "cddaxp_lamessctrenchcoat",
@@ -542,9 +509,6 @@
     "material": [ "kevlar", "ceramic" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "torso" ],
-    "coverage": 90,
-    "encumbrance": 28,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "3500 g", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "3500 g", "moves": 80 },
@@ -563,7 +527,8 @@
     "material_thickness": 3,
     "environmental_protection": 2,
     "use_action": { "type": "holster" },
-    "flags": [ "STURDY", "VARSIZE", "POCKETS", "OUTER", "NO_QUICKDRAW", "FANCY", "WATERPROOF", "RAINPROOF" ]
+    "flags": [ "STURDY", "VARSIZE", "POCKETS", "OUTER", "NO_QUICKDRAW", "FANCY", "WATERPROOF", "RAINPROOF" ],
+    "armor": { "coverage": 90, "covers": [ "torso" ], "encumbrance": 28 }
   },
   {
     "id": "cddaxp_lamesccpants",
@@ -576,9 +541,6 @@
     "material": [ "kevlar", "ceramic" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 28,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1200 ml", "max_contains_weight": "2 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1200 ml", "max_contains_weight": "2 kg", "moves": 80 },
@@ -605,7 +567,8 @@
     "warmth": 15,
     "material_thickness": 3,
     "environmental_protection": 2,
-    "flags": [ "STURDY", "VARSIZE", "POCKETS", "FANCY", "WATERPROOF", "RAINPROOF" ]
+    "flags": [ "STURDY", "VARSIZE", "POCKETS", "FANCY", "WATERPROOF", "RAINPROOF" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r" ], "encumbrance": 28 }
   },
   {
     "id": "cddaxp_hlamesstrenchcoat",
@@ -619,9 +582,6 @@
     "material": [ "kevlar", "steel" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "torso" ],
-    "coverage": 90,
-    "encumbrance": 30,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1750 ml", "max_contains_weight": "3 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1750 ml", "max_contains_weight": "3 kg", "moves": 80 },
@@ -640,7 +600,8 @@
     "material_thickness": 4,
     "environmental_protection": 3,
     "use_action": { "type": "holster" },
-    "flags": [ "STURDY", "VARSIZE", "POCKETS", "OUTER", "FANCY", "WATERPROOF", "RAINPROOF" ]
+    "flags": [ "STURDY", "VARSIZE", "POCKETS", "OUTER", "FANCY", "WATERPROOF", "RAINPROOF" ],
+    "armor": { "coverage": 90, "covers": [ "torso" ], "encumbrance": 30 }
   },
   {
     "id": "cddaxp_hlamescpants",
@@ -653,9 +614,6 @@
     "material": [ "kevlar", "steel" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 30,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "875 ml", "max_contains_weight": "1500 g", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "875 ml", "max_contains_weight": "1500 g", "moves": 80 },
@@ -682,7 +640,8 @@
     "warmth": 15,
     "material_thickness": 4,
     "environmental_protection": 3,
-    "flags": [ "STURDY", "VARSIZE", "POCKETS", "FANCY", "WATERPROOF", "RAINPROOF" ]
+    "flags": [ "STURDY", "VARSIZE", "POCKETS", "FANCY", "WATERPROOF", "RAINPROOF" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r" ], "encumbrance": 30 }
   },
   {
     "id": "cddaxp_fbackholster",
@@ -695,9 +654,6 @@
     "material": [ "leather" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "torso" ],
-    "coverage": 5,
-    "encumbrance": 6,
     "material_thickness": 1,
     "pocket_data": [
       {
@@ -710,7 +666,8 @@
       }
     ],
     "use_action": { "type": "holster" },
-    "flags": [ "BELTED", "OVERSIZE" ]
+    "flags": [ "BELTED", "OVERSIZE" ],
+    "armor": { "coverage": 5, "covers": [ "torso" ], "encumbrance": 6 }
   },
   {
     "id": "cddaxp_bplamesstrenchcoat",
@@ -724,9 +681,6 @@
     "material": [ "superalloy", "steel" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "torso" ],
-    "coverage": 90,
-    "encumbrance": 32,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "3 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "3 kg", "moves": 80 },
@@ -745,7 +699,8 @@
     "material_thickness": 4,
     "environmental_protection": 3,
     "use_action": { "type": "holster" },
-    "flags": [ "STURDY", "VARSIZE", "POCKETS", "OUTER", "FANCY", "WATERPROOF", "RAINPROOF" ]
+    "flags": [ "STURDY", "VARSIZE", "POCKETS", "OUTER", "FANCY", "WATERPROOF", "RAINPROOF" ],
+    "armor": { "coverage": 90, "covers": [ "torso" ], "encumbrance": 32 }
   },
   {
     "id": "cddaxp_bplamescpants",
@@ -758,9 +713,6 @@
     "material": [ "superalloy", "steel" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 32,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "625 ml", "max_contains_weight": "1 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "625 ml", "max_contains_weight": "1 kg", "moves": 80 },
@@ -787,6 +739,7 @@
     "warmth": 15,
     "material_thickness": 4,
     "environmental_protection": 3,
-    "flags": [ "STURDY", "VARSIZE", "POCKETS", "FANCY", "WATERPROOF", "RAINPROOF" ]
+    "flags": [ "STURDY", "VARSIZE", "POCKETS", "FANCY", "WATERPROOF", "RAINPROOF" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r" ], "encumbrance": 32 }
   }
 ]

--- a/data/Rebalance_mods/mods/ZSFixed_CDDAXP/CDDAXP_Tool_Armor.json
+++ b/data/Rebalance_mods/mods/ZSFixed_CDDAXP/CDDAXP_Tool_Armor.json
@@ -37,15 +37,13 @@
     "charges_per_use": 10,
     "turns_per_charge": 0,
     "revert_to": null,
-    "covers": [ "head" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "warmth": 10,
     "material_thickness": 4,
     "environmental_protection": 0,
     "techniques": [ "WBLOCK_1" ],
     "use_action": "ROBOTCONTROL",
-    "flags": [ "WATER_FRIENDLY", "STURDY", "VARSIZE" ]
+    "flags": [ "WATER_FRIENDLY", "STURDY", "VARSIZE" ],
+    "armor": { "coverage": 95, "covers": [ "head" ], "encumbrance": 20 }
   },
   {
     "id": "cddaxp_goggles_artnv",
@@ -85,9 +83,6 @@
     "charges_per_use": 6,
     "turns_per_charge": 0,
     "revert_to": null,
-    "covers": [ "eyes" ],
-    "coverage": 100,
-    "encumbrance": 30,
     "warmth": 20,
     "material_thickness": 2,
     "environmental_protection": 8,
@@ -99,7 +94,8 @@
       "need_charges_msg": "The %s's batteries are dead.",
       "type": "transform"
     },
-    "flags": [ "FRAGILE", "VARSIZE" ]
+    "flags": [ "FRAGILE", "VARSIZE" ],
+    "armor": { "coverage": 100, "covers": [ "eyes" ], "encumbrance": 30 }
   },
   {
     "id": "cddaxp_goggles_artnv_on",
@@ -139,15 +135,13 @@
     "charges_per_use": 0,
     "turns_per_charge": 5,
     "revert_to": "cddaxp_goggles_artnv",
-    "covers": [ "eyes" ],
-    "coverage": 100,
-    "encumbrance": 15,
     "warmth": 25,
     "material_thickness": 2,
     "environmental_protection": 8,
     "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "PERCEPTION", "add": 3 } ] } ] },
     "use_action": { "target": "cddaxp_goggles_artnv", "msg": "Your %s deactivates.", "type": "transform" },
-    "flags": [ "GNV_EFFECT", "FRAGILE", "VARSIZE" ]
+    "flags": [ "GNV_EFFECT", "FRAGILE", "VARSIZE" ],
+    "armor": { "coverage": 100, "covers": [ "eyes" ], "encumbrance": 15 }
   },
   {
     "id": "cddaxp_artclocloak",
@@ -187,9 +181,6 @@
     "charges_per_use": 4,
     "turns_per_charge": 0,
     "revert_to": null,
-    "covers": [ "torso", "head", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 5,
     "warmth": 50,
     "material_thickness": 2,
     "environmental_protection": 6,
@@ -201,7 +192,12 @@
       "need_charges_msg": "The %s's batteries are dead.",
       "type": "transform"
     },
-    "flags": [ "OVERSIZE", "HOOD", "WATERPROOF", "OUTER", "VARSIZE" ]
+    "flags": [ "OVERSIZE", "HOOD", "WATERPROOF", "OUTER", "VARSIZE" ],
+    "armor": {
+      "coverage": 95,
+      "covers": [ "torso", "head", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r" ],
+      "encumbrance": 5
+    }
   },
   {
     "id": "cddaxp_artclocloak_on",
@@ -241,9 +237,6 @@
     "charges_per_use": 0,
     "turns_per_charge": 2,
     "revert_to": "cddaxp_artclocloak",
-    "covers": [ "torso", "head", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 5,
     "warmth": 55,
     "material_thickness": 2,
     "environmental_protection": 6,
@@ -258,7 +251,12 @@
       ]
     },
     "use_action": { "target": "cddaxp_artclocloak", "msg": "Your %s deactivates.  You are visible again.", "type": "transform" },
-    "flags": [ "OVERSIZE", "HOOD", "WATERPROOF", "OUTER", "VARSIZE" ]
+    "flags": [ "OVERSIZE", "HOOD", "WATERPROOF", "OUTER", "VARSIZE" ],
+    "armor": {
+      "coverage": 95,
+      "covers": [ "torso", "head", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r" ],
+      "encumbrance": 5
+    }
   },
   {
     "id": "cddaxp_artesosk",
@@ -290,9 +288,6 @@
     "charges_per_use": 5,
     "turns_per_charge": 0,
     "revert_to": null,
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 60,
-    "encumbrance": 15,
     "warmth": 5,
     "material_thickness": 2,
     "environmental_protection": 0,
@@ -304,7 +299,8 @@
       "need_charges_msg": "The %s's batteries are dead.",
       "type": "transform"
     },
-    "flags": [ "STURDY", "WATCH", "ALARMCLOCK", "OUTER", "VARSIZE" ]
+    "flags": [ "STURDY", "WATCH", "ALARMCLOCK", "OUTER", "VARSIZE" ],
+    "armor": { "coverage": 60, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 15 }
   },
   {
     "id": "cddaxp_artesosk_on",
@@ -336,15 +332,13 @@
     "charges_per_use": 0,
     "turns_per_charge": 2,
     "revert_to": "cddaxp_artesosk",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 60,
-    "encumbrance": 10,
     "warmth": 10,
     "material_thickness": 2,
     "environmental_protection": 0,
     "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "STRENGTH", "add": 3 } ] } ] },
     "use_action": { "target": "cddaxp_artesosk", "msg": "Your %s deactivates.", "type": "transform" },
-    "flags": [ "STURDY", "WATCH", "ALARMCLOCK", "OUTER", "VARSIZE", "LIGHT_100", "CHARGEDIM" ]
+    "flags": [ "STURDY", "WATCH", "ALARMCLOCK", "OUTER", "VARSIZE", "LIGHT_100", "CHARGEDIM" ],
+    "armor": { "coverage": 60, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 10 }
   },
   {
     "id": "cddaxp_artgloves",
@@ -384,9 +378,6 @@
     "charges_per_use": 4,
     "turns_per_charge": 0,
     "revert_to": null,
-    "covers": [ "hand_l", "hand_r" ],
-    "coverage": 100,
-    "encumbrance": 14,
     "warmth": 20,
     "material_thickness": 2,
     "environmental_protection": 1,
@@ -398,7 +389,8 @@
       "need_charges_msg": "The %s's batteries are dead.",
       "type": "transform"
     },
-    "flags": [ "VARSIZE", "STURDY" ]
+    "flags": [ "VARSIZE", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "hand_l", "hand_r" ], "encumbrance": 14 }
   },
   {
     "id": "cddaxp_artgloves_on",
@@ -438,15 +430,13 @@
     "charges_per_use": 0,
     "turns_per_charge": 2,
     "revert_to": "cddaxp_artgloves",
-    "covers": [ "hand_l", "hand_r" ],
-    "coverage": 100,
-    "encumbrance": 14,
     "warmth": 25,
     "material_thickness": 2,
     "environmental_protection": 1,
     "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "DEXTERITY", "add": 3 } ] } ] },
     "use_action": { "target": "cddaxp_artgloves", "msg": "Your %s deactivates.", "type": "transform" },
-    "flags": [ "VARSIZE", "STURDY" ]
+    "flags": [ "VARSIZE", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "hand_l", "hand_r" ], "encumbrance": 14 }
   },
   {
     "id": "cddaxp_survrbelt",
@@ -460,9 +450,6 @@
     "material": [ "leather", "iron" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso" ],
-    "coverage": 15,
-    "encumbrance": 0,
     "material_thickness": 2,
     "qualities": [
       [ "HAMMER", 3 ],
@@ -490,7 +477,8 @@
       }
     ],
     "use_action": [ { "type": "holster" }, "HAMMER", "HACKSAW", "LUMBER", "REMOVE_ALL_MODS", "CROWBAR" ],
-    "flags": [ "VARSIZE", "WATER_FRIENDLY", "STURDY", "WAIST", "OVERSIZE" ]
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "STURDY", "WAIST", "OVERSIZE" ],
+    "armor": { "coverage": 15, "covers": [ "torso" ], "encumbrance": 0 }
   },
   {
     "id": "cddaxp_mtsuit",
@@ -516,9 +504,6 @@
       }
     ],
     "charges_per_use": 1,
-    "covers": [ "head", "mouth", "torso", "arm_l", "arm_r", "leg_l", "leg_r", "hand_l", "hand_r", "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 0,
     "warmth": 10,
     "material_thickness": 2,
     "environmental_protection": 2,
@@ -530,7 +515,12 @@
       "need_charges_msg": "The %s's batteries are dead.",
       "type": "transform"
     },
-    "flags": [ "VARSIZE", "SKINTIGHT", "WATER_FRIENDLY", "WATERPROOF" ]
+    "flags": [ "VARSIZE", "SKINTIGHT", "WATER_FRIENDLY", "WATERPROOF" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "head", "mouth", "torso", "arm_l", "arm_r", "leg_l", "leg_r", "hand_l", "hand_r", "foot_l", "foot_r" ],
+      "encumbrance": 0
+    }
   },
   {
     "id": "cddaxp_mtsuit_on",
@@ -557,13 +547,15 @@
     ],
     "turns_per_charge": 8,
     "revert_to": "cddaxp_mtsuit",
-    "covers": [ "head", "mouth", "torso", "arm_l", "arm_r", "leg_l", "leg_r", "hand_l", "hand_r", "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 0,
     "warmth": 80,
     "material_thickness": 2,
     "environmental_protection": 2,
     "use_action": { "target": "cddaxp_mtsuit", "msg": "Your %s deactivates.", "type": "transform" },
-    "flags": [ "VARSIZE", "SKINTIGHT", "WATER_FRIENDLY", "WATERPROOF" ]
+    "flags": [ "VARSIZE", "SKINTIGHT", "WATER_FRIENDLY", "WATERPROOF" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "head", "mouth", "torso", "arm_l", "arm_r", "leg_l", "leg_r", "hand_l", "hand_r", "foot_l", "foot_r" ],
+      "encumbrance": 0
+    }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Advanced_Gear/items/gear/equipment.json
+++ b/data/Unleash_The_Mods/Working_mods/Advanced_Gear/items/gear/equipment.json
@@ -17,9 +17,8 @@
     "to_hit": 0,
     "warmth": 0,
     "environmental_protection": 0,
-    "encumbrance": 0,
-    "coverage": 10,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 10, "encumbrance": 0 }
   },
   {
     "id": "nano_shield",
@@ -37,13 +36,11 @@
     "material": [ "nanite" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ],
-    "coverage": 90,
-    "encumbrance": 28,
     "material_thickness": 4,
     "techniques": [ "WBLOCK_3" ],
     "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN", "TRADER_AVOID" ],
-    "use_action": { "type": "transform", "target": "nano_shield_active", "active": false, "msg": "Shield switched to active mode." }
+    "use_action": { "type": "transform", "target": "nano_shield_active", "active": false, "msg": "Shield switched to active mode." },
+    "armor": { "coverage": 90, "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ], "encumbrance": 28 }
   },
   {
     "id": "nano_shield_active",
@@ -61,13 +58,11 @@
     "material": [ "nanite" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "arm_l", "arm_r" ],
-    "coverage": 60,
-    "encumbrance": 15,
     "material_thickness": 4,
     "techniques": [ "WBLOCK_3" ],
     "flags": [ "OVERSIZE", "BELTED", "BLOCK_WHILE_WORN", "TRADER_AVOID" ],
-    "use_action": { "type": "transform", "target": "nano_shield", "active": false, "msg": "Shield switched to passive mode." }
+    "use_action": { "type": "transform", "target": "nano_shield", "active": false, "msg": "Shield switched to passive mode." },
+    "armor": { "coverage": 60, "covers": [ "arm_l", "arm_r" ], "encumbrance": 15 }
   },
   {
     "id": "nano_storage",
@@ -77,7 +72,6 @@
     "looks_like": "slime_scrap",
     "weight": "3157 g",
     "volume": "2000 ml",
-    "covers": [ "torso" ],
     "description": "A large blob of nanites with an AI, it actively branches out pseudopods to grasp items held near it and supports them as optimally as possible, including reaching down and forming 'legs' to support itself if needed.",
     "pocket_data": [
       {
@@ -92,7 +86,7 @@
       }
     ],
     "extend": { "flags": [ "BELTED", "TARDIS" ] },
-    "coverage": 30
+    "armor": { "coverage": 30, "covers": [ "torso" ] }
   },
   {
     "id": "nano_holster",
@@ -100,7 +94,6 @@
     "name": { "str": "nanotech holster" },
     "copy-from": "nanogear",
     "looks_like": "holster",
-    "covers": [ "leg_l", "leg_r" ],
     "description": "A small blob of nanites with an AI, it actively branches out pseudopods to grasp guns held nearby it, and put them into the user's hands automatically as needed.",
     "extend": { "flags": [ "BELTED" ] },
     "pocket_data": [
@@ -113,7 +106,8 @@
         "holster": true
       }
     ],
-    "use_action": { "type": "holster", "holster_prompt": "Store weapon", "holster_msg": "You store your %s" }
+    "use_action": { "type": "holster", "holster_prompt": "Store weapon", "holster_msg": "You store your %s" },
+    "armor": { "covers": [ "leg_l", "leg_r" ] }
   },
   {
     "id": "nano_sheath",
@@ -121,7 +115,6 @@
     "name": { "str": "nanotech sheath" },
     "copy-from": "nanogear",
     "looks_like": "sheath",
-    "covers": [ "leg_l", "leg_r" ],
     "description": "A small blob of nanites with an AI, it actively branches out pseudopods to grasp blades held nearby it, and put them into the user's hands automatically as needed.",
     "extend": { "flags": [ "BELTED" ] },
     "pocket_data": [
@@ -134,7 +127,8 @@
         "flag_restriction": [ "SHEATH_KNIFE", "SHEATH_SWORD", "SHEATH_SPEAR" ]
       }
     ],
-    "use_action": { "type": "holster", "holster_prompt": "Store weapon?", "holster_msg": "You store your %s" }
+    "use_action": { "type": "holster", "holster_prompt": "Store weapon?", "holster_msg": "You store your %s" },
+    "armor": { "covers": [ "leg_l", "leg_r" ] }
   },
   {
     "id": "nano_mag_holder",
@@ -143,7 +137,6 @@
     "copy-from": "nanogear",
     "looks_like": "slime_scrap",
     "description": "A small blob of nanites with an AI, it stores magazines and assists in loading them as needed.",
-    "covers": [ "arm_l", "arm_r" ],
     "extend": { "flags": [ "BELTED" ] },
     "pocket_data": [
       {
@@ -155,7 +148,8 @@
         "flag_restriction": [ "MAG_COMPACT", "MAG_BULKY" ]
       }
     ],
-    "use_action": { "type": "holster", "holster_prompt": "Store ammo", "holster_msg": "You store your %s." }
+    "use_action": { "type": "holster", "holster_prompt": "Store ammo", "holster_msg": "You store your %s." },
+    "armor": { "covers": [ "arm_l", "arm_r" ] }
   },
   {
     "id": "nanosuit",
@@ -164,7 +158,6 @@
     "copy-from": "nanogear",
     "weight": "9836 g",
     "volume": "1500 ml",
-    "covers": [ "head", "mouth", "eyes", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
     "description": "A cluster of carefully programmed nanites designed to fully cover the body and defend against external threats.  Can be activated to produce heat.",
     "looks_like": "rm13_armor_on",
     "relic_data": {
@@ -209,7 +202,6 @@
         "WATERPROOF"
       ]
     },
-    "coverage": 100,
     "material_thickness": 3,
     "use_action": [
       {
@@ -219,7 +211,11 @@
         "active": false,
         "msg": "Enabling nanosuit's heating mode."
       }
-    ]
+    ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "head", "mouth", "eyes", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
+    }
   },
   {
     "id": "nanosuit_heated",

--- a/data/Unleash_The_Mods/Working_mods/Advanced_Technologies/at_armor.json
+++ b/data/Unleash_The_Mods/Working_mods/Advanced_Technologies/at_armor.json
@@ -10,7 +10,6 @@
     "color": "dark_gray",
     "symbol": "[",
     "material": [ "plastic" ],
-    "covers": [ "torso" ],
     "price": "1 cent",
     "cutting": 0,
     "phase": "solid",
@@ -18,12 +17,11 @@
     "to_hit": 0,
     "power_armor": false,
     "warmth": 0,
-    "encumbrance": 0,
     "bashing": 0,
     "flags": [ "WATERPROOF", "STURDY", "SHEATH_KNIFE" ],
-    "coverage": 0,
     "material_thickness": 0,
-    "use_action": { "type": "holster", "holster_prompt": "Sheath knife", "holster_msg": "You sheath your %s" }
+    "use_action": { "type": "holster", "holster_prompt": "Sheath knife", "holster_msg": "You sheath your %s" },
+    "armor": { "coverage": 0, "covers": [ "torso" ], "encumbrance": 0 }
   },
   {
     "id": "advanced_power_armor_helmet",
@@ -36,7 +34,6 @@
     "color": "dark_gray",
     "symbol": "[",
     "material": [ "plastic" ],
-    "covers": [ "eyes" ],
     "price": "1 cent",
     "cutting": 0,
     "phase": "solid",
@@ -44,11 +41,10 @@
     "to_hit": 0,
     "power_armor": false,
     "warmth": 0,
-    "encumbrance": 0,
     "bashing": 0,
-    "coverage": 0,
     "material_thickness": 0,
-    "flags": [ "WATCH", "WATERPROOF", "STURDY" ]
+    "flags": [ "WATCH", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 0, "covers": [ "eyes" ], "encumbrance": 0 }
   },
   {
     "id": "helmet_robot",
@@ -57,7 +53,6 @@
     "name": { "str": "robot helmet" },
     "weight": "2043 g",
     "color": "green",
-    "covers": [ "head", "eyes", "mouth" ],
     "techniques": [ "WBLOCK_1" ],
     "to_hit": -1,
     "symbol": "[",
@@ -69,11 +64,10 @@
     "warmth": 30,
     "phase": "solid",
     "environmental_protection": 4,
-    "encumbrance": 20,
     "bashing": 12,
     "flags": [ "WATERPROOF", "STURDY", "SUN_GLASSES" ],
-    "coverage": 100,
-    "material_thickness": 5
+    "material_thickness": 5,
+    "armor": { "coverage": 100, "covers": [ "head", "eyes", "mouth" ], "encumbrance": 20 }
   },
   {
     "id": "helmet_met",
@@ -82,7 +76,6 @@
     "name": { "str": "steel helmet" },
     "weight": "1683 g",
     "color": "dark_gray",
-    "covers": [ "head" ],
     "techniques": [ "WBLOCK_1" ],
     "to_hit": -1,
     "symbol": "[",
@@ -94,11 +87,10 @@
     "warmth": 10,
     "phase": "solid",
     "environmental_protection": 0,
-    "encumbrance": 20,
     "bashing": 10,
     "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
-    "coverage": 95,
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 95, "covers": [ "head" ], "encumbrance": 20 }
   },
   {
     "id": "helmet_mechpilot",
@@ -107,7 +99,6 @@
     "name": { "str": "pilot helmet" },
     "weight": "2287 g",
     "color": "dark_gray",
-    "covers": [ "head", "eyes", "mouth" ],
     "techniques": [ "WBLOCK_1" ],
     "to_hit": -1,
     "symbol": "[",
@@ -119,11 +110,10 @@
     "warmth": 30,
     "phase": "solid",
     "environmental_protection": 8,
-    "encumbrance": 30,
     "bashing": 12,
     "flags": [ "WATCH", "WATERPROOF", "STURDY", "SUN_GLASSES" ],
-    "coverage": 100,
-    "material_thickness": 6
+    "material_thickness": 6,
+    "armor": { "coverage": 100, "covers": [ "head", "eyes", "mouth" ], "encumbrance": 30 }
   },
   {
     "id": "fire__armor",
@@ -136,7 +126,6 @@
     "color": "dark_gray",
     "symbol": "[",
     "material": [ "plastic" ],
-    "covers": [ "torso" ],
     "price": "1 cent",
     "cutting": 0,
     "phase": "solid",
@@ -144,11 +133,10 @@
     "to_hit": 0,
     "power_armor": false,
     "warmth": 0,
-    "encumbrance": 0,
     "bashing": 0,
     "flags": [ "WATERPROOF", "STURDY" ],
-    "coverage": 0,
-    "material_thickness": 0
+    "material_thickness": 0,
+    "armor": { "coverage": 0, "covers": [ "torso" ], "encumbrance": 0 }
   },
   {
     "id": "fire_power_armor_helmet",
@@ -161,7 +149,6 @@
     "color": "dark_gray",
     "symbol": "[",
     "material": [ "plastic" ],
-    "covers": [ "eyes" ],
     "price": "1 cent",
     "cutting": 0,
     "phase": "solid",
@@ -169,10 +156,9 @@
     "to_hit": 1,
     "power_armor": false,
     "warmth": 0,
-    "encumbrance": 0,
     "bashing": 0,
-    "coverage": 0,
     "material_thickness": 0,
-    "flags": [ "WATCH", "WATERPROOF", "STURDY" ]
+    "flags": [ "WATCH", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 0, "covers": [ "eyes" ], "encumbrance": 0 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Alchemic_bomb/alc_item.json
+++ b/data/Unleash_The_Mods/Working_mods/Alchemic_bomb/alc_item.json
@@ -45,14 +45,12 @@
     "material": [ "kevlar", "plastic", "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "head", "mouth", "eyes" ],
-    "coverage": 100,
-    "encumbrance": 15,
     "warmth": 15,
     "qualities": [ [ "GLARE", 3 ] ],
     "material_thickness": 6,
     "environmental_protection": 15,
-    "flags": [ "WATERPROOF", "STURDY", "OVERSIZE", "PARTIAL_DEAF" ]
+    "flags": [ "WATERPROOF", "STURDY", "OVERSIZE", "PARTIAL_DEAF" ],
+    "armor": { "coverage": 100, "covers": [ "head", "mouth", "eyes" ], "encumbrance": 15 }
   },
   {
     "id": "d_pouch_alc",

--- a/data/Unleash_The_Mods/Working_mods/Alternate_ear_graphics/cosmetic_armor.json
+++ b/data/Unleash_The_Mods/Working_mods/Alternate_ear_graphics/cosmetic_armor.json
@@ -13,12 +13,10 @@
     "material": [  ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [  ],
-    "coverage": 0,
-    "encumbrance": 0,
     "material_thickness": 1,
     "qualities": [  ],
-    "flags": [ "ZERO_WEIGHT" ]
+    "flags": [ "ZERO_WEIGHT" ],
+    "armor": { "coverage": 0, "covers": [  ], "encumbrance": 0 }
   },
   {
     "id": "lupine_ears",
@@ -34,12 +32,10 @@
     "material": [  ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [  ],
-    "coverage": 0,
-    "encumbrance": 0,
     "material_thickness": 1,
     "qualities": [  ],
-    "flags": [ "ZERO_WEIGHT" ]
+    "flags": [ "ZERO_WEIGHT" ],
+    "armor": { "coverage": 0, "covers": [  ], "encumbrance": 0 }
   },
   {
     "id": "feline_ears",
@@ -55,11 +51,9 @@
     "material": [  ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [  ],
-    "coverage": 0,
-    "encumbrance": 0,
     "material_thickness": 1,
     "qualities": [  ],
-    "flags": [ "ZERO_WEIGHT" ]
+    "flags": [ "ZERO_WEIGHT" ],
+    "armor": { "coverage": 0, "covers": [  ], "encumbrance": 0 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Armor_Up_PA_Utilities/Items.json
+++ b/data/Unleash_The_Mods/Working_mods/Armor_Up_PA_Utilities/Items.json
@@ -11,15 +11,14 @@
     "symbol": "[",
     "color": "light_gray",
     "power_armor": true,
-    "coverage": 5,
-    "encumbrance": 2,
     "material_thickness": 1,
     "use_action": { "type": "holster", "holster_prompt": "Stash item", "holster_msg": "You stash your %s." },
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1 L", "max_contains_weight": "2500 g", "moves": 30 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1 L", "max_contains_weight": "2500 g", "moves": 30 }
     ],
-    "flags": [ "STURDY", "BELTED", "OVERSIZE", "NO_QUICKDRAW" ]
+    "flags": [ "STURDY", "BELTED", "OVERSIZE", "NO_QUICKDRAW" ],
+    "armor": { "coverage": 5, "encumbrance": 2 }
   },
   {
     "id": "pa_holster",
@@ -33,8 +32,6 @@
     "symbol": "[",
     "color": "light_gray",
     "power_armor": true,
-    "coverage": 5,
-    "encumbrance": 1,
     "material_thickness": 1,
     "use_action": { "type": "holster" },
     "pocket_data": [
@@ -47,7 +44,8 @@
         "moves": 150
       }
     ],
-    "flags": [ "WAIST", "OVERSIZE", "STURDY" ]
+    "flags": [ "WAIST", "OVERSIZE", "STURDY" ],
+    "armor": { "coverage": 5, "encumbrance": 1 }
   },
   {
     "id": "pa_magbandolier",
@@ -61,8 +59,6 @@
     "symbol": "[",
     "power_armor": true,
     "color": "dark_gray",
-    "coverage": 5,
-    "encumbrance": 2,
     "material_thickness": 2,
     "use_action": { "type": "holster", "holster_prompt": "Stash ammo", "holster_msg": "You stash your %s." },
     "pocket_data": [
@@ -75,7 +71,8 @@
         "moves": 150
       }
     ],
-    "flags": [ "BELTED", "WAIST", "MAG_COMPACT" ]
+    "flags": [ "BELTED", "WAIST", "MAG_COMPACT" ],
+    "armor": { "coverage": 5, "encumbrance": 2 }
   },
   {
     "id": "pa_bscabbard",
@@ -90,8 +87,6 @@
     "symbol": "[",
     "color": "brown",
     "power_armor": true,
-    "coverage": 5,
-    "encumbrance": 3,
     "material_thickness": 1,
     "use_action": { "type": "holster", "holster_prompt": "Sheath sword", "holster_msg": "You sheath your %s" },
     "pocket_data": [
@@ -104,7 +99,8 @@
         "moves": 150
       }
     ],
-    "flags": [ "STURDY", "BELTED", "OVERSIZE", "SHEATH_SWORD" ]
+    "flags": [ "STURDY", "BELTED", "OVERSIZE", "SHEATH_SWORD" ],
+    "armor": { "coverage": 5, "encumbrance": 3 }
   },
   {
     "id": "pa_scabbard",
@@ -119,8 +115,6 @@
     "symbol": "[",
     "color": "brown",
     "power_armor": true,
-    "coverage": 3,
-    "encumbrance": 2,
     "material_thickness": 1,
     "use_action": { "type": "holster", "holster_prompt": "Sheath sword", "holster_msg": "You sheath your %s" },
     "pocket_data": [
@@ -133,7 +127,8 @@
         "moves": 150
       }
     ],
-    "flags": [ "WAIST", "OVERSIZE", "STURDY", "SHEATH_SWORD" ]
+    "flags": [ "WAIST", "OVERSIZE", "STURDY", "SHEATH_SWORD" ],
+    "armor": { "coverage": 3, "encumbrance": 2 }
   },
   {
     "id": "pa_sheath",
@@ -147,7 +142,6 @@
     "symbol": "|",
     "color": "brown",
     "power_armor": true,
-    "coverage": 5,
     "material_thickness": 1,
     "use_action": { "type": "holster", "holster_prompt": "Sheath knife", "holster_msg": "You sheath your %s" },
     "pocket_data": [
@@ -160,6 +154,7 @@
         "moves": 150
       }
     ],
-    "flags": [ "WAIST", "OVERSIZE", "SHEATH_KNIFE" ]
+    "flags": [ "WAIST", "OVERSIZE", "SHEATH_KNIFE" ],
+    "armor": { "coverage": 5 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Armor_Up_Survivor_Expansion/Items.json
+++ b/data/Unleash_The_Mods/Working_mods/Armor_Up_Survivor_Expansion/Items.json
@@ -8,8 +8,8 @@
     "weight": "7000 g",
     "price": "1200 USD",
     "material": [ "superalloy", "leather" ],
-    "encumbrance": 18,
-    "material_thickness": 5
+    "material_thickness": 5,
+    "armor": { "encumbrance": 18 }
   },
   {
     "id": "survivor_lightplate",
@@ -21,11 +21,10 @@
     "volume": "18 L",
     "price": "800 USD",
     "material": [ "steel", "kevlar" ],
-    "coverage": 100,
-    "encumbrance": 24,
     "warmth": 25,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "OUTER", "STURDY" ]
+    "flags": [ "VARSIZE", "OUTER", "STURDY" ],
+    "armor": { "coverage": 100, "encumbrance": 24 }
   },
   {
     "id": "survivor_alloyplate",
@@ -37,11 +36,10 @@
     "volume": "18 L",
     "price": "1600 USD",
     "material": [ "superalloy", "kevlar" ],
-    "coverage": 100,
-    "encumbrance": 22,
     "warmth": 25,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "OUTER", "STURDY" ]
+    "flags": [ "VARSIZE", "OUTER", "STURDY" ],
+    "armor": { "coverage": 100, "encumbrance": 22 }
   },
   {
     "id": "survivor_skinsuit",
@@ -55,9 +53,6 @@
     "material": [ "kevlar", "cotton" ],
     "symbol": "[",
     "color": "green",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 100,
-    "encumbrance": 6,
     "warmth": 10,
     "material_thickness": 1,
     "environmental_protection": 2,
@@ -65,7 +60,8 @@
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "2 kg", "moves": 45 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "2 kg", "moves": 45 }
     ],
-    "flags": [ "VARSIZE", "RAINPROOF", "STURDY", "SKINTIGHT" ]
+    "flags": [ "VARSIZE", "RAINPROOF", "STURDY", "SKINTIGHT" ],
+    "armor": { "coverage": 100, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 6 }
   },
   {
     "id": "environmental_skinsuit",
@@ -80,13 +76,15 @@
     "material": [ "kevlar", "plastic" ],
     "symbol": "[",
     "color": "light_red",
-    "covers": [ "head", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 10,
     "warmth": 30,
     "material_thickness": 1,
     "environmental_protection": 4,
-    "flags": [ "VARSIZE", "RAINPROOF", "STURDY", "ELECTRIC_IMMUNE", "SKINTIGHT" ]
+    "flags": [ "VARSIZE", "RAINPROOF", "STURDY", "ELECTRIC_IMMUNE", "SKINTIGHT" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "head", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 10
+    }
   },
   {
     "id": "armored_pack",
@@ -99,9 +97,6 @@
     "material": [ "kevlar", "steel", "leather" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso" ],
-    "coverage": 30,
-    "encumbrance": 12,
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -126,6 +121,7 @@
       }
     ],
     "material_thickness": 2,
-    "flags": [ "WATER_FRIENDLY", "STURDY", "BELTED" ]
+    "flags": [ "WATER_FRIENDLY", "STURDY", "BELTED" ],
+    "armor": { "coverage": 30, "covers": [ "torso" ], "encumbrance": 12 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Battle_Maid_Redux/armor.json
+++ b/data/Unleash_The_Mods/Working_mods/Battle_Maid_Redux/armor.json
@@ -6,7 +6,6 @@
     "name": { "str": "Victorian maid dress", "str_pl": "Victorian maid dresses" },
     "weight": "800 g",
     "color": "black",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
     "to_hit": 0,
     "pocket_data": [
       {
@@ -38,11 +37,9 @@
     "volume": "4250 ml",
     "warmth": 20,
     "environmental_protection": 1,
-    "encumbrance": 6,
-    "max_encumbrance": 11,
     "flags": [ "VARSIZE", "FANCY", "OVERSIZE", "POCKETS" ],
-    "coverage": 95,
-    "material_thickness": 4
+    "material_thickness": 4,
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": [ 6, 11 ] }
   },
   {
     "type": "TOOL_ARMOR",
@@ -51,7 +48,6 @@
     "name": { "str": "French maid dress", "str_pl": "French maid dresses" },
     "weight": "100 g",
     "color": "blue",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -67,11 +63,9 @@
     "material": [ "cotton" ],
     "volume": "250 ml",
     "warmth": 5,
-    "encumbrance": 5,
-    "max_encumbrance": 10,
     "flags": [ "VARSIZE", "SUPER_FANCY", "OVERSIZE" ],
-    "coverage": 70,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 70, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": [ 5, 10 ] }
   },
   {
     "type": "TOOL_ARMOR",
@@ -81,18 +75,15 @@
     "name": { "str": "strange French maid dress", "str_pl": "strange French maid dresses" },
     "weight": "100 g",
     "color": "blue",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
     "symbol": "[",
     "description": "A French maid dress in the modern style, black with a frilly white apron. Doesn't cover much past the thigh or shoulder. Something seems off about it.",
     "price": "50 USD",
     "material": [ "cotton" ],
     "volume": "250 ml",
     "warmth": 20,
-    "encumbrance": 5,
-    "max_encumbrance": 10,
     "flags": [ "VARSIZE", "SUPER_FANCY", "OVERSIZE", "STURDY" ],
-    "coverage": 0,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 0, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": [ 5, 10 ] }
   },
   {
     "id": "survivor_maid_dress",
@@ -102,7 +93,6 @@
     "name": { "str": "survivor Victorian maid dress", "str_pl": "survivor Victorian maid dresses" },
     "weight": "2300 g",
     "color": "black",
-    "covers": [ "leg_l", "leg_r", "head", "torso", "arm_l", "arm_r" ],
     "symbol": "[",
     "description": "A Victorian maid dress tailored specifically for post-cataclysm maids. The kevlar weave provides modest protection, but makes it somewhat harder to move in.",
     "price": "1100 USD",
@@ -110,8 +100,6 @@
     "volume": "10500 ml",
     "warmth": 30,
     "environmental_protection": 5,
-    "encumbrance": 8,
-    "max_encumbrance": 17,
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -136,8 +124,8 @@
       }
     ],
     "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "STURDY", "FANCY", "OVERSIZE", "POCKETS" ],
-    "coverage": 100,
-    "material_thickness": 4
+    "material_thickness": 4,
+    "armor": { "coverage": 100, "covers": [ "leg_l", "leg_r", "head", "torso", "arm_l", "arm_r" ], "encumbrance": [ 8, 17 ] }
   },
   {
     "type": "ARMOR",
@@ -146,7 +134,6 @@
     "name": { "str": "Jokyu dress", "str_pl": "Jokyu dresses" },
     "weight": "1200 g",
     "color": "brown",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
     "symbol": "[",
     "description": "Women's servant clothes worn in Japanese cafes a long time ago. Essentially a white apron over a kimono.",
     "price": "50 USD",
@@ -154,8 +141,6 @@
     "volume": "5 L",
     "warmth": 20,
     "environmental_protection": 1,
-    "encumbrance": 9,
-    "max_encumbrance": 15,
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -166,9 +151,9 @@
       }
     ],
     "flags": [ "VARSIZE", "FANCY", "OVERSIZE" ],
-    "coverage": 95,
     "material_thickness": 4,
-    "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "mutations": [ "AEP_DEX_UP" ] } ] }
+    "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "mutations": [ "AEP_DEX_UP" ] } ] },
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": [ 9, 15 ] }
   },
   {
     "type": "ARMOR",
@@ -177,7 +162,6 @@
     "name": { "str": "lace stockings with garterbelt", "str_pl": "lace stockings with garterbelts" },
     "weight": "90 g",
     "color": "white",
-    "covers": [ "foot_l", "foot_r", "leg_l", "leg_r" ],
     "symbol": "[",
     "description": "A set of pure white stockings with garterbelt and panties, decorated with elegant lacing.",
     "price": "5 USD",
@@ -185,8 +169,8 @@
     "volume": "250 ml",
     "warmth": 6,
     "flags": [ "VARSIZE", "SKINTIGHT", "SUPER_FANCY", "OVERSIZE" ],
-    "coverage": 85,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 85, "covers": [ "foot_l", "foot_r", "leg_l", "leg_r" ] }
   },
   {
     "type": "TOOL_ARMOR",
@@ -195,7 +179,6 @@
     "name": { "str": "tuxedo" },
     "weight": "1587 g",
     "color": "dark_gray",
-    "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r" ],
     "symbol": "[",
     "description": "A full-body tuxedo.  Makes the apocalypse feel a little more classy.",
     "price": "210 USD",
@@ -203,12 +186,11 @@
     "volume": "5500 ml",
     "warmth": 30,
     "environmental_protection": 1,
-    "encumbrance": 12,
     "flags": [ "VARSIZE", "SUPER_FANCY", "OVERSIZE" ],
-    "coverage": 95,
     "material_thickness": 4,
     "max_charges": 12,
-    "ammo": [ "assassins_throwing_dagger" ]
+    "ammo": [ "assassins_throwing_dagger" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r" ], "encumbrance": 12 }
   },
   {
     "id": "survivor_tux",
@@ -218,7 +200,6 @@
     "name": { "str": "survivor tuxedo" },
     "weight": "3050 g",
     "color": "dark_gray",
-    "covers": [ "leg_l", "leg_r", "head", "torso", "arm_l", "arm_r" ],
     "symbol": "[",
     "description": "A tux tailored specifically for post-cataclysm butlers. The kevlar weave provides modest protection, but makes it somewhat harder to move in.",
     "price": "1100 USD",
@@ -226,8 +207,6 @@
     "volume": "11250 ml",
     "warmth": 30,
     "environmental_protection": 5,
-    "encumbrance": 9,
-    "max_encumbrance": 17,
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -245,10 +224,10 @@
       }
     ],
     "flags": [ "VARSIZE", "HOOD", "WATERPROOF", "RAINPROOF", "STURDY", "SUPER_FANCY", "OVERSIZE" ],
-    "coverage": 100,
     "material_thickness": 4,
     "max_charges": 12,
-    "ammo": [ "assassins_throwing_dagger" ]
+    "ammo": [ "assassins_throwing_dagger" ],
+    "armor": { "coverage": 100, "covers": [ "leg_l", "leg_r", "head", "torso", "arm_l", "arm_r" ], "encumbrance": [ 9, 17 ] }
   },
   {
     "type": "ARMOR",
@@ -257,7 +236,6 @@
     "name": { "str": "maid cap" },
     "weight": "50 g",
     "color": "white",
-    "covers": [ "head" ],
     "symbol": "[",
     "description": "A frilly white cap commonly used by maids.",
     "price": "20 USD",
@@ -265,8 +243,8 @@
     "volume": "250 ml",
     "warmth": 30,
     "flags": [ "VARSIZE" ],
-    "coverage": 60,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 60, "covers": [ "head" ] }
   },
   {
     "type": "ARMOR",
@@ -276,7 +254,6 @@
     "weight": "50 g",
     "looks_like": "maid_cap",
     "color": "white",
-    "covers": [ "head" ],
     "symbol": "[",
     "description": "A frilly white headband commonly used by maids. Something seems off about it.",
     "price": "20 USD",
@@ -284,8 +261,8 @@
     "volume": "250 ml",
     "warmth": 30,
     "flags": [ "VARSIZE", "STURDY", "FANCY" ],
-    "coverage": 0,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 0, "covers": [ "head" ] }
   },
   {
     "type": "ARMOR",
@@ -294,7 +271,6 @@
     "name": { "str": "cat eared maid cap" },
     "weight": "60 g",
     "color": "white",
-    "covers": [ "head" ],
     "symbol": "[",
     "description": "A frilly white cap commonly used by maids. There's two bumps on top of it that look like cat ears. It's very cute.",
     "price": "20 USD",
@@ -302,8 +278,8 @@
     "volume": "250 ml",
     "warmth": 30,
     "flags": [ "VARSIZE", "FANCY" ],
-    "coverage": 60,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 60, "covers": [ "head" ] }
   },
   {
     "type": "ARMOR",
@@ -327,7 +303,6 @@
     "name": { "str": "tail panties", "str_pl": "tail panties" },
     "weight": "100 g",
     "color": "white",
-    "covers": [ "leg_l", "leg_r" ],
     "symbol": "[",
     "description": "A special type of underwear meant for people with tails. Although it's incredibly thin, it's the last line of defense for your dignity.",
     "price": "50 USD",
@@ -335,8 +310,8 @@
     "volume": "250 ml",
     "warmth": 5,
     "flags": [ "VARSIZE", "SKINTIGHT", "OVERSIZE" ],
-    "coverage": 15,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 15, "covers": [ "leg_l", "leg_r" ] }
   },
   {
     "id": "briefs_kemo",
@@ -344,7 +319,6 @@
     "name": { "str": "tail briefs", "str_pl": "tail briefs" },
     "weight": "32 g",
     "color": "white",
-    "covers": [ "leg_l", "leg_r" ],
     "symbol": "[",
     "description": "A special type of underwear meant for people with tails. It stands as the difference between being a gentleman and being a beast.",
     "price": "10 USD",
@@ -352,8 +326,8 @@
     "volume": "250 ml",
     "warmth": 5,
     "flags": [ "VARSIZE", "SKINTIGHT", "OVERSIZE" ],
-    "coverage": 15,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 15, "covers": [ "leg_l", "leg_r" ] }
   },
   {
     "id": "maids_scarf",
@@ -368,12 +342,10 @@
     "weight": "120 g",
     "volume": "1 L",
     "to_hit": -3,
-    "covers": [ "mouth" ],
     "flags": [ "OVERSIZE", "POCKETS", "OUTER", "ALLOWS_NATURAL_ATTACKS" ],
     "warmth": 20,
     "environmental_protection": 5,
-    "encumbrance": 0,
-    "coverage": 100,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 100, "covers": [ "mouth" ], "encumbrance": 0 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Battle_Maid_Redux/tool_armor.json
+++ b/data/Unleash_The_Mods/Working_mods/Battle_Maid_Redux/tool_armor.json
@@ -63,7 +63,6 @@
     "name": { "str": "human-sized carry bag" },
     "weight": "1000 g",
     "color": "brown",
-    "covers": [ "torso", "head", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
     "symbol": "[",
     "description": "A large bag that could fit a person inside. The zipper running across it provides ventilation and you can open and close it from the inside. It can be used as a sleeping bag, as well.",
     "price": "205 USD",
@@ -71,12 +70,15 @@
     "volume": "5 L",
     "warmth": 80,
     "environmental_protection": 1,
-    "encumbrance": 80,
-    "coverage": 100,
     "flags": [ "OVERSIZE", "OUTER" ],
     "use_action": "CAPTURE_MONSTER_ACT",
     "properties": [ [ "monster_size_capacity", "MEDIUM" ] ],
-    "material_thickness": 4
+    "material_thickness": 4,
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "head", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 80
+    }
   },
   {
     "type": "TOOL_ARMOR",
@@ -85,7 +87,6 @@
     "name": { "str": "maid cloak (off)" },
     "weight": "1175 g",
     "color": "green",
-    "covers": [ "torso", "head", "arm_l", "arm_r", "leg_l", "leg_r" ],
     "symbol": "[",
     "description": "An elegant mantle to keep you warm when going outside. Use it to turn invisible. Consumes maid points.",
     "price": "107 USD",
@@ -93,8 +94,6 @@
     "volume": "3000 ml",
     "warmth": 30,
     "environmental_protection": 3,
-    "encumbrance": 10,
-    "coverage": 65,
     "flags": [ "OVERSIZE", "HOOD", "OUTER", "VARSIZE" ],
     "material_thickness": 2,
     "max_charges": 100,
@@ -108,7 +107,8 @@
       "active": true,
       "need_charges": 100,
       "need_charges_msg": "Not enough maid points!"
-    }
+    },
+    "armor": { "coverage": 65, "covers": [ "torso", "head", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 10 }
   },
   {
     "type": "TOOL_ARMOR",
@@ -117,7 +117,6 @@
     "name": { "str": "maid cloak (on)" },
     "weight": "1175 g",
     "color": "green",
-    "covers": [ "torso", "head", "arm_l", "arm_r", "leg_l", "leg_r" ],
     "symbol": "[",
     "description": "An elegant mantle to keep you warm when going outside. Use it to turn visible. It is currently on and consuming maid points.",
     "price": "107 USD",
@@ -125,8 +124,6 @@
     "volume": "3000 ml",
     "warmth": 30,
     "environmental_protection": 3,
-    "encumbrance": 10,
-    "coverage": 65,
     "flags": [ "OVERSIZE", "HOOD", "OUTER", "VARSIZE", "NO_RELOAD" ],
     "material_thickness": 2,
     "max_charges": 100,
@@ -140,7 +137,8 @@
       "target": "maid_cloak_off",
       "need_charges": 0
     },
-    "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "mutations": [ "AEP_INVISIBLE", "AEP_STEALTH" ] } ] }
+    "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "mutations": [ "AEP_INVISIBLE", "AEP_STEALTH" ] } ] },
+    "armor": { "coverage": 65, "covers": [ "torso", "head", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 10 }
   },
   {
     "type": "TOOL_ARMOR",
@@ -149,7 +147,6 @@
     "name": { "str": "white brim with veil", "str_pl": "white brims with veils" },
     "weight": "150 g",
     "color": "white",
-    "covers": [ "eyes" ],
     "symbol": "[",
     "description": "A regular maid's white brim with an elegant veil sewn into it, decorated with silver frills. Although it covers your eyes and blocks your vision quite harshly, you can use maid points to turn it on and gain otherwordly sight.",
     "price": "80 USD",
@@ -157,7 +154,6 @@
     "volume": "250 ml",
     "warmth": 10,
     "environmental_protection": 6,
-    "coverage": 100,
     "flags": [ "SUN_GLASSES", "FANCY" ],
     "qualities": [ [ "GLARE", 1 ] ],
     "material_thickness": 4,
@@ -172,7 +168,8 @@
       "active": true,
       "need_charges": 100,
       "need_charges_msg": "Not enough maid points!"
-    }
+    },
+    "armor": { "coverage": 100, "covers": [ "eyes" ] }
   },
   {
     "type": "TOOL_ARMOR",
@@ -181,7 +178,6 @@
     "name": { "str": "white brim with veil (clairvoyant)", "str_pl": "white brims with veils (clairvoyant)" },
     "weight": "150 g",
     "color": "white",
-    "covers": [ "eyes" ],
     "symbol": "[",
     "description": "A regular maid's white brim with an elegant veil sewn into it, decorated with silver frills. It is currently see-through.",
     "price": "80 USD",
@@ -189,7 +185,6 @@
     "volume": "250 ml",
     "warmth": 10,
     "environmental_protection": 6,
-    "coverage": 100,
     "flags": [ "SUN_GLASSES", "FANCY", "NO_RELOAD" ],
     "qualities": [ [ "GLARE", 1 ] ],
     "material_thickness": 4,
@@ -204,6 +199,7 @@
       "target": "maidguy_mask_off",
       "need_charges": 0
     },
-    "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "mutations": [ "AEP_SUPER_CLAIRVOYANCE" ] } ] }
+    "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "mutations": [ "AEP_SUPER_CLAIRVOYANCE" ] } ] },
+    "armor": { "coverage": 100, "covers": [ "eyes" ] }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/CBM_Arms/cbma_armors.json
+++ b/data/Unleash_The_Mods/Working_mods/CBM_Arms/cbma_armors.json
@@ -12,9 +12,6 @@
     "symbol": "[",
     "color": "dark_gray",
     "looks_like": "survivor_suit",
-    "covers": [ "torso" ],
-    "coverage": 100,
-    "encumbrance": 24,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2400 ml", "max_contains_weight": "7 kg", "moves": 65 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2400 ml", "max_contains_weight": "7 kg", "moves": 65 },
@@ -26,7 +23,8 @@
     "warmth": 15,
     "material_thickness": 6,
     "environmental_protection": 9,
-    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "STURDY", "OVERSIZE", "TRADER_AVOID" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "STURDY", "OVERSIZE", "TRADER_AVOID" ],
+    "armor": { "coverage": 100, "covers": [ "torso" ], "encumbrance": 24 }
   },
   {
     "id": "cbma_enhanced_armor",
@@ -42,9 +40,6 @@
     "symbol": "[",
     "color": "dark_gray",
     "looks_like": "survivor_suit",
-    "covers": [ "torso" ],
-    "coverage": 100,
-    "encumbrance": 12,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2400 ml", "max_contains_weight": "7 kg", "moves": 65 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2400 ml", "max_contains_weight": "7 kg", "moves": 65 },
@@ -72,7 +67,8 @@
       "active": true,
       "need_charges": 1,
       "need_charges_msg": "The system started for a moment... and then went silent."
-    }
+    },
+    "armor": { "coverage": 100, "covers": [ "torso" ], "encumbrance": 12 }
   },
   {
     "id": "cbma_enhanced_armor_on",
@@ -89,9 +85,6 @@
     "symbol": "[",
     "color": "dark_gray",
     "looks_like": "survivor_suit",
-    "covers": [ "torso" ],
-    "coverage": 100,
-    "encumbrance": 6,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2400 ml", "max_contains_weight": "7 kg", "moves": 65 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2400 ml", "max_contains_weight": "7 kg", "moves": 65 },
@@ -125,7 +118,8 @@
           ]
         }
       ]
-    }
+    },
+    "armor": { "coverage": 100, "covers": [ "torso" ], "encumbrance": 6 }
   },
   {
     "id": "cbma_bionic_helmet",
@@ -142,13 +136,11 @@
     "symbol": "[",
     "color": "dark_gray",
     "looks_like": "helmet_survivor",
-    "covers": [ "head" ],
-    "coverage": 100,
-    "encumbrance": 24,
     "warmth": 15,
     "material_thickness": 6,
     "environmental_protection": 9,
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY", "RAINPROOF", "OVERSIZE", "TRADER_AVOID" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY", "RAINPROOF", "OVERSIZE", "TRADER_AVOID" ],
+    "armor": { "coverage": 100, "covers": [ "head" ], "encumbrance": 24 }
   },
   {
     "id": "cbma_bionic_mask",
@@ -165,13 +157,11 @@
     "symbol": "[",
     "color": "dark_gray",
     "looks_like": "mask_gas",
-    "covers": [ "mouth", "eyes" ],
-    "coverage": 100,
-    "encumbrance": 24,
     "warmth": 15,
     "material_thickness": 6,
     "environmental_protection": 22,
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY", "RAINPROOF", "OVERSIZE", "GAS_PROOF", "TRADER_AVOID" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY", "RAINPROOF", "OVERSIZE", "GAS_PROOF", "TRADER_AVOID" ],
+    "armor": { "coverage": 100, "covers": [ "mouth", "eyes" ], "encumbrance": 24 }
   },
   {
     "id": "cbma_enhanced_helmet",
@@ -199,9 +189,6 @@
     "symbol": "[",
     "color": "dark_gray",
     "looks_like": "helmet_hsurvivor",
-    "covers": [ "head", "mouth", "eyes" ],
-    "coverage": 100,
-    "encumbrance": 12,
     "warmth": 15,
     "material_thickness": 6,
     "environmental_protection": 24,
@@ -225,7 +212,8 @@
       "GAS_PROOF",
       "TRADER_AVOID",
       "NO_UNLOAD"
-    ]
+    ],
+    "armor": { "coverage": 100, "covers": [ "head", "mouth", "eyes" ], "encumbrance": 12 }
   },
   {
     "id": "cbma_enhanced_helmet_on",
@@ -254,9 +242,6 @@
     "symbol": "[",
     "color": "dark_gray",
     "looks_like": "helmet_hsurvivor",
-    "covers": [ "head", "mouth", "eyes" ],
-    "coverage": 100,
-    "encumbrance": 0,
     "warmth": 15,
     "material_thickness": 6,
     "environmental_protection": 24,
@@ -290,7 +275,8 @@
           ]
         }
       ]
-    }
+    },
+    "armor": { "coverage": 100, "covers": [ "head", "mouth", "eyes" ], "encumbrance": 0 }
   },
   {
     "id": "cbma_bionic_gloves",
@@ -306,13 +292,11 @@
     "symbol": "[",
     "color": "dark_gray",
     "looks_like": "gloves_lsurvivor",
-    "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ],
-    "coverage": 100,
-    "encumbrance": 24,
     "warmth": 15,
     "material_thickness": 6,
     "environmental_protection": 9,
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY", "OVERSIZE", "TRADER_AVOID" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY", "OVERSIZE", "TRADER_AVOID" ],
+    "armor": { "coverage": 100, "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ], "encumbrance": 24 }
   },
   {
     "id": "cbma_enhanced_gloves",
@@ -339,9 +323,6 @@
     "symbol": "[",
     "color": "dark_gray",
     "looks_like": "gloves_lsurvivor",
-    "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ],
-    "coverage": 100,
-    "encumbrance": 12,
     "warmth": 15,
     "material_thickness": 6,
     "environmental_protection": 15,
@@ -353,7 +334,8 @@
       "need_charges": 1,
       "need_charges_msg": "The system started for a moment... and then went silent."
     },
-    "flags": [ "VARSIZE", "WATERPROOF", "WATER_FRIENDLY", "STURDY", "OVERSIZE", "TRADER_AVOID" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "WATER_FRIENDLY", "STURDY", "OVERSIZE", "TRADER_AVOID" ],
+    "armor": { "coverage": 100, "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ], "encumbrance": 12 }
   },
   {
     "id": "cbma_enhanced_gloves_on",
@@ -381,14 +363,12 @@
     "symbol": "[",
     "color": "dark_gray",
     "looks_like": "gloves_lsurvivor",
-    "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ],
-    "coverage": 100,
-    "encumbrance": 0,
     "warmth": 15,
     "material_thickness": 6,
     "environmental_protection": 15,
     "use_action": { "type": "transform", "msg": "Your %s deactivates.", "target": "cbma_enhanced_gloves" },
-    "flags": [ "VARSIZE", "WATERPROOF", "WATER_FRIENDLY", "STURDY", "OVERSIZE", "TRADER_AVOID" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "WATER_FRIENDLY", "STURDY", "OVERSIZE", "TRADER_AVOID" ],
+    "armor": { "coverage": 100, "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ], "encumbrance": 0 }
   },
   {
     "id": "cbma_bionic_boots",
@@ -405,13 +385,11 @@
     "symbol": "[",
     "color": "dark_gray",
     "looks_like": "boots_plate",
-    "covers": [ "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 24,
     "warmth": 15,
     "material_thickness": 6,
     "environmental_protection": 9,
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY", "OVERSIZE", "TRADER_AVOID" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY", "OVERSIZE", "TRADER_AVOID" ],
+    "armor": { "coverage": 100, "covers": [ "leg_l", "leg_r", "foot_l", "foot_r" ], "encumbrance": 24 }
   },
   {
     "id": "cbma_enhanced_boots",
@@ -439,9 +417,6 @@
     "symbol": "[",
     "color": "dark_gray",
     "looks_like": "boots_plate",
-    "covers": [ "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 12,
     "warmth": 15,
     "material_thickness": 6,
     "environmental_protection": 15,
@@ -453,7 +428,8 @@
       "active": true,
       "need_charges": 1,
       "need_charges_msg": "The system started for a moment... and then went silent."
-    }
+    },
+    "armor": { "coverage": 100, "covers": [ "leg_l", "leg_r", "foot_l", "foot_r" ], "encumbrance": 12 }
   },
   {
     "id": "cbma_enhanced_boots_on",
@@ -482,9 +458,6 @@
     "symbol": "[",
     "color": "dark_gray",
     "looks_like": "boots_plate",
-    "covers": [ "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 6,
     "warmth": 15,
     "material_thickness": 6,
     "environmental_protection": 15,
@@ -502,7 +475,8 @@
           ]
         }
       ]
-    }
+    },
+    "armor": { "coverage": 100, "covers": [ "leg_l", "leg_r", "foot_l", "foot_r" ], "encumbrance": 6 }
   },
   {
     "id": "cbma_bionic_duster",
@@ -518,9 +492,6 @@
     "symbol": "[",
     "color": "brown",
     "looks_like": "trenchcoat_survivor",
-    "covers": [ "torso" ],
-    "coverage": 85,
-    "encumbrance": 10,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2400 ml", "max_contains_weight": "7 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2400 ml", "max_contains_weight": "7 kg", "moves": 75 },
@@ -532,7 +503,8 @@
     "warmth": 0,
     "material_thickness": 7,
     "environmental_protection": 3,
-    "flags": [ "VARSIZE", "POCKETS", "HOOD", "COLLAR", "STURDY", "WATERPROOF", "RAINPROOF", "OUTER", "OVERSIZE", "TRADER_AVOID" ]
+    "flags": [ "VARSIZE", "POCKETS", "HOOD", "COLLAR", "STURDY", "WATERPROOF", "RAINPROOF", "OUTER", "OVERSIZE", "TRADER_AVOID" ],
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": 10 }
   },
   {
     "id": "cbma_enhanced_duster",
@@ -549,9 +521,6 @@
     "symbol": "[",
     "color": "brown",
     "looks_like": "trenchcoat_survivor",
-    "covers": [ "torso" ],
-    "coverage": 85,
-    "encumbrance": 10,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2400 ml", "max_contains_weight": "7 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2400 ml", "max_contains_weight": "7 kg", "moves": 75 },
@@ -591,7 +560,8 @@
       "active": true,
       "need_charges": 1,
       "need_charges_msg": "The system started for a moment... and then went silent."
-    }
+    },
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": 10 }
   },
   {
     "id": "cbma_enhanced_duster_on",
@@ -609,9 +579,6 @@
     "symbol": "[",
     "color": "brown",
     "looks_like": "trenchcoat_survivor",
-    "covers": [ "torso" ],
-    "coverage": 85,
-    "encumbrance": 10,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2400 ml", "max_contains_weight": "7 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2400 ml", "max_contains_weight": "7 kg", "moves": 75 },
@@ -645,7 +612,8 @@
       "TRADER_AVOID"
     ],
     "use_action": { "type": "transform", "msg": "Your %s deactivates.", "target": "cbma_enhanced_duster" },
-    "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "ARMOR_ELEC", "add": 20 } ] } ] }
+    "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "ARMOR_ELEC", "add": 20 } ] } ] },
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": 10 }
   },
   {
     "id": "cbma_carry_frame",
@@ -673,9 +641,6 @@
     "symbol": "[",
     "color": "light_gray",
     "looks_like": "power_armor_frame",
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 85,
-    "encumbrance": 120,
     "warmth": 0,
     "material_thickness": 7,
     "flags": [ "STURDY", "WATERPROOF", "WATER_FRIENDLY", "RAINPROOF", "OUTER", "OVERSIZE", "TRADER_AVOID" ],
@@ -695,6 +660,11 @@
           "values": [ { "value": "STRENGTH", "add": -3 }, { "value": "DEXTERITY", "add": -2 }, { "value": "SPEED", "multiply": -0.2 } ]
         }
       ]
+    },
+    "armor": {
+      "coverage": 85,
+      "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 120
     }
   },
   {
@@ -723,9 +693,6 @@
     "symbol": "[",
     "color": "light_gray",
     "looks_like": "power_armor_frame",
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 85,
-    "encumbrance": 40,
     "warmth": 0,
     "material_thickness": 7,
     "flags": [ "STURDY", "WATERPROOF", "WATER_FRIENDLY", "RAINPROOF", "OUTER", "OVERSIZE", "TRADER_AVOID" ],
@@ -739,6 +706,11 @@
           "mutations": [ "STRONGBACK", "PACKMULE", "CLUMSY" ]
         }
       ]
+    },
+    "armor": {
+      "coverage": 85,
+      "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 40
     }
   },
   {
@@ -765,9 +737,6 @@
         "item_restriction": [ "heavy_battery_cell", "heavy_plus_battery_cell", "heavy_atomic_battery_cell", "heavy_disposable_cell" ]
       }
     ],
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 5,
     "warmth": 0,
     "material_thickness": 1,
     "flags": [ "WATERPROOF", "WATER_FRIENDLY", "RAINPROOF", "SKINTIGHT", "TRADER_AVOID", "NO_UNLOAD", "RAD_RESIST" ],
@@ -778,6 +747,11 @@
       "active": true,
       "need_charges": 1,
       "need_charges_msg": "The system started for a moment... and then went silent."
+    },
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 5
     }
   },
   {
@@ -806,9 +780,6 @@
       }
     ],
     "turns_per_charge": 20,
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 0,
     "warmth": 0,
     "material_thickness": 1,
     "environmental_protection": 20,
@@ -837,6 +808,11 @@
           ]
         }
       ]
+    },
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 0
     }
   },
   {
@@ -856,9 +832,6 @@
     "symbol": "[",
     "color": "dark_gray",
     "looks_like": "survivor_suit",
-    "covers": [ "torso" ],
-    "coverage": 100,
-    "encumbrance": 12,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2400 ml", "max_contains_weight": "7 kg", "moves": 65 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2400 ml", "max_contains_weight": "7 kg", "moves": 65 },
@@ -889,7 +862,8 @@
       "active": true,
       "need_charges": 1,
       "need_charges_msg": "The system started for a moment... and then went silent."
-    }
+    },
+    "armor": { "coverage": 100, "covers": [ "torso" ], "encumbrance": 12 }
   },
   {
     "id": "cbma_enhanced_armor_ups_on",
@@ -907,9 +881,6 @@
     "symbol": "[",
     "color": "dark_gray",
     "looks_like": "survivor_suit",
-    "covers": [ "torso" ],
-    "coverage": 100,
-    "encumbrance": 6,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2400 ml", "max_contains_weight": "7 kg", "moves": 65 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2400 ml", "max_contains_weight": "7 kg", "moves": 65 },
@@ -935,7 +906,8 @@
       "NO_RELOAD"
     ],
     "use_action": { "type": "transform", "msg": "Your %s deactivates.", "target": "cbma_enhanced_armor_ups" },
-    "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "STRENGTH", "add": 3 } ] } ] }
+    "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "STRENGTH", "add": 3 } ] } ] },
+    "armor": { "coverage": 100, "covers": [ "torso" ], "encumbrance": 6 }
   },
   {
     "id": "cbma_enhanced_helmet_ups",
@@ -956,9 +928,6 @@
     "symbol": "[",
     "color": "dark_gray",
     "looks_like": "helmet_hsurvivor",
-    "covers": [ "head", "mouth", "eyes" ],
-    "coverage": 100,
-    "encumbrance": 12,
     "warmth": 15,
     "material_thickness": 6,
     "environmental_protection": 24,
@@ -985,7 +954,8 @@
       "NO_UNLOAD",
       "USE_UPS",
       "NO_RELOAD"
-    ]
+    ],
+    "armor": { "coverage": 100, "covers": [ "head", "mouth", "eyes" ], "encumbrance": 12 }
   },
   {
     "id": "cbma_enhanced_helmet_ups_on",
@@ -1005,9 +975,6 @@
     "symbol": "[",
     "color": "dark_gray",
     "looks_like": "helmet_hsurvivor",
-    "covers": [ "head", "mouth", "eyes" ],
-    "coverage": 100,
-    "encumbrance": 0,
     "warmth": 15,
     "material_thickness": 6,
     "environmental_protection": 24,
@@ -1033,7 +1000,8 @@
       "USE_UPS",
       "NO_RELOAD"
     ],
-    "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "PERCEPTION", "add": 3 } ] } ] }
+    "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "PERCEPTION", "add": 3 } ] } ] },
+    "armor": { "coverage": 100, "covers": [ "head", "mouth", "eyes" ], "encumbrance": 0 }
   },
   {
     "id": "cbma_enhanced_gloves_ups",
@@ -1053,9 +1021,6 @@
     "symbol": "[",
     "color": "dark_gray",
     "looks_like": "gloves_lsurvivor",
-    "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ],
-    "coverage": 100,
-    "encumbrance": 12,
     "warmth": 15,
     "material_thickness": 6,
     "environmental_protection": 15,
@@ -1067,7 +1032,8 @@
       "need_charges": 1,
       "need_charges_msg": "The system started for a moment... and then went silent."
     },
-    "flags": [ "VARSIZE", "WATERPROOF", "WATER_FRIENDLY", "STURDY", "OVERSIZE", "TRADER_AVOID", "USE_UPS", "NO_UNLOAD", "NO_RELOAD" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "WATER_FRIENDLY", "STURDY", "OVERSIZE", "TRADER_AVOID", "USE_UPS", "NO_UNLOAD", "NO_RELOAD" ],
+    "armor": { "coverage": 100, "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ], "encumbrance": 12 }
   },
   {
     "id": "cbma_enhanced_gloves_ups_on",
@@ -1086,15 +1052,13 @@
     "symbol": "[",
     "color": "dark_gray",
     "looks_like": "gloves_lsurvivor",
-    "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ],
-    "coverage": 100,
-    "encumbrance": 0,
     "warmth": 15,
     "material_thickness": 6,
     "environmental_protection": 15,
     "revert_to": "cbma_enhanced_gloves_ups",
     "use_action": { "type": "transform", "msg": "Your %s deactivates.", "target": "cbma_enhanced_gloves_ups" },
-    "flags": [ "VARSIZE", "WATERPROOF", "WATER_FRIENDLY", "STURDY", "OVERSIZE", "TRADER_AVOID", "USE_UPS", "NO_UNLOAD", "NO_RELOAD" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "WATER_FRIENDLY", "STURDY", "OVERSIZE", "TRADER_AVOID", "USE_UPS", "NO_UNLOAD", "NO_RELOAD" ],
+    "armor": { "coverage": 100, "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ], "encumbrance": 0 }
   },
   {
     "id": "cbma_enhanced_boots_ups",
@@ -1115,9 +1079,6 @@
     "symbol": "[",
     "color": "dark_gray",
     "looks_like": "boots_plate",
-    "covers": [ "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 12,
     "warmth": 15,
     "material_thickness": 6,
     "environmental_protection": 15,
@@ -1129,7 +1090,8 @@
       "active": true,
       "need_charges": 1,
       "need_charges_msg": "The system started for a moment... and then went silent."
-    }
+    },
+    "armor": { "coverage": 100, "covers": [ "leg_l", "leg_r", "foot_l", "foot_r" ], "encumbrance": 12 }
   },
   {
     "id": "cbma_enhanced_boots_ups_on",
@@ -1149,16 +1111,14 @@
     "symbol": "[",
     "color": "dark_gray",
     "looks_like": "boots_plate",
-    "covers": [ "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 6,
     "warmth": 15,
     "material_thickness": 6,
     "environmental_protection": 15,
     "revert_to": "cbma_enhanced_boots_ups",
     "flags": [ "VARSIZE", "WATERPROOF", "WATER_FRIENDLY", "STURDY", "OVERSIZE", "TRADER_AVOID", "USE_UPS", "NO_UNLOAD", "NO_RELOAD" ],
     "use_action": { "type": "transform", "msg": "Your %s deactivates.", "target": "cbma_enhanced_boots_ups" },
-    "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "DEXTERITY", "add": 3 } ] } ] }
+    "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "DEXTERITY", "add": 3 } ] } ] },
+    "armor": { "coverage": 100, "covers": [ "leg_l", "leg_r", "foot_l", "foot_r" ], "encumbrance": 6 }
   },
   {
     "id": "cbma_enhanced_duster_ups",
@@ -1178,9 +1138,6 @@
     "symbol": "[",
     "color": "brown",
     "looks_like": "trenchcoat_survivor",
-    "covers": [ "torso" ],
-    "coverage": 85,
-    "encumbrance": 10,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2400 ml", "max_contains_weight": "7 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2400 ml", "max_contains_weight": "7 kg", "moves": 75 },
@@ -1215,7 +1172,8 @@
       "active": true,
       "need_charges": 1,
       "need_charges_msg": "The system started for a moment... and then went silent."
-    }
+    },
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": 10 }
   },
   {
     "id": "cbma_enhanced_duster_ups_on",
@@ -1234,9 +1192,6 @@
     "symbol": "[",
     "color": "brown",
     "looks_like": "trenchcoat_survivor",
-    "covers": [ "torso" ],
-    "coverage": 85,
-    "encumbrance": 10,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2400 ml", "max_contains_weight": "7 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2400 ml", "max_contains_weight": "7 kg", "moves": 75 },
@@ -1266,7 +1221,8 @@
       "NO_RELOAD"
     ],
     "use_action": { "type": "transform", "msg": "Your %s deactivates.", "target": "cbma_enhanced_duster_ups" },
-    "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "ARMOR_ELEC", "add": 20 } ] } ] }
+    "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "ARMOR_ELEC", "add": 20 } ] } ] },
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": 10 }
   },
   {
     "id": "cbma_inner_suite_ups",
@@ -1286,9 +1242,6 @@
     "initial_charges": 0,
     "charges_per_use": 1,
     "ammo": [ "battery" ],
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 5,
     "warmth": 0,
     "material_thickness": 1,
     "flags": [
@@ -1311,7 +1264,12 @@
         "need_charges": 1,
         "need_charges_msg": "The system started for a moment... and then went silent."
       }
-    ]
+    ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 5
+    }
   },
   {
     "id": "cbma_inner_suite_ups_on",
@@ -1330,9 +1288,6 @@
     "max_charges": 1000,
     "turns_per_charge": 10,
     "ammo": [ "battery" ],
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 0,
     "warmth": 0,
     "material_thickness": 1,
     "environmental_protection": 20,
@@ -1364,6 +1319,11 @@
           ]
         }
       ]
+    },
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 0
     }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Civilian_power_armor/power_armor.json
+++ b/data/Unleash_The_Mods/Working_mods/Civilian_power_armor/power_armor.json
@@ -15,9 +15,6 @@
     "material": [ "steel" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 90,
-    "encumbrance": 35,
     "warmth": 50,
     "material_thickness": 4,
     "environmental_protection": 3,
@@ -25,7 +22,12 @@
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "5 kg", "moves": 120 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "5 kg", "moves": 120 }
-    ]
+    ],
+    "armor": {
+      "coverage": 90,
+      "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 35
+    }
   },
   {
     "id": "power_armor_Civilian",
@@ -42,9 +44,6 @@
     "material": [ "steel", "plastic" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 95,
-    "encumbrance": 35,
     "warmth": 55,
     "power_armor": true,
     "material_thickness": 6,
@@ -59,7 +58,12 @@
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2750 ml", "max_contains_weight": "5 kg", "moves": 120 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2750 ml", "max_contains_weight": "5 kg", "moves": 120 }
-    ]
+    ],
+    "armor": {
+      "coverage": 95,
+      "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 35
+    }
   },
   {
     "id": "power_armor_Civilian_on",
@@ -78,6 +82,6 @@
       "msg": "Your Commercial power armor disengages.",
       "target": "power_armor_Civilian"
     },
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
+    "armor": { "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ] }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Community_Aftershock/items/afs_armor.json
+++ b/data/Unleash_The_Mods/Working_mods/Community_Aftershock/items/afs_armor.json
@@ -11,10 +11,7 @@
     "price": "100 kUSD",
     "price_postapoc": "50 USD",
     "material": [ "superalloy", "plastic" ],
-    "covers": [ "head", "eyes", "mouth" ],
-    "coverage": 100,
     "material_thickness": 2,
-    "encumbrance": 15,
     "warmth": 20,
     "environmental_protection": 11,
     "qualities": [ [ "GLARE", 3 ] ],
@@ -30,7 +27,8 @@
     },
     "flags": [ "WATERPROOF", "FLASH_PROTECTION", "ONLY_ONE", "STURDY" ],
     "looks_like": "depowered_helmet",
-    "magazines": [ [ "battery", [ "light_battery_cell", "light_minus_battery_cell", "light_plus_battery_cell" ] ] ]
+    "magazines": [ [ "battery", [ "light_battery_cell", "light_minus_battery_cell", "light_plus_battery_cell" ] ] ],
+    "armor": { "coverage": 100, "covers": [ "head", "eyes", "mouth" ], "encumbrance": 15 }
   },
   {
     "id": "afs_hev_helmet_on",
@@ -58,9 +56,6 @@
     "material": [ "glass", "superalloy", "platinum" ],
     "symbol": "[",
     "color": "cyan",
-    "covers": [ "torso" ],
-    "coverage": 30,
-    "encumbrance": 10,
     "warmth": 5,
     "material_thickness": 2,
     "flags": [ "BELTED", "ONLY_ONE", "LEAK_DAM" ],
@@ -71,7 +66,8 @@
       { "pocket_type": "CONTAINER", "max_contains_volume": "10 ml", "max_contains_weight": "10 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "10 ml", "max_contains_weight": "10 kg", "moves": 80 }
     ],
-    "looks_like": "portal"
+    "looks_like": "portal",
+    "armor": { "coverage": 30, "covers": [ "torso" ], "encumbrance": 10 }
   },
   {
     "id": "afs_boot_arrow_quiver",
@@ -85,12 +81,10 @@
     "material": [ "leather" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "torso" ],
-    "coverage": 20,
-    "encumbrance": 5,
     "material_thickness": 1,
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "arrow": 40 } } ],
-    "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY" ]
+    "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY" ],
+    "armor": { "coverage": 20, "covers": [ "torso" ], "encumbrance": 5 }
   },
   {
     "id": "afs_boot_bolt_quiver",
@@ -104,12 +98,10 @@
     "material": [ "leather" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "torso" ],
-    "coverage": 20,
-    "encumbrance": 5,
     "material_thickness": 1,
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "bolt": 40 } } ],
-    "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY" ]
+    "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY" ],
+    "armor": { "coverage": 20, "covers": [ "torso" ], "encumbrance": 5 }
   },
   {
     "id": "daypack",
@@ -124,17 +116,15 @@
     "price": "50 USD",
     "price_postapoc": "100 USD",
     "material": [ "plastic" ],
-    "covers": [ "torso" ],
-    "coverage": 50,
     "material_thickness": 1,
-    "encumbrance": 10,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "5 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "5 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "15 L", "max_contains_weight": "30 kg", "moves": 120 }
     ],
     "flags": [ "BELTED", "ONLY_ONE", "OVERSIZE", "STURDY" ],
-    "looks_like": "backpack"
+    "looks_like": "backpack",
+    "armor": { "coverage": 50, "covers": [ "torso" ], "encumbrance": 10 }
   },
   {
     "id": "afs_blatant_half_life_reference",
@@ -148,10 +138,7 @@
     "price": "1000 kUSD",
     "price_postapoc": "500 USD",
     "material": [ "superalloy", "kevlar" ],
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 100,
     "material_thickness": 2,
-    "encumbrance": 9,
     "warmth": 20,
     "environmental_protection": 5,
     "flags": [
@@ -169,7 +156,12 @@
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "5 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "5 kg", "moves": 80 }
     ],
-    "looks_like": "depowered_armor"
+    "looks_like": "depowered_armor",
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 9
+    }
   },
   {
     "id": "afs_quilt",
@@ -183,14 +175,16 @@
     "material": [ "wool" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "torse", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 40,
     "warmth": 100,
     "material_thickness": 3,
     "environmental_protection": 2,
     "flags": [ "OVERSIZE", "OUTER", "ALLOWS_NATURAL_ATTACKS" ],
-    "looks_like": "down_blanket"
+    "looks_like": "down_blanket",
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torse", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 40
+    }
   },
   {
     "id": "afs_quilt_patchwork",
@@ -198,8 +192,8 @@
     "copy-from": "afs_quilt",
     "name": { "str": "patchwork quilt" },
     "description": "A huge, patchwork wool quilt.  Very, very warm.",
-    "encumbrance": 50,
-    "warmth": 90
+    "warmth": 90,
+    "armor": { "encumbrance": 50 }
   },
   {
     "id": "ski_jacket",
@@ -212,9 +206,6 @@
     "material": [ "cotton", "plastic" ],
     "symbol": "[",
     "color": "light_blue",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 95,
-    "encumbrance": 14,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "700 ml", "max_contains_weight": "3 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "700 ml", "max_contains_weight": "3 kg", "moves": 80 }
@@ -223,7 +214,8 @@
     "material_thickness": 5,
     "environmental_protection": 3,
     "flags": [ "VARSIZE", "POCKETS", "HOOD", "COLLAR", "OUTER" ],
-    "looks_like": "coat_winter"
+    "looks_like": "coat_winter",
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 14 }
   },
   {
     "id": "afs_survivor_belt",
@@ -251,12 +243,10 @@
     "material": [ "steel" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "head", "mouth", "eyes" ],
-    "coverage": 100,
-    "encumbrance": 30,
     "material_thickness": 3,
     "qualities": [ [ "GLARE", 3 ] ],
-    "flags": [ "SUN_GLASSES", "FLASH_PROTECTION" ]
+    "flags": [ "SUN_GLASSES", "FLASH_PROTECTION" ],
+    "armor": { "coverage": 100, "covers": [ "head", "mouth", "eyes" ], "encumbrance": 30 }
   },
   {
     "id": "welding_mask_crude",
@@ -270,12 +260,10 @@
     "material": [ "steel" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "eyes", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 60,
     "material_thickness": 2,
     "qualities": [ [ "GLARE", 2 ] ],
-    "flags": [ "SUN_GLASSES", "FLASH_PROTECTION", "BLIND" ]
+    "flags": [ "SUN_GLASSES", "FLASH_PROTECTION", "BLIND" ],
+    "armor": { "coverage": 100, "covers": [ "eyes", "mouth" ], "encumbrance": 60 }
   },
   {
     "id": "afs_brigandine",
@@ -289,12 +277,10 @@
     "material": [ "leather", "steel" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso" ],
-    "coverage": 100,
-    "encumbrance": 16,
     "warmth": 25,
     "material_thickness": 3,
-    "flags": [ "RAINPROOF", "STURDY", "OUTER", "ONLY_ONE", "VARSIZE" ]
+    "flags": [ "RAINPROOF", "STURDY", "OUTER", "ONLY_ONE", "VARSIZE" ],
+    "armor": { "coverage": 100, "covers": [ "torso" ], "encumbrance": 16 }
   },
   {
     "id": "afs_brigandine_crafted",
@@ -308,12 +294,10 @@
     "material": [ "cotton", "steel" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "torso" ],
-    "coverage": 95,
-    "encumbrance": 14,
     "warmth": 20,
     "material_thickness": 2,
-    "flags": [ "OUTER", "VARSIZE" ]
+    "flags": [ "OUTER", "VARSIZE" ],
+    "armor": { "coverage": 95, "covers": [ "torso" ], "encumbrance": 14 }
   },
   {
     "id": "afs_titanium_vest",
@@ -327,10 +311,8 @@
     "material": [ "titanium", "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "torso" ],
-    "coverage": 80,
-    "encumbrance": 4,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 80, "covers": [ "torso" ], "encumbrance": 4 }
   },
   {
     "id": "afs_mbr_titanium",
@@ -346,9 +328,6 @@
     "material": [ "kevlar", "titanium" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "torso" ],
-    "coverage": 85,
-    "encumbrance": 7,
     "warmth": 15,
     "material_thickness": 3,
     "use_action": { "type": "holster", "holster_prompt": "Stash ammo", "holster_msg": "You stash your %s." },
@@ -356,6 +335,7 @@
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "5 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "5 kg", "moves": 80 }
     ],
-    "flags": [ "STURDY", "OUTER" ]
+    "flags": [ "STURDY", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": 7 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Community_Aftershock/items/afs_tools.json
+++ b/data/Unleash_The_Mods/Working_mods/Community_Aftershock/items/afs_tools.json
@@ -211,10 +211,8 @@
     "copy-from": "UPS_off",
     "name": { "str": "UPS", "str_pl": "UPS's" },
     "description": "This is a unified power supply, or UPS.  It is a device developed jointly by military and scientific interests for use in combat and the field.  The UPS is designed to power armor and some guns, but drains batteries quickly.  It can be worn around to either leg for ease of access, and it's been waterproofed to protect the delicate electronics.",
-    "coverage": 5,
-    "encumbrance": 2,
-    "covers": [ "leg_l", "leg_r" ],
-    "flags": [ "NO_UNLOAD", "RECHARGE", "WAIST", "FRAGILE", "OVERSIZE", "WATERPROOF" ]
+    "flags": [ "NO_UNLOAD", "RECHARGE", "WAIST", "FRAGILE", "OVERSIZE", "WATERPROOF" ],
+    "armor": { "coverage": 5, "covers": [ "leg_l", "leg_r" ], "encumbrance": 2 }
   },
   {
     "id": "adv_UPS_off",
@@ -222,10 +220,8 @@
     "copy-from": "adv_UPS_off",
     "name": { "str": "advanced UPS", "str_pl": "advanced UPS's" },
     "description": "This is an advanced version of the unified power supply, or UPS.  This device has been significantly redesigned to provide better efficiency as well as to consume plutonium fuel cells rather than batteries, and is both slimmer and lighter to wear.  Sadly, its plutonium reactor can't be charged in UPS charging station.",
-    "coverage": 5,
-    "encumbrance": 1,
-    "covers": [ "leg_l", "leg_r" ],
-    "flags": [ "WAIST", "FRAGILE", "OVERSIZE" ]
+    "flags": [ "WAIST", "FRAGILE", "OVERSIZE" ],
+    "armor": { "coverage": 5, "covers": [ "leg_l", "leg_r" ], "encumbrance": 1 }
   },
   {
     "id": "afs_bionic_power_mod",

--- a/data/Unleash_The_Mods/Working_mods/Crude_Improvised/armor.json
+++ b/data/Unleash_The_Mods/Working_mods/Crude_Improvised/armor.json
@@ -12,10 +12,6 @@
     "symbol": "[",
     "looks_like": "ragpouch",
     "color": "dark_gray",
-    "covers": [ "torso" ],
-    "coverage": 30,
-    "encumbrance": 1,
-    "max_encumbrance": 25,
     "warmth": 5,
     "material_thickness": 1,
     "pocket_data": [
@@ -26,6 +22,7 @@
         "max_item_length": "40 cm",
         "moves": 300
       }
-    ]
+    ],
+    "armor": { "coverage": 30, "covers": [ "torso" ], "encumbrance": [ 1, 25 ] }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Cursed_thighs/thigh_high_quiver.json
+++ b/data/Unleash_The_Mods/Working_mods/Cursed_thighs/thigh_high_quiver.json
@@ -12,15 +12,13 @@
     "material": [ "leather" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "torso" ],
-    "coverage": 30,
-    "encumbrance": 25,
     "warmth": 5,
     "material_thickness": 3,
     "environmental_protection": 2,
     "use_action": [ { "menu_text": "Curse.", "type": "transform", "target": "thigh_high_boots", "msg": "You make a terrible plan..." } ],
     "pocket_data": [ { "ammo_restriction": { "arrow": 20, "bolt": 20 }, "moves": 20 } ],
-    "flags": [ "VARSIZE", "WATERPROOF", "FANCY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "FANCY" ],
+    "armor": { "coverage": 30, "covers": [ "torso" ], "encumbrance": 25 }
   },
   {
     "id": "thigh_high_boots",
@@ -35,9 +33,6 @@
     "material": [ "leather" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "foot_l", "foot_r", "leg_l", "leg_r" ],
-    "coverage": 80,
-    "encumbrance": 25,
     "warmth": 20,
     "material_thickness": 3,
     "environmental_protection": 2,
@@ -47,6 +42,7 @@
       "target": "thigh_high_boots_quiver",
       "msg": "You make a terrible plan..."
     },
-    "flags": [ "VARSIZE", "WATERPROOF", "FANCY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "FANCY" ],
+    "armor": { "coverage": 80, "covers": [ "foot_l", "foot_r", "leg_l", "leg_r" ], "encumbrance": 25 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Dumb_Sabaton_Memes/items.json
+++ b/data/Unleash_The_Mods/Working_mods/Dumb_Sabaton_Memes/items.json
@@ -49,12 +49,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 80,
-    "encumbrance": 8,
     "warmth": 10,
     "material_thickness": 2,
-    "flags": [ "SKINTIGHT", "VARSIZE", "FANCY" ]
+    "flags": [ "SKINTIGHT", "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 80, "covers": [ "leg_l", "leg_r" ], "encumbrance": 8 }
   },
   {
     "id": "helmet_szyszak",
@@ -69,13 +67,11 @@
     "material": [ "steel", "leather" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "head", "eyes" ],
-    "coverage": 80,
-    "encumbrance": 30,
     "warmth": 10,
     "material_thickness": 4,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "FANCY", "VARSIZE", "STURDY", "SUN_GLASSES" ]
+    "flags": [ "FANCY", "VARSIZE", "STURDY", "SUN_GLASSES" ],
+    "armor": { "coverage": 80, "covers": [ "head", "eyes" ], "encumbrance": 30 }
   },
   {
     "id": "wings_ornamental",
@@ -88,11 +84,9 @@
     "material": [ "wood", "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "torso" ],
-    "coverage": 20,
-    "encumbrance": 10,
     "warmth": 5,
     "material_thickness": 2,
-    "flags": [ "BELTED", "SUPER_FANCY", "BLOCK_WHILE_WORN" ]
+    "flags": [ "BELTED", "SUPER_FANCY", "BLOCK_WHILE_WORN" ],
+    "armor": { "coverage": 20, "covers": [ "torso" ], "encumbrance": 10 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Engineering_Essentials/armor.json
+++ b/data/Unleash_The_Mods/Working_mods/Engineering_Essentials/armor.json
@@ -12,9 +12,6 @@
     "symbol": "[",
     "looks_like": "leather_belt",
     "color": "dark_gray",
-    "covers": [ "torso" ],
-    "coverage": 10,
-    "encumbrance": 1,
     "material_thickness": 1,
     "pocket_data": [
       {
@@ -39,7 +36,8 @@
         "moves": 20
       }
     ],
-    "flags": [ "WATER_FRIENDLY", "WAIST", "OVERSIZE" ]
+    "flags": [ "WATER_FRIENDLY", "WAIST", "OVERSIZE" ],
+    "armor": { "coverage": 10, "covers": [ "torso" ], "encumbrance": 1 }
   },
   {
     "id": "bandolier_wrist",
@@ -54,10 +52,7 @@
     "symbol": "[",
     "looks_like": "leather_belt",
     "color": "dark_gray",
-    "covers": [ "hand_l", "hand_r" ],
     "sided": true,
-    "coverage": 5,
-    "encumbrance": 1,
     "material_thickness": 1,
     "pocket_data": [
       {
@@ -82,7 +77,8 @@
         "moves": 20
       }
     ],
-    "flags": [ "WATER_FRIENDLY", "BELTED", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "WATER_FRIENDLY", "BELTED", "ALLOWS_NATURAL_ATTACKS" ],
+    "armor": { "coverage": 5, "covers": [ "hand_l", "hand_r" ], "encumbrance": 1 }
   },
   {
     "id": "goggles_welding",
@@ -109,9 +105,6 @@
     "material": [ "plastic" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "head" ],
-    "coverage": 15,
-    "encumbrance": 5,
     "warmth": 5,
     "material_thickness": 4,
     "environmental_protection": 6,
@@ -122,6 +115,7 @@
       "target": "goggles_welding",
       "menu_text": "Cover the eyes"
     },
-    "flags": [ "BELTED", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "BELTED", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS" ],
+    "armor": { "coverage": 15, "covers": [ "head" ], "encumbrance": 5 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Forgotten_Races/all_items_large.json
+++ b/data/Unleash_The_Mods/Working_mods/Forgotten_Races/all_items_large.json
@@ -14,12 +14,10 @@
     "cutting": 0,
     "warmth": 7,
     "environmental_protection": 0,
-    "encumbrance": 0,
     "bashing": 0,
-    "coverage": 100,
     "material_thickness": 1,
     "phase": "solid",
-    "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ],
-    "flags": [ "VARSIZE" ]
+    "flags": [ "VARSIZE" ],
+    "armor": { "coverage": 100, "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ], "encumbrance": 0 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Forgotten_Races/all_items_small.json
+++ b/data/Unleash_The_Mods/Working_mods/Forgotten_Races/all_items_small.json
@@ -5,7 +5,6 @@
     "name": { "str": "small rag tunic" },
     "weight": "450 g",
     "color": "light_red",
-    "covers": [ "torso" ],
     "symbol": "[",
     "description": "A poorly made tunic sized for a young child, it is too tight to wear comfortably.",
     "price": "250 cent",
@@ -13,11 +12,10 @@
     "volume": "750 ml",
     "warmth": 10,
     "phase": "solid",
-    "encumbrance": 15,
     "bashing": 0,
     "flags": [  ],
-    "coverage": 35,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 35, "covers": [ "torso" ], "encumbrance": 15 }
   },
   {
     "id": "small_cap",

--- a/data/Unleash_The_Mods/Working_mods/Kingsman/apparel/armor.json
+++ b/data/Unleash_The_Mods/Working_mods/Kingsman/apparel/armor.json
@@ -13,13 +13,11 @@
     "material": [ "leather" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 90,
-    "encumbrance": 12,
     "warmth": 20,
     "qualities": [ [ "CUT", 2 ] ],
     "material_thickness": 3,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY", "SHEATH_SWORD", "KNIFE_TIP" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY", "SHEATH_SWORD", "KNIFE_TIP" ],
+    "armor": { "coverage": 90, "covers": [ "foot_l", "foot_r" ], "encumbrance": 12 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Kingsman/apparel/clothing.json
+++ b/data/Unleash_The_Mods/Working_mods/Kingsman/apparel/clothing.json
@@ -10,9 +10,6 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 90,
-    "encumbrance": 8,
     "warmth": 20,
     "material_thickness": 2,
     "pocket_data": [
@@ -20,7 +17,8 @@
       { "pocket_type": "CONTAINER", "max_contains_volume": "750 ml", "max_contains_weight": "2 kg", "moves": 30 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "250 ml", "max_contains_weight": "2 kg", "moves": 50 }
     ],
-    "flags": [ "VARSIZE", "POCKETS", "OUTER" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 8 }
   },
   {
     "id": "suit_jacket_kingsman",
@@ -33,16 +31,14 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "light_blue",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 90,
-    "encumbrance": 3,
     "warmth": 15,
     "material_thickness": 2,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "750 ml", "max_contains_weight": "2 kg", "moves": 30 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "750 ml", "max_contains_weight": "2 kg", "moves": 30 }
     ],
-    "flags": [ "VARSIZE", "POCKETS", "OUTER" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 3 }
   },
   {
     "id": "overcoat_statesman",
@@ -55,16 +51,14 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 90,
-    "encumbrance": 8,
     "warmth": 20,
     "material_thickness": 2,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "2 kg", "moves": 30 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "2 kg", "moves": 30 }
     ],
-    "flags": [ "VARSIZE", "POCKETS", "OUTER" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 8 }
   },
   {
     "id": "suit_jacket_statesman",
@@ -77,15 +71,13 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "light_blue",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 90,
-    "encumbrance": 3,
     "warmth": 15,
     "material_thickness": 2,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "2 kg", "moves": 30 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "2 kg", "moves": 30 }
     ],
-    "flags": [ "VARSIZE", "POCKETS", "OUTER" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 3 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Kingsman/apparel/other.json
+++ b/data/Unleash_The_Mods/Working_mods/Kingsman/apparel/other.json
@@ -11,13 +11,11 @@
     "material": [ "glass", "stainless_steel" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "eyes" ],
-    "coverage": 95,
-    "encumbrance": 1,
     "material_thickness": 1,
     "environmental_protection": 1,
     "qualities": [ [ "GLARE", 1 ] ],
-    "flags": [ "FANCY", "WATER_FRIENDLY" ]
+    "flags": [ "FANCY", "WATER_FRIENDLY" ],
+    "armor": { "coverage": 95, "covers": [ "eyes" ], "encumbrance": 1 }
   },
   {
     "id": "watch_kingsman",
@@ -31,9 +29,8 @@
     "material": [ "steel", "silver" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "hand_l", "hand_r" ],
-    "coverage": 5,
-    "flags": [ "WATCH", "FANCY", "BELTED", "FRAGILE", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "WATCH", "FANCY", "BELTED", "FRAGILE", "ALLOWS_NATURAL_ATTACKS" ],
+    "armor": { "coverage": 5, "covers": [ "hand_l", "hand_r" ] }
   },
   {
     "id": "glasses_statesman",
@@ -47,13 +44,11 @@
     "material": [ "glass", "stainless_steel" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "eyes" ],
-    "coverage": 95,
-    "encumbrance": 1,
     "material_thickness": 1,
     "environmental_protection": 1,
     "qualities": [ [ "GLARE", 1 ] ],
-    "flags": [ "FANCY", "WATER_FRIENDLY" ]
+    "flags": [ "FANCY", "WATER_FRIENDLY" ],
+    "armor": { "coverage": 95, "covers": [ "eyes" ], "encumbrance": 1 }
   },
   {
     "id": "watch_statesman",
@@ -67,9 +62,8 @@
     "material": [ "leather", "silver" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "hand_l", "hand_r" ],
-    "coverage": 5,
-    "flags": [ "WATCH", "FANCY", "BELTED", "FRAGILE", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "WATCH", "FANCY", "BELTED", "FRAGILE", "ALLOWS_NATURAL_ATTACKS" ],
+    "armor": { "coverage": 5, "covers": [ "hand_l", "hand_r" ] }
   },
   {
     "id": "hat_statesman",
@@ -82,12 +76,10 @@
     "material": [ "leather" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "head" ],
-    "coverage": 50,
-    "encumbrance": 10,
     "warmth": 7,
     "material_thickness": 2,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "SUN_GLASSES" ]
+    "flags": [ "VARSIZE", "SUN_GLASSES" ],
+    "armor": { "coverage": 50, "covers": [ "head" ], "encumbrance": 10 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Magic_Revamp_Additions/Spells_Override/attunements/Force_Mage.json
+++ b/data/Unleash_The_Mods/Working_mods/Magic_Revamp_Additions/Spells_Override/attunements/Force_Mage.json
@@ -34,9 +34,6 @@
     "to_hit": -10,
     "symbol": "[",
     "color": "brown",
-    "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r", "mouth", "eyes" ],
-    "coverage": 100,
-    "encumbrance": 0,
     "environmental_protection": 2,
     "relic_data": {
       "passive_effects": [
@@ -52,7 +49,12 @@
         }
       ]
     },
-    "flags": [ "WATERPROOF", "TRADER_AVOID", "SEMITANGIBLE", "ONLY_ONE", "OVERSIZE", "AURA" ]
+    "flags": [ "WATERPROOF", "TRADER_AVOID", "SEMITANGIBLE", "ONLY_ONE", "OVERSIZE", "AURA" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r", "mouth", "eyes" ],
+      "encumbrance": 0
+    }
   },
   {
     "id": "force_magical_armor",

--- a/data/Unleash_The_Mods/Working_mods/Medieval_Mod_Reborn/items/armor.json
+++ b/data/Unleash_The_Mods/Working_mods/Medieval_Mod_Reborn/items/armor.json
@@ -13,13 +13,11 @@
     "material": [ "wood" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ],
     "sided": true,
-    "coverage": 90,
-    "encumbrance": 15,
     "material_thickness": 2,
     "techniques": [ "WBLOCK_2" ],
-    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ]
+    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ],
+    "armor": { "coverage": 90, "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ], "encumbrance": 15 }
   },
   {
     "id": "shield_wooden_large",
@@ -35,13 +33,11 @@
     "material": [ "wood" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ],
     "sided": true,
-    "coverage": 100,
-    "encumbrance": 25,
     "material_thickness": 2,
     "techniques": [ "WBLOCK_3" ],
-    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ]
+    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ],
+    "armor": { "coverage": 100, "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ], "encumbrance": 25 }
   },
   {
     "id": "shield_heater",
@@ -57,13 +53,11 @@
     "material": [ "wood" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ],
     "sided": true,
-    "coverage": 90,
-    "encumbrance": 10,
     "material_thickness": 3,
     "techniques": [ "WBLOCK_2" ],
-    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ]
+    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ],
+    "armor": { "coverage": 90, "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ], "encumbrance": 10 }
   },
   {
     "id": "shield_kite",
@@ -80,13 +74,11 @@
     "material": [ "wood" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ],
     "sided": true,
-    "coverage": 95,
-    "encumbrance": 20,
     "material_thickness": 3,
     "techniques": [ "WBLOCK_3" ],
-    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ]
+    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ],
+    "armor": { "coverage": 95, "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ], "encumbrance": 20 }
   },
   {
     "id": "shield_round",
@@ -101,13 +93,11 @@
     "material": [ "wood", "iron" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ],
     "sided": true,
-    "coverage": 90,
-    "encumbrance": 15,
     "material_thickness": 3,
     "techniques": [ "WBLOCK_2" ],
-    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ]
+    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ],
+    "armor": { "coverage": 90, "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ], "encumbrance": 15 }
   },
   {
     "id": "shield_hoplon",
@@ -123,13 +113,11 @@
     "material": [ "wood", "bronze" ],
     "symbol": "[",
     "color": "yellow",
-    "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ],
     "sided": true,
-    "coverage": 90,
-    "encumbrance": 20,
     "material_thickness": 4,
     "techniques": [ "WBLOCK_2" ],
-    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ]
+    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ],
+    "armor": { "coverage": 90, "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ], "encumbrance": 20 }
   },
   {
     "id": "shield_scutum",
@@ -145,13 +133,11 @@
     "material": [ "wood", "iron" ],
     "symbol": "[",
     "color": "red",
-    "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ],
     "sided": true,
-    "coverage": 100,
-    "encumbrance": 25,
     "material_thickness": 4,
     "techniques": [ "WBLOCK_3" ],
-    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ]
+    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ],
+    "armor": { "coverage": 100, "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ], "encumbrance": 25 }
   },
   {
     "id": "shield_buckler",
@@ -166,13 +152,11 @@
     "material": [ "steel" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ],
     "sided": true,
-    "coverage": 80,
-    "encumbrance": 10,
     "material_thickness": 3,
     "techniques": [ "WBLOCK_2" ],
-    "flags": [ "OVERSIZE", "STURDY", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ]
+    "flags": [ "OVERSIZE", "STURDY", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ],
+    "armor": { "coverage": 80, "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ], "encumbrance": 10 }
   },
   {
     "id": "helmet_szyszak",
@@ -187,13 +171,11 @@
     "material": [ "steel", "leather" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "head", "eyes" ],
-    "coverage": 80,
-    "encumbrance": 30,
     "warmth": 10,
     "material_thickness": 4,
     "techniques": [ "WBLOCK_2" ],
-    "flags": [ "FANCY", "VARSIZE", "STURDY", "SUN_GLASSES" ]
+    "flags": [ "FANCY", "VARSIZE", "STURDY", "SUN_GLASSES" ],
+    "armor": { "coverage": 80, "covers": [ "head", "eyes" ], "encumbrance": 30 }
   },
   {
     "id": "wings_ornamental",
@@ -206,12 +188,10 @@
     "material": [ "wood", "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "torso" ],
-    "coverage": 20,
-    "encumbrance": 10,
     "warmth": 5,
     "material_thickness": 2,
-    "flags": [ "WAIST", "SUPER_FANCY", "BLOCK_WHILE_WORN" ]
+    "flags": [ "WAIST", "SUPER_FANCY", "BLOCK_WHILE_WORN" ],
+    "armor": { "coverage": 20, "covers": [ "torso" ], "encumbrance": 10 }
   },
   {
     "id": "gambeson",

--- a/data/Unleash_The_Mods/Working_mods/Misc_Gear/g_armor.json
+++ b/data/Unleash_The_Mods/Working_mods/Misc_Gear/g_armor.json
@@ -9,16 +9,15 @@
     "weight": "97 g",
     "to_hit": 0,
     "color": "yellow",
-    "encumbrance": 0,
     "price": "10 USD",
     "material": [ "steel", "cotton" ],
-    "coverage": 0,
     "symbol": "[",
     "bashing": 0,
     "cutting": 0,
     "warmth": 0,
     "environmental_protection": 0,
-    "phase": "solid"
+    "phase": "solid",
+    "armor": { "coverage": 0, "encumbrance": 0 }
   },
   {
     "id": "necklace_teeth",
@@ -30,16 +29,15 @@
     "weight": "16 g",
     "to_hit": 0,
     "color": "dark_gray",
-    "encumbrance": 0,
     "price": "5 USD",
     "material": [ "cotton", "bone" ],
-    "coverage": 0,
     "symbol": "[",
     "bashing": 0,
     "cutting": 0,
     "warmth": 0,
     "environmental_protection": 0,
-    "phase": "solid"
+    "phase": "solid",
+    "armor": { "coverage": 0, "encumbrance": 0 }
   },
   {
     "id": "necklace_stone",
@@ -51,16 +49,15 @@
     "weight": "148 g",
     "to_hit": 0,
     "color": "dark_gray",
-    "encumbrance": 0,
     "price": "5 USD",
     "material": [ "cotton", "stone" ],
-    "coverage": 0,
     "symbol": "[",
     "bashing": 0,
     "cutting": 0,
     "warmth": 0,
     "environmental_protection": 0,
-    "phase": "solid"
+    "phase": "solid",
+    "armor": { "coverage": 0, "encumbrance": 0 }
   },
   {
     "id": "belt_bullet",
@@ -72,16 +69,15 @@
     "weight": "1130 g",
     "to_hit": 0,
     "color": "yellow",
-    "encumbrance": 0,
     "price": "50 USD",
     "material": [ "steel", "leather" ],
-    "coverage": 0,
     "symbol": "[",
     "bashing": 0,
     "cutting": 0,
     "warmth": 0,
     "environmental_protection": 0,
-    "phase": "solid"
+    "phase": "solid",
+    "armor": { "coverage": 0, "encumbrance": 0 }
   },
   {
     "id": "belt_hands",
@@ -93,10 +89,8 @@
     "weight": "156 g",
     "to_hit": 0,
     "color": "brown",
-    "encumbrance": 0,
     "price": "15 USD",
     "material": [ "leather", "hflesh" ],
-    "coverage": 0,
     "symbol": "[",
     "bashing": 0,
     "cutting": 0,
@@ -114,7 +108,8 @@
       }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Attach what to belt loop?", "holster_msg": "You clip your %s to your %s" },
-    "flags": [ "FANCY", "WAIST", "NO_QUICKDRAW", "WATER_FRIENDLY" ]
+    "flags": [ "FANCY", "WAIST", "NO_QUICKDRAW", "WATER_FRIENDLY" ],
+    "armor": { "coverage": 0, "encumbrance": 0 }
   },
   {
     "id": "belt_bandolier",
@@ -122,15 +117,12 @@
     "name": { "str": "bandolier" },
     "volume": "3 ml",
     "material_thickness": 2,
-    "covers": [ "torso" ],
     "description": "A leather belt to be worn across the torso, with many pockets for decent storage.",
     "weight": "1156 g",
     "to_hit": 0,
     "color": "brown",
-    "encumbrance": 5,
     "price": "150 USD",
     "material": [ "leather", "steel" ],
-    "coverage": 20,
     "symbol": "[",
     "environmental_protection": 0,
     "phase": "solid",
@@ -141,7 +133,8 @@
       { "pocket_type": "CONTAINER", "max_contains_volume": "750 ml", "max_contains_weight": "2 kg", "moves": 30 }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Stash items", "holster_msg": "You stash your %s." },
-    "flags": [ "WATER_FRIENDLY", "BELTED" ]
+    "flags": [ "WATER_FRIENDLY", "BELTED" ],
+    "armor": { "coverage": 20, "covers": [ "torso" ], "encumbrance": 5 }
   },
   {
     "id": "spiked_pauldrons",
@@ -150,7 +143,6 @@
     "category": "armor",
     "weight": "2365 g",
     "color": "dark_gray",
-    "covers": [ "torso" ],
     "to_hit": -1,
     "symbol": "[",
     "description": "Two large steel pauldrons covered with dozens of small sharp spikes, secured to the torso with a set of leather straps.",
@@ -161,11 +153,10 @@
     "warmth": 0,
     "phase": "solid",
     "environmental_protection": 0,
-    "encumbrance": 20,
     "bashing": 4,
     "flags": [ "VARSIZE", "BELTED" ],
-    "coverage": 30,
-    "material_thickness": 4
+    "material_thickness": 4,
+    "armor": { "coverage": 30, "covers": [ "torso" ], "encumbrance": 20 }
   },
   {
     "id": "necklace_picks",
@@ -177,17 +168,16 @@
     "weight": "97 g",
     "to_hit": 0,
     "color": "dark_gray",
-    "encumbrance": 0,
     "price": "10 USD",
     "material": [ "steel", "cotton" ],
-    "coverage": 0,
     "symbol": "[",
     "bashing": 0,
     "cutting": 0,
     "warmth": 0,
     "environmental_protection": 0,
     "phase": "solid",
-    "qualities": [ [ "LOCKPICK", 30 ] ]
+    "qualities": [ [ "LOCKPICK", 30 ] ],
+    "armor": { "coverage": 0, "encumbrance": 0 }
   },
   {
     "id": "steel_bra",
@@ -196,7 +186,6 @@
     "category": "armor",
     "weight": "2365 g",
     "color": "dark_gray",
-    "covers": [ "torso" ],
     "to_hit": -1,
     "symbol": "[",
     "description": "Two steel breast cups, held in place by a series of small leather straps.",
@@ -207,11 +196,10 @@
     "warmth": 0,
     "phase": "solid",
     "environmental_protection": 0,
-    "encumbrance": 10,
     "bashing": 1,
     "flags": [ "VARSIZE", "BELTED" ],
-    "coverage": 20,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 20, "covers": [ "torso" ], "encumbrance": 10 }
   },
   {
     "id": "glasses_vertigo",
@@ -219,7 +207,6 @@
     "name": { "str": "pair of vertigo glasses", "str_pl": "pairs of vertigo glasses" },
     "weight": "30 g",
     "color": "yellow",
-    "covers": [ "eyes" ],
     "to_hit": -2,
     "symbol": "[",
     "description": "A pair of glasses with a rectangular green lens and a circular red lens.",
@@ -230,11 +217,10 @@
     "warmth": 0,
     "phase": "solid",
     "environmental_protection": 1,
-    "encumbrance": 0,
     "bashing": 0,
     "flags": [ "WATER_FRIENDLY", "LENS", "SUN_GLASSES" ],
     "qualities": [ [ "GLARE", 1 ] ],
-    "coverage": 75,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 75, "covers": [ "eyes" ], "encumbrance": 0 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Miso_touyou_touhou/miso_Touhou/items/armor/hero.json
+++ b/data/Unleash_The_Mods/Working_mods/Miso_touyou_touhou/miso_Touhou/items/armor/hero.json
@@ -10,9 +10,6 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 100,
-    "encumbrance": 16,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2800 ml", "max_contains_weight": "4 kg", "moves": 275 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "3 L", "max_contains_weight": "5 kg", "moves": 315 }
@@ -20,7 +17,8 @@
     "warmth": 15,
     "material_thickness": 9,
     "environmental_protection": 3,
-    "flags": [ "VARSIZE", "POCKETS", "FANCY", "OVERSIZE", "STURDY" ]
+    "flags": [ "VARSIZE", "POCKETS", "FANCY", "OVERSIZE", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 16 }
   },
   {
     "id": "sumireko_cloth",
@@ -33,12 +31,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "light_red",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 100,
-    "encumbrance": 8,
     "warmth": 35,
     "material_thickness": 4,
     "environmental_protection": 2,
-    "flags": [ "OVERSIZE", "FANCY", "POCKETS", "WATERPROOF", "COLLAR", "RAINPROOF", "OUTER" ]
+    "flags": [ "OVERSIZE", "FANCY", "POCKETS", "WATERPROOF", "COLLAR", "RAINPROOF", "OUTER" ],
+    "armor": { "coverage": 100, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 8 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Miso_touyou_touhou/miso_Touhou/items/armor/koumakyou.json
+++ b/data/Unleash_The_Mods/Working_mods/Miso_touyou_touhou/miso_Touhou/items/armor/koumakyou.json
@@ -10,11 +10,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "light_red",
-    "covers": [ "head" ],
-    "coverage": 5,
     "warmth": 0,
     "material_thickness": 1,
-    "flags": [ "SKINTIGHT", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS", "ZERO_WEIGHT" ]
+    "flags": [ "SKINTIGHT", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS", "ZERO_WEIGHT" ],
+    "armor": { "coverage": 5, "covers": [ "head" ] }
   },
   {
     "id": "cirno_ribbon",
@@ -27,11 +26,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "head" ],
-    "coverage": 5,
     "warmth": 0,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "SKINTIGHT", "FANCY" ]
+    "flags": [ "VARSIZE", "SKINTIGHT", "FANCY" ],
+    "armor": { "coverage": 5, "covers": [ "head" ] }
   },
   {
     "id": "cirno_wing1",
@@ -44,11 +42,13 @@
     "material": [ "glass" ],
     "symbol": "[",
     "color": "light_blue",
-    "covers": [ "torso", "head", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 0,
     "warmth": 50,
     "material_thickness": 0,
-    "flags": [ "VARSIZE", "WATER_FRIENDLY", "SKINTIGHT", "ZERO_WEIGHT" ]
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "SKINTIGHT", "ZERO_WEIGHT" ],
+    "armor": {
+      "coverage": 0,
+      "covers": [ "torso", "head", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
+    }
   },
   {
     "id": "cirno_wing2",
@@ -61,11 +61,13 @@
     "material": [ "glass" ],
     "symbol": "[",
     "color": "light_blue",
-    "covers": [ "torso", "head", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 0,
     "warmth": 50,
     "material_thickness": 0,
-    "flags": [ "VARSIZE", "WATER_FRIENDLY", "SKINTIGHT", "ZERO_WEIGHT" ]
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "SKINTIGHT", "ZERO_WEIGHT" ],
+    "armor": {
+      "coverage": 0,
+      "covers": [ "torso", "head", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
+    }
   },
   {
     "id": "cirno_wing3",
@@ -78,11 +80,13 @@
     "material": [ "glass" ],
     "symbol": "[",
     "color": "light_blue",
-    "covers": [ "torso", "head", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 0,
     "warmth": 50,
     "material_thickness": 0,
-    "flags": [ "VARSIZE", "WATER_FRIENDLY", "SKINTIGHT", "ZERO_WEIGHT" ]
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "SKINTIGHT", "ZERO_WEIGHT" ],
+    "armor": {
+      "coverage": 0,
+      "covers": [ "torso", "head", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
+    }
   },
   {
     "id": "cirno_onepiece",
@@ -95,11 +99,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 85,
     "warmth": 0,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 85, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ] }
   },
   {
     "id": "meirin_dress",
@@ -112,16 +115,14 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "green",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 80,
-    "encumbrance": 7,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "585 ml", "max_contains_weight": "1 kg", "moves": 145 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "585 ml", "max_contains_weight": "1 kg", "moves": 145 }
     ],
     "warmth": 15,
     "material_thickness": 3,
-    "flags": [ "VARSIZE", "FANCY", "STURDY" ]
+    "flags": [ "VARSIZE", "FANCY", "STURDY" ],
+    "armor": { "coverage": 80, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 7 }
   },
   {
     "id": "meirin_jinminbou",
@@ -134,11 +135,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "green",
-    "covers": [ "head" ],
-    "coverage": 45,
     "warmth": 8,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 45, "covers": [ "head" ] }
   },
   {
     "id": "fairy_maid_dress",
@@ -151,16 +151,14 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 68,
-    "encumbrance": 7,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "300 ml", "max_contains_weight": "775 g", "moves": 15 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "300 ml", "max_contains_weight": "775 g", "moves": 115 }
     ],
     "warmth": 5,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 68, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 7 }
   },
   {
     "id": "patchouli_robe",
@@ -174,9 +172,6 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "magenta",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 90,
-    "encumbrance": 11,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1800 ml", "max_contains_weight": "3 kg", "moves": 165 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1800 ml", "max_contains_weight": "3 kg", "moves": 165 }
@@ -184,7 +179,8 @@
     "warmth": 15,
     "material_thickness": 2,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 11 }
   },
   {
     "id": "patchouli_cap",
@@ -198,12 +194,11 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "magenta",
-    "covers": [ "head" ],
-    "coverage": 90,
     "warmth": 15,
     "material_thickness": 2,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 90, "covers": [ "head" ] }
   },
   {
     "id": "vampir_cloth",
@@ -216,16 +211,18 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso", "head", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 15,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1800 ml", "max_contains_weight": "3 kg", "moves": 165 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1800 ml", "max_contains_weight": "3 kg", "moves": 165 }
     ],
     "warmth": 20,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "RAIN_PROTECT", "OUTER", "ALLOWS_NATURAL_ATTACKS", "STURDY", "OVERSIZE" ]
+    "flags": [ "VARSIZE", "RAIN_PROTECT", "OUTER", "ALLOWS_NATURAL_ATTACKS", "STURDY", "OVERSIZE" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "head", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 15
+    }
   },
   {
     "id": "scarlet_cap",
@@ -239,11 +236,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "pink",
-    "covers": [ "head" ],
-    "coverage": 90,
     "warmth": 15,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "FANCY", "ALLOWS_NATURAL_ATTACKS", "OVERSIZE" ]
+    "flags": [ "VARSIZE", "FANCY", "ALLOWS_NATURAL_ATTACKS", "OVERSIZE" ],
+    "armor": { "coverage": 90, "covers": [ "head" ] }
   },
   {
     "id": "remilia_dress",
@@ -257,12 +253,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "pink",
-    "covers": [ "torso", "leg_l", "leg_r" ],
-    "coverage": 85,
-    "encumbrance": 7,
     "warmth": 15,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "FANCY", "ALLOWS_NATURAL_ATTACKS", "OVERSIZE" ]
+    "flags": [ "VARSIZE", "FANCY", "ALLOWS_NATURAL_ATTACKS", "OVERSIZE" ],
+    "armor": { "coverage": 85, "covers": [ "torso", "leg_l", "leg_r" ], "encumbrance": 7 }
   },
   {
     "id": "frandre_dress1",
@@ -276,12 +270,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "torso" ],
-    "coverage": 80,
-    "encumbrance": 0,
     "warmth": 10,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "ALLOWS_NATURAL_ATTACKS", "OVERSIZE", "SKINTIGHT" ]
+    "flags": [ "VARSIZE", "ALLOWS_NATURAL_ATTACKS", "OVERSIZE", "SKINTIGHT" ],
+    "armor": { "coverage": 80, "covers": [ "torso" ], "encumbrance": 0 }
   },
   {
     "id": "frandre_dress2",
@@ -295,12 +287,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "red",
-    "covers": [ "torso" ],
-    "coverage": 75,
-    "encumbrance": 0,
     "warmth": 8,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "FANCY", "ALLOWS_NATURAL_ATTACKS", "OVERSIZE" ]
+    "flags": [ "VARSIZE", "FANCY", "ALLOWS_NATURAL_ATTACKS", "OVERSIZE" ],
+    "armor": { "coverage": 75, "covers": [ "torso" ], "encumbrance": 0 }
   },
   {
     "id": "frandre_skirt",
@@ -314,11 +304,9 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "red",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 60,
-    "encumbrance": 1,
     "warmth": 8,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "FANCY", "ALLOWS_NATURAL_ATTACKS", "OVERSIZE" ]
+    "flags": [ "VARSIZE", "FANCY", "ALLOWS_NATURAL_ATTACKS", "OVERSIZE" ],
+    "armor": { "coverage": 60, "covers": [ "leg_l", "leg_r" ], "encumbrance": 1 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Miso_touyou_touhou/miso_Touhou/items/armor/other.json
+++ b/data/Unleash_The_Mods/Working_mods/Miso_touyou_touhou/miso_Touhou/items/armor/other.json
@@ -10,9 +10,6 @@
     "material": [ "chitin" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "torso" ],
-    "coverage": 0,
-    "encumbrance": 0,
     "warmth": 0,
     "material_thickness": 0,
     "use_action": {
@@ -20,7 +17,8 @@
       "target": "wriggle_lamp02",
       "msg": "A chemical reaction occurred to cause the light emitter to function."
     },
-    "flags": [ "VARSIZE", "WATER_FRIENDLY", "WAIST", "OVERSIZE", "ZERO_WEIGHT" ]
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "WAIST", "OVERSIZE", "ZERO_WEIGHT" ],
+    "armor": { "coverage": 0, "covers": [ "torso" ], "encumbrance": 0 }
   },
   {
     "id": "wriggle_lamp02",
@@ -33,13 +31,11 @@
     "material": [ "chitin" ],
     "symbol": "[",
     "color": "yellow",
-    "covers": [ "torso" ],
-    "coverage": 0,
-    "encumbrance": 0,
     "warmth": 0,
     "material_thickness": 0,
     "use_action": { "type": "transform", "target": "wriggle_lamp01", "msg": "Stopped the light emitter function." },
-    "flags": [ "VARSIZE", "WATER_FRIENDLY", "WAIST", "LIGHT_140", "OVERSIZE", "ZERO_WEIGHT" ]
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "WAIST", "LIGHT_140", "OVERSIZE", "ZERO_WEIGHT" ],
+    "armor": { "coverage": 0, "covers": [ "torso" ], "encumbrance": 0 }
   },
   {
     "id": "wriggle_skirt",
@@ -52,15 +48,14 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 50,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "275 ml", "max_contains_weight": "1 kg", "moves": 90 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "275 ml", "max_contains_weight": "1 kg", "moves": 90 }
     ],
     "warmth": 10,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 50, "covers": [ "leg_l", "leg_r" ] }
   },
   {
     "id": "mistia_cap",
@@ -74,12 +69,11 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "head" ],
-    "coverage": 95,
     "warmth": 15,
     "material_thickness": 2,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "OVERSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "OVERSIZE", "FANCY" ],
+    "armor": { "coverage": 95, "covers": [ "head" ] }
   },
   {
     "id": "mistia_dress",
@@ -92,16 +86,14 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso", "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 6,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "645 ml", "max_contains_weight": "1200 g", "moves": 115 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "645 ml", "max_contains_weight": "1200 g", "moves": 115 }
     ],
     "warmth": 15,
     "material_thickness": 3,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 95, "covers": [ "torso", "leg_l", "leg_r" ], "encumbrance": 6 }
   },
   {
     "id": "mistia_strap_shoes",
@@ -114,13 +106,11 @@
     "material": [ "leather" ],
     "symbol": "[",
     "color": "light_blue",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 80,
-    "encumbrance": 16,
     "warmth": 15,
     "material_thickness": 2,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 80, "covers": [ "foot_l", "foot_r" ], "encumbrance": 16 }
   },
   {
     "id": "keine_cap",
@@ -134,12 +124,11 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "head" ],
-    "coverage": 85,
     "warmth": 10,
     "material_thickness": 2,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "OVERSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "OVERSIZE", "FANCY" ],
+    "armor": { "coverage": 85, "covers": [ "head" ] }
   },
   {
     "id": "keine_dress",
@@ -152,16 +141,14 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "magenta",
-    "covers": [ "torso", "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 8,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "645 ml", "max_contains_weight": "1200 g", "moves": 115 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "645 ml", "max_contains_weight": "1200 g", "moves": 115 }
     ],
     "warmth": 10,
     "material_thickness": 3,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 95, "covers": [ "torso", "leg_l", "leg_r" ], "encumbrance": 8 }
   },
   {
     "id": "kosuzu_clamp",
@@ -174,10 +161,10 @@
     "material": [ "iron" ],
     "symbol": "[",
     "color": "yellow",
-    "coverage": 0,
     "warmth": 0,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "FANCY", "SKINTIGHT", "OVERSIZE", "ZERO_WEIGHT" ]
+    "flags": [ "VARSIZE", "FANCY", "SKINTIGHT", "OVERSIZE", "ZERO_WEIGHT" ],
+    "armor": { "coverage": 0 }
   },
   {
     "id": "kosuzu_kimono",
@@ -190,9 +177,6 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "light_red",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 100,
-    "encumbrance": 3,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "575 ml", "max_contains_weight": "1500 g", "moves": 110 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "575 ml", "max_contains_weight": "1500 g", "moves": 110 }
@@ -200,7 +184,8 @@
     "warmth": 15,
     "material_thickness": 2,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 100, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 3 }
   },
   {
     "id": "kosuzu_skirt",
@@ -213,13 +198,11 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "green",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 8,
     "warmth": 15,
     "material_thickness": 2,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r" ], "encumbrance": 8 }
   },
   {
     "id": "kosuzu_apron",
@@ -232,15 +215,14 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "yellow",
-    "covers": [ "torso", "leg_l", "leg_r" ],
-    "coverage": 30,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "575 ml", "max_contains_weight": "1500 g", "moves": 110 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "575 ml", "max_contains_weight": "1500 g", "moves": 110 }
     ],
     "warmth": 1,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "WAIST", "FANCY" ]
+    "flags": [ "VARSIZE", "WAIST", "FANCY" ],
+    "armor": { "coverage": 30, "covers": [ "torso", "leg_l", "leg_r" ] }
   },
   {
     "id": "ekisya_cap",
@@ -254,11 +236,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "head" ],
-    "coverage": 80,
     "warmth": 5,
     "material_thickness": 1,
-    "flags": [ "VARSIZE" ]
+    "flags": [ "VARSIZE" ],
+    "armor": { "coverage": 80, "covers": [ "head" ] }
   },
   {
     "id": "ekisya_kimono",
@@ -271,9 +252,6 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "light_red",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 100,
-    "encumbrance": 7,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "275 ml", "max_contains_weight": "1 kg", "moves": 90 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "275 ml", "max_contains_weight": "1 kg", "moves": 90 }
@@ -281,7 +259,8 @@
     "warmth": 15,
     "material_thickness": 2,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE" ]
+    "flags": [ "VARSIZE" ],
+    "armor": { "coverage": 100, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 7 }
   },
   {
     "id": "akyuu_clamp",
@@ -294,10 +273,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "yellow",
-    "coverage": 0,
     "warmth": 0,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "FANCY", "SKINTIGHT", "OVERSIZE", "ZERO_WEIGHT" ]
+    "flags": [ "VARSIZE", "FANCY", "SKINTIGHT", "OVERSIZE", "ZERO_WEIGHT" ],
+    "armor": { "coverage": 0 }
   },
   {
     "id": "akyuu_kimono01",
@@ -310,13 +289,11 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "light_green",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 100,
-    "encumbrance": 5,
     "warmth": 12,
     "material_thickness": 2,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 100, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 5 }
   },
   {
     "id": "akyuu_kimono02",
@@ -329,9 +306,6 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "yellow",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 100,
-    "encumbrance": 6,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1200 ml", "max_contains_weight": "2 kg", "moves": 135 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1200 ml", "max_contains_weight": "2 kg", "moves": 135 }
@@ -339,7 +313,8 @@
     "warmth": 13,
     "material_thickness": 2,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 100, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 6 }
   },
   {
     "id": "akyuu_skirt",
@@ -352,13 +327,11 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "red",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 8,
     "warmth": 15,
     "material_thickness": 2,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r" ], "encumbrance": 8 }
   },
   {
     "id": "ibukibyou",
@@ -373,16 +346,14 @@
     "material": [ "wood" ],
     "symbol": ")",
     "color": "yellow",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 5,
-    "encumbrance": 2,
     "material_thickness": 2,
     "initial_charges": 0,
     "max_charges": 24,
     "relic_data": {
       "passive_effects": [ { "has": "WIELD", "condition": "ALWAYS", "hit_you_effect": [ { "id": "ARTC_TIME", "once_in": 3 } ] } ]
     },
-    "flags": [ "WAIST", "OVERSIZE" ]
+    "flags": [ "WAIST", "OVERSIZE" ],
+    "armor": { "coverage": 5, "covers": [ "leg_l", "leg_r" ], "encumbrance": 2 }
   },
   {
     "id": "ibuki_ribbon",
@@ -395,10 +366,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "blue",
-    "coverage": 5,
     "warmth": 2,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "FANCY", "SKINTIGHT", "OVERSIZE", "ZERO_WEIGHT" ]
+    "flags": [ "VARSIZE", "FANCY", "SKINTIGHT", "OVERSIZE", "ZERO_WEIGHT" ],
+    "armor": { "coverage": 5 }
   },
   {
     "id": "ibuki_ribbon2",
@@ -411,11 +382,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "red",
-    "covers": [ "head" ],
-    "coverage": 5,
     "warmth": 2,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "FANCY", "SKINTIGHT", "OVERSIZE", "ZERO_WEIGHT" ]
+    "flags": [ "VARSIZE", "FANCY", "SKINTIGHT", "OVERSIZE", "ZERO_WEIGHT" ],
+    "armor": { "coverage": 5, "covers": [ "head" ] }
   },
   {
     "id": "hosiguma_bracelet",
@@ -428,12 +398,10 @@
     "material": [ "iron" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "arm_l", "arm_l" ],
-    "coverage": 5,
-    "encumbrance": 5,
     "warmth": 2,
     "material_thickness": 4,
-    "flags": [ "SKINTIGHT", "OVERSIZE" ]
+    "flags": [ "SKINTIGHT", "OVERSIZE" ],
+    "armor": { "coverage": 5, "covers": [ "arm_l", "arm_l" ], "encumbrance": 5 }
   },
   {
     "id": "hosiguma_fetters",
@@ -446,12 +414,10 @@
     "material": [ "iron" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 5,
-    "encumbrance": 5,
     "warmth": 2,
     "material_thickness": 4,
-    "flags": [ "SKINTIGHT", "OVERSIZE" ]
+    "flags": [ "SKINTIGHT", "OVERSIZE" ],
+    "armor": { "coverage": 5, "covers": [ "leg_l", "leg_r" ], "encumbrance": 5 }
   },
   {
     "id": "hosigumahai",
@@ -474,8 +440,8 @@
         "max_contains_weight": "10 kg"
       }
     ],
-    "armor_data": { "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ], "coverage": 0, "encumbrance": 60, "material_thickness": 2 },
-    "flags": [ "SUPER_FANCY", "OVERSIZE", "TARDIS" ]
+    "flags": [ "SUPER_FANCY", "OVERSIZE", "TARDIS" ],
+    "armor": { "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ], "coverage": 0, "encumbrance": 60, "material_thickness": 2 }
   },
   {
     "id": "ibuki_skirt",
@@ -488,16 +454,14 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "magenta",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 70,
-    "encumbrance": 6,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "275 ml", "max_contains_weight": "1 kg", "moves": 90 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "275 ml", "max_contains_weight": "1 kg", "moves": 90 }
     ],
     "warmth": 15,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 70, "covers": [ "leg_l", "leg_r" ], "encumbrance": 6 }
   },
   {
     "id": "kogasa_bodice",
@@ -510,13 +474,11 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "light_blue",
-    "covers": [ "torso" ],
-    "coverage": 100,
-    "encumbrance": 1,
     "warmth": 5,
     "material_thickness": 2,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 100, "covers": [ "torso" ], "encumbrance": 1 }
   },
   {
     "id": "kogasa_skirt",
@@ -529,15 +491,14 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "light_blue",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 50,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "275 ml", "max_contains_weight": "1 kg", "moves": 90 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "275 ml", "max_contains_weight": "1 kg", "moves": 90 }
     ],
     "warmth": 10,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 50, "covers": [ "leg_l", "leg_r" ] }
   },
   {
     "id": "nazrin_vest",
@@ -550,12 +511,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "torso" ],
-    "coverage": 95,
-    "encumbrance": 1,
     "warmth": 10,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 95, "covers": [ "torso" ], "encumbrance": 1 }
   },
   {
     "id": "nazrin_cape",
@@ -567,12 +526,10 @@
     "price": "60 USD",
     "material": [ "cotton" ],
     "symbol": "[",
-    "covers": [ "torso" ],
-    "coverage": 20,
-    "encumbrance": 0,
     "warmth": 5,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 20, "covers": [ "torso" ], "encumbrance": 0 }
   },
   {
     "id": "nazrin_skirt",
@@ -585,15 +542,14 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 50,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "275 ml", "max_contains_weight": "1 kg", "moves": 90 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "275 ml", "max_contains_weight": "1 kg", "moves": 90 }
     ],
     "warmth": 10,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 50, "covers": [ "leg_l", "leg_r" ] }
   },
   {
     "id": "nazrin_pendulum",
@@ -606,9 +562,9 @@
     "material": [ "diamond" ],
     "symbol": "[",
     "color": "light_blue",
-    "coverage": 0,
     "warmth": 0,
     "material_thickness": 1,
-    "flags": [ "FANCY", "ZOOM", "ZERO_WEIGHT" ]
+    "flags": [ "FANCY", "ZOOM", "ZERO_WEIGHT" ],
+    "armor": { "coverage": 0 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Miso_touyou_touhou/miso_Touhou/items/armor/youyoumu.json
+++ b/data/Unleash_The_Mods/Working_mods/Miso_touyou_touhou/miso_Touhou/items/armor/youyoumu.json
@@ -10,16 +10,14 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "green",
-    "covers": [ "torso" ],
-    "coverage": 75,
-    "encumbrance": 0,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "600 ml", "max_contains_weight": "1400 g", "moves": 105 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "600 ml", "max_contains_weight": "1400 g", "moves": 105 }
     ],
     "warmth": 10,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 75, "covers": [ "torso" ], "encumbrance": 0 }
   },
   {
     "id": "compaq_skirt",
@@ -32,16 +30,14 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "green",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 50,
-    "encumbrance": 0,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "300 ml", "max_contains_weight": "900 g", "moves": 90 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "300 ml", "max_contains_weight": "900 g", "moves": 90 }
     ],
     "warmth": 15,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 50, "covers": [ "leg_l", "leg_r" ], "encumbrance": 0 }
   },
   {
     "id": "compaq_ribbon",
@@ -54,11 +50,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "green",
-    "covers": [ "head" ],
-    "coverage": 5,
     "warmth": 1,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "FANCY", "SKINTIGHT", "OVERSIZE", "ZERO_WEIGHT" ]
+    "flags": [ "VARSIZE", "FANCY", "SKINTIGHT", "OVERSIZE", "ZERO_WEIGHT" ],
+    "armor": { "coverage": 5, "covers": [ "head" ] }
   },
   {
     "id": "compaq_a_bow_tie",
@@ -71,10 +66,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "green",
-    "coverage": 0,
     "warmth": 0,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "FANCY", "ZERO_WEIGHT" ]
+    "flags": [ "VARSIZE", "FANCY", "ZERO_WEIGHT" ],
+    "armor": { "coverage": 0 }
   },
   {
     "id": "yuyuko_cap",
@@ -88,8 +83,6 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "magenta",
-    "covers": [ "head" ],
-    "coverage": 90,
     "warmth": 15,
     "material_thickness": 2,
     "environmental_protection": 2,
@@ -97,7 +90,8 @@
     "use_action": "PORTABLE_GAME",
     "max_charges": 60,
     "initial_charges": 60,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 90, "covers": [ "head" ] }
   },
   {
     "id": "ame_coat",
@@ -110,17 +104,15 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "magenta",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 90,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "645 ml", "max_contains_weight": "1600 g", "moves": 115 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "645 ml", "max_contains_weight": "1600 g", "moves": 115 }
     ],
     "warmth": 30,
-    "encumbrance": 27,
     "material_thickness": 2,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "WATERPROOF", "FANCY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "FANCY" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 27 }
   },
   {
     "id": "letty_apron",
@@ -133,13 +125,11 @@
     "material": [ "nomex", "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 40,
     "warmth": 2,
-    "encumbrance": 1,
     "material_thickness": 1,
     "environmental_protection": 5,
-    "flags": [ "FANCY" ]
+    "flags": [ "FANCY" ],
+    "armor": { "coverage": 40, "covers": [ "leg_l", "leg_r" ], "encumbrance": 1 }
   },
   {
     "id": "letty_shirt",
@@ -152,13 +142,11 @@
     "material": [ "nomex", "cotton" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "torso" ],
-    "coverage": 85,
-    "encumbrance": 0,
     "warmth": 3,
     "material_thickness": 2,
     "environmental_protection": 10,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": 0 }
   },
   {
     "id": "letty_skirt",
@@ -171,8 +159,6 @@
     "material": [ "nomex", "cotton" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 50,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "300 ml", "max_contains_weight": "900 g", "moves": 90 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "300 ml", "max_contains_weight": "900 g", "moves": 90 }
@@ -180,7 +166,8 @@
     "warmth": 3,
     "material_thickness": 2,
     "environmental_protection": 10,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 50, "covers": [ "leg_l", "leg_r" ] }
   },
   {
     "id": "letty_turban",
@@ -194,13 +181,11 @@
     "material": [ "nomex", "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "head" ],
-    "coverage": 70,
-    "encumbrance": 8,
     "warmth": 6,
     "material_thickness": 2,
     "environmental_protection": 10,
-    "flags": [ "VARSIZE", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS", "FANCY" ]
+    "flags": [ "VARSIZE", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS", "FANCY" ],
+    "armor": { "coverage": 70, "covers": [ "head" ], "encumbrance": 8 }
   },
   {
     "id": "letty_pow1",
@@ -213,12 +198,14 @@
     "material": [ "nomex", "cotton" ],
     "symbol": "[",
     "color": "light_blue",
-    "covers": [ "torso", "head", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 100,
     "warmth": 50,
     "material_thickness": 10,
     "environmental_protection": 10,
-    "flags": [ "VARSIZE", "WATER_FRIENDLY", "SKINTIGHT", "WATERPROOF", "RAINPROOF", "STURDY", "ZERO_WEIGHT" ]
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "SKINTIGHT", "WATERPROOF", "RAINPROOF", "STURDY", "ZERO_WEIGHT" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "head", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
+    }
   },
   {
     "id": "letty_pow2",
@@ -231,12 +218,14 @@
     "material": [ "nomex", "cotton" ],
     "symbol": "[",
     "color": "light_blue",
-    "covers": [ "torso", "head", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 100,
     "warmth": 50,
     "material_thickness": 10,
     "environmental_protection": 10,
-    "flags": [ "VARSIZE", "WATER_FRIENDLY", "SKINTIGHT", "WATERPROOF", "RAINPROOF", "STURDY", "ZERO_WEIGHT" ]
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "SKINTIGHT", "WATERPROOF", "RAINPROOF", "STURDY", "ZERO_WEIGHT" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "head", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
+    }
   },
   {
     "id": "letty_pow3",
@@ -249,12 +238,14 @@
     "material": [ "nomex", "cotton" ],
     "symbol": "[",
     "color": "light_blue",
-    "covers": [ "torso", "head", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 100,
     "warmth": 50,
     "material_thickness": 10,
     "environmental_protection": 10,
-    "flags": [ "VARSIZE", "WATER_FRIENDLY", "SKINTIGHT", "WATERPROOF", "RAINPROOF", "STURDY", "ZERO_WEIGHT" ]
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "SKINTIGHT", "WATERPROOF", "RAINPROOF", "STURDY", "ZERO_WEIGHT" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "head", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
+    }
   },
   {
     "id": "letty_pow4",
@@ -267,12 +258,14 @@
     "material": [ "nomex", "cotton" ],
     "symbol": "[",
     "color": "light_blue",
-    "covers": [ "torso", "head", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 100,
     "warmth": 50,
     "material_thickness": 10,
     "environmental_protection": 10,
-    "flags": [ "VARSIZE", "WATER_FRIENDLY", "SKINTIGHT", "WATERPROOF", "RAINPROOF", "STURDY", "ZERO_WEIGHT" ]
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "SKINTIGHT", "WATERPROOF", "RAINPROOF", "STURDY", "ZERO_WEIGHT" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "head", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
+    }
   },
   {
     "id": "chen_dress",
@@ -286,16 +279,14 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "light_red",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 85,
-    "encumbrance": 7,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "600 ml", "max_contains_weight": "1400 g", "moves": 105 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "600 ml", "max_contains_weight": "1400 g", "moves": 105 }
     ],
     "warmth": 15,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "FANCY", "ALLOWS_NATURAL_ATTACKS", "OVERSIZE" ]
+    "flags": [ "VARSIZE", "FANCY", "ALLOWS_NATURAL_ATTACKS", "OVERSIZE" ],
+    "armor": { "coverage": 85, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 7 }
   },
   {
     "id": "chen_cap",
@@ -309,12 +300,11 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "green",
-    "covers": [ "head" ],
-    "coverage": 90,
     "warmth": 15,
     "material_thickness": 2,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "OVERSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "OVERSIZE", "FANCY" ],
+    "armor": { "coverage": 90, "covers": [ "head" ] }
   },
   {
     "id": "chen_pierce",
@@ -327,10 +317,10 @@
     "material": [ "gold" ],
     "symbol": "[",
     "color": "yellow",
-    "coverage": 0,
     "warmth": 0,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "FANCY", "ZERO_WEIGHT" ]
+    "flags": [ "VARSIZE", "FANCY", "ZERO_WEIGHT" ],
+    "armor": { "coverage": 0 }
   },
   {
     "id": "alice_nosleeve",
@@ -343,12 +333,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "torso" ],
-    "coverage": 75,
-    "encumbrance": 1,
     "warmth": 8,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 75, "covers": [ "torso" ], "encumbrance": 1 }
   },
   {
     "id": "alice_cape",
@@ -361,12 +349,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "torso" ],
-    "coverage": 75,
-    "encumbrance": 1,
     "warmth": 4,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 75, "covers": [ "torso" ], "encumbrance": 1 }
   },
   {
     "id": "alice_longskirt",
@@ -379,16 +365,14 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 80,
-    "encumbrance": 7,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "300 ml", "max_contains_weight": "900 g", "moves": 90 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "300 ml", "max_contains_weight": "900 g", "moves": 90 }
     ],
     "warmth": 15,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 80, "covers": [ "leg_l", "leg_r" ], "encumbrance": 7 }
   },
   {
     "id": "alice_ribbon",
@@ -401,11 +385,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "red",
-    "covers": [ "head" ],
-    "coverage": 5,
     "warmth": 1,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "FANCY", "SKINTIGHT", "OVERSIZE", "ZERO_WEIGHT" ]
+    "flags": [ "VARSIZE", "FANCY", "SKINTIGHT", "OVERSIZE", "ZERO_WEIGHT" ],
+    "armor": { "coverage": 5, "covers": [ "head" ] }
   },
   {
     "id": "lunasa_cap",
@@ -418,11 +401,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "head" ],
-    "coverage": 70,
     "warmth": 10,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 70, "covers": [ "head" ] }
   },
   {
     "id": "lunasa_vest",
@@ -435,12 +417,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "torso" ],
-    "coverage": 95,
-    "encumbrance": 1,
     "warmth": 10,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 95, "covers": [ "torso" ], "encumbrance": 1 }
   },
   {
     "id": "lunasa_skirt",
@@ -453,15 +433,14 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 50,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "300 ml", "max_contains_weight": "900 g", "moves": 90 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "300 ml", "max_contains_weight": "900 g", "moves": 90 }
     ],
     "warmth": 10,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 50, "covers": [ "leg_l", "leg_r" ] }
   },
   {
     "id": "merlin_cap",
@@ -474,11 +453,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "pink",
-    "covers": [ "head" ],
-    "coverage": 70,
     "warmth": 10,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 70, "covers": [ "head" ] }
   },
   {
     "id": "merlin_vest",
@@ -491,12 +469,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "pink",
-    "covers": [ "torso" ],
-    "coverage": 95,
-    "encumbrance": 1,
     "warmth": 10,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 95, "covers": [ "torso" ], "encumbrance": 1 }
   },
   {
     "id": "merlin_skirt",
@@ -509,15 +485,14 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "pink",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 50,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "300 ml", "max_contains_weight": "900 g", "moves": 90 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "300 ml", "max_contains_weight": "900 g", "moves": 90 }
     ],
     "warmth": 10,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 50, "covers": [ "leg_l", "leg_r" ] }
   },
   {
     "id": "lyrica_cap",
@@ -530,11 +505,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "red",
-    "covers": [ "head" ],
-    "coverage": 100,
     "warmth": 10,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 100, "covers": [ "head" ] }
   },
   {
     "id": "lyrica_vest",
@@ -547,12 +521,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "red",
-    "covers": [ "torso" ],
-    "coverage": 95,
-    "encumbrance": 1,
     "warmth": 10,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 95, "covers": [ "torso" ], "encumbrance": 1 }
   },
   {
     "id": "lyrica_skirt",
@@ -565,15 +537,14 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "red",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 50,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "300 ml", "max_contains_weight": "900 g", "moves": 90 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "300 ml", "max_contains_weight": "900 g", "moves": 90 }
     ],
     "warmth": 10,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 50, "covers": [ "leg_l", "leg_r" ] }
   },
   {
     "id": "yakumoran_cap",
@@ -587,12 +558,11 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "head" ],
-    "coverage": 100,
     "warmth": 15,
     "material_thickness": 2,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "FANCY", "ALLOWS_NATURAL_ATTACKS", "OVERSIZE" ]
+    "flags": [ "VARSIZE", "FANCY", "ALLOWS_NATURAL_ATTACKS", "OVERSIZE" ],
+    "armor": { "coverage": 100, "covers": [ "head" ] }
   },
   {
     "id": "yakumo_hanhok01",
@@ -605,16 +575,14 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 100,
-    "encumbrance": 7,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "800 ml", "max_contains_weight": "2200 g", "moves": 125 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "800 ml", "max_contains_weight": "2200 g", "moves": 125 }
     ],
     "warmth": 15,
     "material_thickness": 3,
-    "flags": [ "VARSIZE", "FANCY", "STURDY", "POCKETS", "ALLOWS_NATURAL_ATTACKS", "OVERSIZE" ]
+    "flags": [ "VARSIZE", "FANCY", "STURDY", "POCKETS", "ALLOWS_NATURAL_ATTACKS", "OVERSIZE" ],
+    "armor": { "coverage": 100, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 7 }
   },
   {
     "id": "yakumo_hanhok02",
@@ -627,12 +595,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "magenta",
-    "covers": [ "torso", "leg_l", "leg_r" ],
-    "coverage": 40,
-    "encumbrance": 0,
     "warmth": 3,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "FANCY", "STURDY", "ALLOWS_NATURAL_ATTACKS", "OVERSIZE" ]
+    "flags": [ "VARSIZE", "FANCY", "STURDY", "ALLOWS_NATURAL_ATTACKS", "OVERSIZE" ],
+    "armor": { "coverage": 40, "covers": [ "torso", "leg_l", "leg_r" ], "encumbrance": 0 }
   },
   {
     "id": "yakumo_hanhok03",
@@ -645,12 +611,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "pink",
-    "covers": [ "torso", "leg_l", "leg_r" ],
-    "coverage": 40,
-    "encumbrance": 0,
     "warmth": 3,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "FANCY", "STURDY", "ALLOWS_NATURAL_ATTACKS", "OVERSIZE" ]
+    "flags": [ "VARSIZE", "FANCY", "STURDY", "ALLOWS_NATURAL_ATTACKS", "OVERSIZE" ],
+    "armor": { "coverage": 40, "covers": [ "torso", "leg_l", "leg_r" ], "encumbrance": 0 }
   },
   {
     "id": "yakumoyukri_cap",
@@ -664,11 +628,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "head" ],
-    "coverage": 90,
     "warmth": 15,
     "material_thickness": 2,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "OVERSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "OVERSIZE", "FANCY" ],
+    "armor": { "coverage": 90, "covers": [ "head" ] }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Miso_touyou_touhou/miso_Touhou/items/tool_armor/tools.json
+++ b/data/Unleash_The_Mods/Working_mods/Miso_touyou_touhou/miso_Touhou/items/tool_armor/tools.json
@@ -10,10 +10,8 @@
     "price": "700 USD",
     "material": [ "cotton", "flesh" ],
     "symbol": "@",
-    "covers": [ "torso" ],
     "color": "white_red",
     "initial_charges": 1,
-    "encumbrance": 60,
     "max_charges": 1,
     "flags": [ "SLEEP_AID", "SUPER_FANCY", "OVERSIZE", "WATER_FRIENDLY", "WAIST" ],
     "material_thickness": 1,
@@ -30,7 +28,8 @@
         "You let the miko play a nice melody.",
         "The miko made a sound of water sound like falling."
       ]
-    }
+    },
+    "armor": { "covers": [ "torso" ], "encumbrance": 60 }
   },
   {
     "id": "instrument_nosferatu_izayoi_sakuya",
@@ -43,10 +42,8 @@
     "price": "700 USD",
     "material": [ "cotton", "flesh" ],
     "symbol": "@",
-    "covers": [ "torso" ],
     "color": "blue_white",
     "initial_charges": 1,
-    "encumbrance": 60,
     "max_charges": 1,
     "flags": [ "SLEEP_AID", "SUPER_FANCY", "OVERSIZE", "WATER_FRIENDLY", "WAIST" ],
     "material_thickness": 1,
@@ -64,7 +61,8 @@
         "The maid played a nice melody.",
         "The maid made a sound of water sound like falling."
       ]
-    }
+    },
+    "armor": { "covers": [ "torso" ], "encumbrance": 60 }
   },
   {
     "id": "lunasa_violin",
@@ -77,7 +75,6 @@
     "price": "10 kUSD",
     "to_hit": 2,
     "bashing": 7,
-    "covers": [ "torso" ],
     "flags": [ "WAIST", "UNBREAKABLE_MELEE" ],
     "material_thickness": 1,
     "material": [ "gold" ],
@@ -98,7 +95,8 @@
         "I played a sad melody in the violin.",
         "The silent tones of the violin echo through the heart and induce melancholy."
       ]
-    }
+    },
+    "armor": { "covers": [ "torso" ] }
   },
   {
     "id": "merlin_trumpet",
@@ -111,7 +109,6 @@
     "price": "10 kUSD",
     "to_hit": 2,
     "bashing": 6,
-    "covers": [ "torso" ],
     "flags": [ "WAIST", "UNBREAKABLE_MELEE" ],
     "material_thickness": 1,
     "material": [ "brass", "gold" ],
@@ -132,7 +129,8 @@
         "I played a small piece with trumpet.",
         "I played a fun melody with the trumpet."
       ]
-    }
+    },
+    "armor": { "covers": [ "torso" ] }
   },
   {
     "id": "lyrica_keyboard",
@@ -147,7 +145,6 @@
     "bashing": 6,
     "material": [ "gold", "plastic" ],
     "symbol": "-",
-    "covers": [ "torso" ],
     "color": "yellow",
     "initial_charges": 1,
     "max_charges": 1,
@@ -166,7 +163,8 @@
         "I ran a finger on the keyboard and played a fantastic melody.",
         "It sounded to make the forgotten tone fall off."
       ]
-    }
+    },
+    "armor": { "covers": [ "torso" ] }
   },
   {
     "id": "magic_barrage_energy",
@@ -181,13 +179,12 @@
     "symbol": ",",
     "color": "white",
     "initial_charges": 10,
-    "encumbrance": 2,
     "max_charges": 24,
-    "coverage": 0,
     "flags": [ "WATER_FRIENDLY", "OVERSIZE" ],
     "material_thickness": 1,
     "relic_data": {
       "passive_effects": [ { "has": "WIELD", "condition": "ALWAYS", "hit_you_effect": [ { "id": "ARTC_TIME", "once_in": 5 } ] } ]
-    }
+    },
+    "armor": { "coverage": 0, "encumbrance": 2 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Miso_touyou_touhou/miso_Touyou/items/clothing/armor.json
+++ b/data/Unleash_The_Mods/Working_mods/Miso_touyou_touhou/miso_Touyou/items/clothing/armor.json
@@ -11,14 +11,12 @@
     "material": [ "plastic" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 100,
-    "encumbrance": 28,
     "warmth": 10,
     "material_thickness": 1,
     "environmental_protection": 10,
     "looks_like": "cleansuit",
-    "flags": [ "VARSIZE", "WATERPROOF", "HOOD", "RAINPROOF", "RAD_RESIST", "OVERSIZE", "OUTER" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "HOOD", "RAINPROOF", "RAD_RESIST", "OVERSIZE", "OUTER" ],
+    "armor": { "coverage": 100, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 28 }
   },
   {
     "id": "hazmat_suit_xl",
@@ -32,14 +30,16 @@
     "material": [ "plastic" ],
     "symbol": "[",
     "color": "yellow",
-    "covers": [ "torso", "head", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 40,
     "warmth": 40,
     "material_thickness": 2,
     "environmental_protection": 20,
     "looks_like": "hazmat_suit",
-    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "RAD_PROOF", "ELECTRIC_IMMUNE", "GAS_PROOF", "OVERSIZE", "OUTER" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "RAD_PROOF", "ELECTRIC_IMMUNE", "GAS_PROOF", "OVERSIZE", "OUTER" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "head", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 40
+    }
   },
   {
     "id": "t_take_kabuto",
@@ -53,12 +53,10 @@
     "material": [ "cotton", "bamboomaterial" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "head" ],
-    "coverage": 100,
-    "encumbrance": 17,
     "warmth": 15,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "WATERPROOF" ]
+    "flags": [ "VARSIZE", "WATERPROOF" ],
+    "armor": { "coverage": 100, "covers": [ "head" ], "encumbrance": 17 }
   },
   {
     "id": "t_gauntlets_take",
@@ -74,13 +72,11 @@
     "material": [ "cotton", "bamboomaterial" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "hand_l", "hand_r" ],
-    "coverage": 60,
-    "encumbrance": 4,
     "warmth": 15,
     "material_thickness": 2,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "STURDY", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "VARSIZE", "STURDY", "ALLOWS_NATURAL_ATTACKS" ],
+    "armor": { "coverage": 60, "covers": [ "hand_l", "hand_r" ], "encumbrance": 4 }
   },
   {
     "id": "armor_take",
@@ -95,14 +91,12 @@
     "material": [ "bamboomaterial", "cotton" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r" ],
-    "coverage": 100,
-    "encumbrance": 16,
     "warmth": 15,
     "material_thickness": 6,
     "environmental_protection": 5,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "VARSIZE", "ELECTRIC_IMMUNE", "STURDY" ]
+    "flags": [ "VARSIZE", "ELECTRIC_IMMUNE", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r" ], "encumbrance": 16 }
   },
   {
     "id": "take_boots",
@@ -115,13 +109,11 @@
     "material": [ "cotton", "bamboomaterial" ],
     "symbol": "[",
     "color": "yellow_white",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 90,
-    "encumbrance": 18,
     "warmth": 9,
     "material_thickness": 2,
     "environmental_protection": 5,
-    "flags": [ "VARSIZE", "WATERPROOF" ]
+    "flags": [ "VARSIZE", "WATERPROOF" ],
+    "armor": { "coverage": 90, "covers": [ "foot_l", "foot_r" ], "encumbrance": 18 }
   },
   {
     "id": "hsurvivor_suit_xl",
@@ -137,9 +129,6 @@
     "material": [ "kevlar", "steel" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 100,
-    "encumbrance": 40,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "7 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "7 kg", "moves": 80 },
@@ -152,7 +141,8 @@
     "material_thickness": 5,
     "environmental_protection": 3,
     "looks_like": "hsurvivor_suit",
-    "flags": [ "VARSIZE", "WATERPROOF", "POCKETS", "HOOD", "RAINPROOF", "OVERSIZE", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "POCKETS", "HOOD", "RAINPROOF", "OVERSIZE", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 40 }
   },
   {
     "id": "t_syoiko",
@@ -165,11 +155,8 @@
     "material": [ "wood" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "torso" ],
     "to_hit": -2,
     "bashing": 11,
-    "coverage": 15,
-    "encumbrance": 30,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "5 L", "max_contains_weight": "8 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "5 L", "max_contains_weight": "8 kg", "moves": 80 },
@@ -180,7 +167,8 @@
     ],
     "warmth": 0,
     "material_thickness": 3,
-    "flags": [ "OVERSIZE", "BELTED", "WATER_FRIENDLY" ]
+    "flags": [ "OVERSIZE", "BELTED", "WATER_FRIENDLY" ],
+    "armor": { "coverage": 15, "covers": [ "torso" ], "encumbrance": 30 }
   },
   {
     "id": "t_syoiko_dai",
@@ -193,11 +181,8 @@
     "material": [ "wood" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "torso" ],
     "to_hit": -4,
     "bashing": 20,
-    "coverage": 25,
-    "encumbrance": 50,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "10 L", "max_contains_weight": "12 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "10 L", "max_contains_weight": "12 kg", "moves": 80 },
@@ -208,7 +193,8 @@
     ],
     "warmth": 0,
     "material_thickness": 3,
-    "flags": [ "OVERSIZE", "BELTED", "WATER_FRIENDLY" ]
+    "flags": [ "OVERSIZE", "BELTED", "WATER_FRIENDLY" ],
+    "armor": { "coverage": 25, "covers": [ "torso" ], "encumbrance": 50 }
   },
   {
     "id": "t_syoikago",
@@ -221,11 +207,8 @@
     "material": [ "bamboomaterial" ],
     "symbol": "[",
     "color": "yellow_white",
-    "covers": [ "torso" ],
     "to_hit": -2,
     "bashing": 11,
-    "coverage": 15,
-    "encumbrance": 30,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "5 L", "max_contains_weight": "8 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "5 L", "max_contains_weight": "8 kg", "moves": 80 },
@@ -236,7 +219,8 @@
     ],
     "warmth": 0,
     "material_thickness": 3,
-    "flags": [ "OVERSIZE", "BELTED", "WATER_FRIENDLY" ]
+    "flags": [ "OVERSIZE", "BELTED", "WATER_FRIENDLY" ],
+    "armor": { "coverage": 15, "covers": [ "torso" ], "encumbrance": 30 }
   },
   {
     "id": "t_syoikago_dai",
@@ -249,11 +233,8 @@
     "material": [ "bamboomaterial" ],
     "symbol": "[",
     "color": "yellow_white",
-    "covers": [ "torso" ],
     "to_hit": -4,
     "bashing": 20,
-    "coverage": 25,
-    "encumbrance": 50,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "10 L", "max_contains_weight": "12 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "10 L", "max_contains_weight": "12 kg", "moves": 80 },
@@ -264,7 +245,8 @@
     ],
     "warmth": 0,
     "material_thickness": 3,
-    "flags": [ "OVERSIZE", "BELTED", "WATER_FRIENDLY" ]
+    "flags": [ "OVERSIZE", "BELTED", "WATER_FRIENDLY" ],
+    "armor": { "coverage": 25, "covers": [ "torso" ], "encumbrance": 50 }
   },
   {
     "id": "asinaka",
@@ -277,12 +259,10 @@
     "material": [ "paper" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 25,
-    "encumbrance": 0,
     "warmth": 0,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "OVERSIZE", "OUTER" ]
+    "flags": [ "VARSIZE", "OVERSIZE", "OUTER" ],
+    "armor": { "coverage": 25, "covers": [ "foot_l", "foot_r" ], "encumbrance": 0 }
   },
   {
     "id": "t_setta",
@@ -296,11 +276,9 @@
     "material": [ "paper", "leather" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 35,
-    "encumbrance": 10,
     "material_thickness": 2,
-    "flags": [ "FANCY", "VARSIZE", "WATER_FRIENDLY", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "FANCY", "VARSIZE", "WATER_FRIENDLY", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS" ],
+    "armor": { "coverage": 35, "covers": [ "foot_l", "foot_r" ], "encumbrance": 10 }
   },
   {
     "id": "strap_shoes",
@@ -313,13 +291,11 @@
     "material": [ "leather" ],
     "symbol": "[",
     "color": "light_blue",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 80,
-    "encumbrance": 16,
     "warmth": 15,
     "material_thickness": 2,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 80, "covers": [ "foot_l", "foot_r" ], "encumbrance": 16 }
   },
   {
     "id": "ranhansie01",
@@ -332,12 +308,10 @@
     "material": [ "cotton", "plastic" ],
     "symbol": "[",
     "color": "green",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 80,
-    "encumbrance": 4,
     "warmth": 15,
     "material_thickness": 2,
-    "flags": [ "VARSIZE" ]
+    "flags": [ "VARSIZE" ],
+    "armor": { "coverage": 80, "covers": [ "foot_l", "foot_r" ], "encumbrance": 4 }
   },
   {
     "id": "ranhansie02",
@@ -350,12 +324,10 @@
     "material": [ "cotton", "plastic" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 80,
-    "encumbrance": 4,
     "warmth": 15,
     "material_thickness": 2,
-    "flags": [ "VARSIZE" ]
+    "flags": [ "VARSIZE" ],
+    "armor": { "coverage": 80, "covers": [ "foot_l", "foot_r" ], "encumbrance": 4 }
   },
   {
     "id": "asagutu",
@@ -368,13 +340,11 @@
     "material": [ "cotton", "wood" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 80,
-    "encumbrance": 14,
     "warmth": 9,
     "material_thickness": 4,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "WATERPROOF", "FANCY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "FANCY" ],
+    "armor": { "coverage": 80, "covers": [ "foot_l", "foot_r" ], "encumbrance": 14 }
   },
   {
     "id": "tabi_dress_leather",
@@ -387,12 +357,10 @@
     "material": [ "leather" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 5,
     "warmth": 10,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "WATERPROOF", "SKINTIGHT" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "SKINTIGHT" ],
+    "armor": { "coverage": 100, "covers": [ "foot_l", "foot_r" ], "encumbrance": 5 }
   },
   {
     "id": "tabi_dress_wool",
@@ -405,12 +373,10 @@
     "material": [ "wool" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 3,
     "warmth": 30,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "SKINTIGHT" ]
+    "flags": [ "VARSIZE", "SKINTIGHT" ],
+    "armor": { "coverage": 100, "covers": [ "foot_l", "foot_r" ], "encumbrance": 3 }
   },
   {
     "id": "t_hatigane",
@@ -424,12 +390,10 @@
     "material": [ "cotton", "iron" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "head" ],
-    "coverage": 40,
-    "encumbrance": 7,
     "warmth": 15,
     "material_thickness": 3,
-    "flags": [ "VARSIZE", "OVERSIZE", "WATER_FRIENDLY", "HELMET_COMPAT" ]
+    "flags": [ "VARSIZE", "OVERSIZE", "WATER_FRIENDLY", "HELMET_COMPAT" ],
+    "armor": { "coverage": 40, "covers": [ "head" ], "encumbrance": 7 }
   },
   {
     "id": "eboshi",
@@ -442,12 +406,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "head" ],
-    "coverage": 80,
-    "encumbrance": 10,
     "warmth": 4,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "OVERSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "OVERSIZE", "FANCY" ],
+    "armor": { "coverage": 80, "covers": [ "head" ], "encumbrance": 10 }
   },
   {
     "id": "lsurvivor_eboshi",
@@ -463,13 +425,11 @@
     "material": [ "kevlar", "cotton" ],
     "symbol": "[",
     "color": "pink",
-    "covers": [ "head" ],
-    "coverage": 100,
-    "encumbrance": 20,
     "warmth": 8,
     "material_thickness": 4,
     "environmental_protection": 3,
-    "flags": [ "VARSIZE", "FANCY", "WATERPROOF", "OVERSIZE", "STURDY" ]
+    "flags": [ "VARSIZE", "FANCY", "WATERPROOF", "OVERSIZE", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "head" ], "encumbrance": 20 }
   },
   {
     "id": "survivor_eboshi",
@@ -483,13 +443,11 @@
     "material": [ "kevlar", "steel", "cotton" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "head" ],
-    "coverage": 100,
     "warmth": 10,
-    "encumbrance": 40,
     "material_thickness": 4,
     "environmental_protection": 4,
-    "flags": [ "VARSIZE", "FANCY", "WATERPROOF", "OVERSIZE", "STURDY", "HELMET_COMPAT" ]
+    "flags": [ "VARSIZE", "FANCY", "WATERPROOF", "OVERSIZE", "STURDY", "HELMET_COMPAT" ],
+    "armor": { "coverage": 100, "covers": [ "head" ], "encumbrance": 40 }
   },
   {
     "id": "hsurvivor_eboshi",
@@ -503,13 +461,11 @@
     "material": [ "kevlar", "steel" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "head" ],
-    "coverage": 100,
     "warmth": 10,
-    "encumbrance": 50,
     "material_thickness": 8,
     "environmental_protection": 5,
-    "flags": [ "VARSIZE", "FANCY", "WATERPROOF", "OVERSIZE", "STURDY" ]
+    "flags": [ "VARSIZE", "FANCY", "WATERPROOF", "OVERSIZE", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "head" ], "encumbrance": 50 }
   },
   {
     "id": "night_cap01",
@@ -523,11 +479,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "pink",
-    "covers": [ "head" ],
-    "coverage": 90,
     "warmth": 15,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "OVERSIZE", "FANCY", "HELMET_COMPAT" ]
+    "flags": [ "VARSIZE", "OVERSIZE", "FANCY", "HELMET_COMPAT" ],
+    "armor": { "coverage": 90, "covers": [ "head" ] }
   },
   {
     "id": "lsurvivor_night_cap01",
@@ -543,13 +498,11 @@
     "material": [ "kevlar", "cotton" ],
     "symbol": "[",
     "color": "pink",
-    "covers": [ "head" ],
-    "coverage": 100,
-    "encumbrance": 8,
     "warmth": 8,
     "material_thickness": 4,
     "environmental_protection": 3,
-    "flags": [ "VARSIZE", "FANCY", "WATERPROOF", "OVERSIZE", "STURDY", "HELMET_COMPAT" ]
+    "flags": [ "VARSIZE", "FANCY", "WATERPROOF", "OVERSIZE", "STURDY", "HELMET_COMPAT" ],
+    "armor": { "coverage": 100, "covers": [ "head" ], "encumbrance": 8 }
   },
   {
     "id": "survivor_night_cap01",
@@ -563,13 +516,11 @@
     "material": [ "kevlar", "steel", "cotton" ],
     "symbol": "[",
     "color": "pink",
-    "covers": [ "head" ],
-    "coverage": 100,
     "warmth": 15,
-    "encumbrance": 10,
     "material_thickness": 4,
     "environmental_protection": 4,
-    "flags": [ "VARSIZE", "FANCY", "WATERPROOF", "OVERSIZE", "STURDY", "HELMET_COMPAT" ]
+    "flags": [ "VARSIZE", "FANCY", "WATERPROOF", "OVERSIZE", "STURDY", "HELMET_COMPAT" ],
+    "armor": { "coverage": 100, "covers": [ "head" ], "encumbrance": 10 }
   },
   {
     "id": "hsurvivor_night_cap01",
@@ -583,13 +534,11 @@
     "material": [ "kevlar", "steel", "cotton" ],
     "symbol": "[",
     "color": "pink",
-    "covers": [ "head" ],
-    "coverage": 100,
     "warmth": 15,
-    "encumbrance": 40,
     "material_thickness": 8,
     "environmental_protection": 5,
-    "flags": [ "VARSIZE", "FANCY", "WATERPROOF", "OVERSIZE", "STURDY", "HELMET_COMPAT" ]
+    "flags": [ "VARSIZE", "FANCY", "WATERPROOF", "OVERSIZE", "STURDY", "HELMET_COMPAT" ],
+    "armor": { "coverage": 100, "covers": [ "head" ], "encumbrance": 40 }
   },
   {
     "id": "miko_hibakama",
@@ -602,12 +551,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "light_red",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 85,
-    "encumbrance": 8,
     "warmth": 16,
     "material_thickness": 3,
-    "flags": [ "VARSIZE", "FANCY", "OVERSIZE" ]
+    "flags": [ "VARSIZE", "FANCY", "OVERSIZE" ],
+    "armor": { "coverage": 85, "covers": [ "leg_l", "leg_r" ], "encumbrance": 8 }
   },
   {
     "id": "miko_suikan",
@@ -620,9 +567,6 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 85,
-    "encumbrance": 8,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1800 ml", "max_contains_weight": "2500 g", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1800 ml", "max_contains_weight": "2500 g", "moves": 80 },
@@ -631,7 +575,8 @@
     ],
     "warmth": 12,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 85, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 8 }
   },
   {
     "id": "miko_tihaya",
@@ -644,12 +589,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 85,
-    "encumbrance": 6,
     "warmth": 12,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 85, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 6 }
   },
   {
     "id": "lsurvivor_miko_tihaya",
@@ -663,9 +606,6 @@
     "material": [ "kevlar", "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 100,
-    "encumbrance": 9,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "3 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "3 kg", "moves": 80 },
@@ -675,7 +615,8 @@
     "warmth": 8,
     "material_thickness": 4,
     "environmental_protection": 3,
-    "flags": [ "VARSIZE", "FANCY", "WATERPROOF", "POCKETS", "OVERSIZE", "HOOD", "RAINPROOF", "COLLAR", "STURDY" ]
+    "flags": [ "VARSIZE", "FANCY", "WATERPROOF", "POCKETS", "OVERSIZE", "HOOD", "RAINPROOF", "COLLAR", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 9 }
   },
   {
     "id": "survivor_miko_tihaya",
@@ -688,9 +629,6 @@
     "material": [ "kevlar", "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 100,
-    "encumbrance": 13,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1900 ml", "max_contains_weight": "5 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1900 ml", "max_contains_weight": "5 kg", "moves": 80 },
@@ -702,7 +640,8 @@
     "warmth": 12,
     "material_thickness": 6,
     "environmental_protection": 4,
-    "flags": [ "VARSIZE", "FANCY", "WATERPROOF", "RAINPROOF", "POCKETS", "OVERSIZE", "HOOD", "COLLAR", "STURDY" ]
+    "flags": [ "VARSIZE", "FANCY", "WATERPROOF", "RAINPROOF", "POCKETS", "OVERSIZE", "HOOD", "COLLAR", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 13 }
   },
   {
     "id": "hsurvivor_miko_tihaya",
@@ -715,9 +654,6 @@
     "material": [ "kevlar", "steel", "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 100,
-    "encumbrance": 31,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "7 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "7 kg", "moves": 80 },
@@ -729,7 +665,8 @@
     "warmth": 12,
     "material_thickness": 5,
     "environmental_protection": 4,
-    "flags": [ "VARSIZE", "FANCY", "WATERPROOF", "RAINPROOF", "POCKETS", "OVERSIZE", "HOOD", "COLLAR", "STURDY" ]
+    "flags": [ "VARSIZE", "FANCY", "WATERPROOF", "RAINPROOF", "POCKETS", "OVERSIZE", "HOOD", "COLLAR", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 31 }
   },
   {
     "id": "lsurvivor_miko_hibakama",
@@ -743,9 +680,6 @@
     "material": [ "kevlar", "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 100,
-    "encumbrance": 15,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1200 ml", "max_contains_weight": "3 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1200 ml", "max_contains_weight": "3 kg", "moves": 80 }
@@ -753,7 +687,8 @@
     "warmth": 8,
     "material_thickness": 4,
     "environmental_protection": 3,
-    "flags": [ "VARSIZE", "FANCY", "WATERPROOF", "POCKETS", "OVERSIZE", "STURDY" ]
+    "flags": [ "VARSIZE", "FANCY", "WATERPROOF", "POCKETS", "OVERSIZE", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "leg_l", "leg_r" ], "encumbrance": 15 }
   },
   {
     "id": "survivor_miko_hibakama",
@@ -766,9 +701,6 @@
     "material": [ "kevlar", "cotton" ],
     "symbol": "[",
     "color": "light_red",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 100,
-    "encumbrance": 18,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "4 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "4 kg", "moves": 80 }
@@ -776,7 +708,8 @@
     "warmth": 15,
     "material_thickness": 6,
     "environmental_protection": 4,
-    "flags": [ "VARSIZE", "FANCY", "WATERPROOF", "POCKETS", "OVERSIZE", "STURDY" ]
+    "flags": [ "VARSIZE", "FANCY", "WATERPROOF", "POCKETS", "OVERSIZE", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "leg_l", "leg_r" ], "encumbrance": 18 }
   },
   {
     "id": "hsurvivor_miko_hibakama",
@@ -789,9 +722,6 @@
     "material": [ "kevlar", "steel", "cotton" ],
     "symbol": "[",
     "color": "light_red",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 100,
-    "encumbrance": 35,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "5 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "5 kg", "moves": 80 }
@@ -799,7 +729,8 @@
     "warmth": 15,
     "material_thickness": 7,
     "environmental_protection": 4,
-    "flags": [ "VARSIZE", "FANCY", "WATERPROOF", "POCKETS", "OVERSIZE", "STURDY" ]
+    "flags": [ "VARSIZE", "FANCY", "WATERPROOF", "POCKETS", "OVERSIZE", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "leg_l", "leg_r" ], "encumbrance": 35 }
   },
   {
     "id": "lsurvivor_miko_suikan",
@@ -813,9 +744,6 @@
     "material": [ "kevlar", "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 100,
-    "encumbrance": 10,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1740 ml", "max_contains_weight": "5 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1740 ml", "max_contains_weight": "5 kg", "moves": 80 },
@@ -827,7 +755,8 @@
     "warmth": 8,
     "material_thickness": 4,
     "environmental_protection": 3,
-    "flags": [ "VARSIZE", "FANCY", "WATERPROOF", "POCKETS", "OVERSIZE", "HOOD", "RAINPROOF", "COLLAR", "STURDY" ]
+    "flags": [ "VARSIZE", "FANCY", "WATERPROOF", "POCKETS", "OVERSIZE", "HOOD", "RAINPROOF", "COLLAR", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 10 }
   },
   {
     "id": "survivor_miko_suikan",
@@ -840,9 +769,6 @@
     "material": [ "kevlar", "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 100,
-    "encumbrance": 13,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2375 ml", "max_contains_weight": "5 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2375 ml", "max_contains_weight": "5 kg", "moves": 80 },
@@ -854,7 +780,8 @@
     "warmth": 12,
     "material_thickness": 6,
     "environmental_protection": 4,
-    "flags": [ "VARSIZE", "FANCY", "WATERPROOF", "RAINPROOF", "POCKETS", "OVERSIZE", "HOOD", "COLLAR", "STURDY" ]
+    "flags": [ "VARSIZE", "FANCY", "WATERPROOF", "RAINPROOF", "POCKETS", "OVERSIZE", "HOOD", "COLLAR", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 13 }
   },
   {
     "id": "hsurvivor_miko_suikan",
@@ -867,9 +794,6 @@
     "material": [ "kevlar", "steel", "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 100,
-    "encumbrance": 31,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "7 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "7 kg", "moves": 80 },
@@ -881,7 +805,8 @@
     "warmth": 12,
     "material_thickness": 5,
     "environmental_protection": 4,
-    "flags": [ "VARSIZE", "FANCY", "WATERPROOF", "RAINPROOF", "POCKETS", "OVERSIZE", "HOOD", "COLLAR", "STURDY" ]
+    "flags": [ "VARSIZE", "FANCY", "WATERPROOF", "RAINPROOF", "POCKETS", "OVERSIZE", "HOOD", "COLLAR", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 31 }
   },
   {
     "id": "miko_siraginu",
@@ -894,11 +819,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "torso" ],
-    "coverage": 85,
     "warmth": 5,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "FANCY", "SKINTIGHT" ]
+    "flags": [ "VARSIZE", "FANCY", "SKINTIGHT" ],
+    "armor": { "coverage": 85, "covers": [ "torso" ] }
   },
   {
     "id": "lsurvivor_miko_siraginu",
@@ -911,9 +835,6 @@
     "material": [ "kevlar", "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "torso" ],
-    "coverage": 100,
-    "encumbrance": 4,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "675 ml", "max_contains_weight": "2 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "675 ml", "max_contains_weight": "2 kg", "moves": 80 }
@@ -921,7 +842,8 @@
     "warmth": 5,
     "material_thickness": 2,
     "environmental_protection": 4,
-    "flags": [ "VARSIZE", "FANCY", "SKINTIGHT", "WATERPROOF", "RAINPROOF", "OVERSIZE", "STURDY" ]
+    "flags": [ "VARSIZE", "FANCY", "SKINTIGHT", "WATERPROOF", "RAINPROOF", "OVERSIZE", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "torso" ], "encumbrance": 4 }
   },
   {
     "id": "survivor_miko_siraginu",
@@ -934,9 +856,6 @@
     "material": [ "kevlar", "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "torso" ],
-    "coverage": 100,
-    "encumbrance": 8,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "750 ml", "max_contains_weight": "3 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "750 ml", "max_contains_weight": "3 kg", "moves": 80 }
@@ -944,7 +863,8 @@
     "warmth": 5,
     "material_thickness": 4,
     "environmental_protection": 4,
-    "flags": [ "VARSIZE", "FANCY", "SKINTIGHT", "WATERPROOF", "RAINPROOF", "OVERSIZE", "STURDY" ]
+    "flags": [ "VARSIZE", "FANCY", "SKINTIGHT", "WATERPROOF", "RAINPROOF", "OVERSIZE", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "torso" ], "encumbrance": 8 }
   },
   {
     "id": "hsurvivor_miko_siraginu",
@@ -957,9 +877,6 @@
     "material": [ "kevlar", "steel", "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "torso" ],
-    "coverage": 100,
-    "encumbrance": 22,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "750 ml", "max_contains_weight": "3 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "750 ml", "max_contains_weight": "3 kg", "moves": 80 }
@@ -967,7 +884,8 @@
     "warmth": 5,
     "material_thickness": 4,
     "environmental_protection": 4,
-    "flags": [ "VARSIZE", "FANCY", "SKINTIGHT", "WATERPROOF", "RAINPROOF", "OVERSIZE", "STURDY" ]
+    "flags": [ "VARSIZE", "FANCY", "SKINTIGHT", "WATERPROOF", "RAINPROOF", "OVERSIZE", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "torso" ], "encumbrance": 22 }
   },
   {
     "id": "lsurvivor_straw_sandals",
@@ -983,12 +901,10 @@
     "material": [ "kevlar", "cotton" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 16,
     "material_thickness": 5,
     "environmental_protection": 3,
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "foot_l", "foot_r" ], "encumbrance": 16 }
   },
   {
     "id": "survivor_straw_sandals",
@@ -1002,12 +918,10 @@
     "material": [ "kevlar", "paper" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 19,
     "material_thickness": 6,
     "environmental_protection": 4,
-    "flags": [ "FANCY", "VARSIZE", "WATER_FRIENDLY", "WATERPROOF", "OVERSIZE", "STURDY" ]
+    "flags": [ "FANCY", "VARSIZE", "WATER_FRIENDLY", "WATERPROOF", "OVERSIZE", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "foot_l", "foot_r" ], "encumbrance": 19 }
   },
   {
     "id": "hsurvivor_straw_sandals",
@@ -1021,12 +935,10 @@
     "material": [ "kevlar", "steel", "paper" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 36,
     "material_thickness": 8,
     "environmental_protection": 7,
-    "flags": [ "FANCY", "VARSIZE", "WATER_FRIENDLY", "WATERPROOF", "OVERSIZE", "STURDY" ]
+    "flags": [ "FANCY", "VARSIZE", "WATER_FRIENDLY", "WATERPROOF", "OVERSIZE", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "foot_l", "foot_r" ], "encumbrance": 36 }
   },
   {
     "id": "hazmat_suit_xl",
@@ -1040,14 +952,16 @@
     "material": [ "plastic" ],
     "symbol": "[",
     "color": "yellow",
-    "covers": [ "torso", "head", "eyes", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 40,
     "warmth": 40,
     "material_thickness": 2,
     "environmental_protection": 20,
     "looks_like": "hazmat_suit",
-    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "RAD_PROOF", "ELECTRIC_IMMUNE", "GAS_PROOF", "OVERSIZE", "OUTER" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "RAD_PROOF", "ELECTRIC_IMMUNE", "GAS_PROOF", "OVERSIZE", "OUTER" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "head", "eyes", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 40
+    }
   },
   {
     "id": "t_pao",
@@ -1060,11 +974,9 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 85,
-    "encumbrance": 15,
     "warmth": 20,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 85, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 15 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/More_Armor/armor.json
+++ b/data/Unleash_The_Mods/Working_mods/More_Armor/armor.json
@@ -14,12 +14,14 @@
     "symbol": "[",
     "color": "light_gray",
     "looks_like": "armor_lightplate",
-    "covers": [ "torso", "head", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "warmth": 20,
     "material_thickness": 4,
-    "flags": [ "VARSIZE", "OUTER", "STURDY", "ELECTRIC_IMMUNE" ]
+    "flags": [ "VARSIZE", "OUTER", "STURDY", "ELECTRIC_IMMUNE" ],
+    "armor": {
+      "coverage": 95,
+      "covers": [ "torso", "head", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 20
+    }
   },
   {
     "id": "jumpsuit_leather",
@@ -34,12 +36,10 @@
     "symbol": "[",
     "color": "dark_gray",
     "looks_like": "touring_suit",
-    "covers": [ "leg_l", "leg_r", "arm_l", "arm_r", "torso" ],
-    "coverage": 95,
-    "encumbrance": 8,
     "warmth": 15,
     "material_thickness": 3,
-    "flags": [ "VARSIZE", "POCKETS" ]
+    "flags": [ "VARSIZE", "POCKETS" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r", "arm_l", "arm_r", "torso" ], "encumbrance": 8 }
   },
   {
     "id": "jumpsuit_xlleather",
@@ -54,12 +54,10 @@
     "symbol": "[",
     "color": "dark_gray",
     "looks_like": "touring_suit",
-    "covers": [ "leg_l", "leg_r", "arm_l", "arm_r", "torso" ],
-    "coverage": 95,
-    "encumbrance": 8,
     "warmth": 15,
     "material_thickness": 2,
-    "flags": [ "POCKETS", "OVERSIZE" ]
+    "flags": [ "POCKETS", "OVERSIZE" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r", "arm_l", "arm_r", "torso" ], "encumbrance": 8 }
   },
   {
     "id": "jumpsuit_leather_mod",
@@ -74,12 +72,10 @@
     "symbol": "[",
     "color": "dark_gray",
     "looks_like": "touring_suit",
-    "covers": [ "leg_l", "leg_r", "arm_l", "arm_r", "torso" ],
-    "coverage": 95,
-    "encumbrance": 12,
     "warmth": 15,
     "material_thickness": 3,
-    "flags": [ "VARSIZE", "POCKETS" ]
+    "flags": [ "VARSIZE", "POCKETS" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r", "arm_l", "arm_r", "torso" ], "encumbrance": 12 }
   },
   {
     "id": "jumpsuit_xlleather_mod",
@@ -94,12 +90,10 @@
     "symbol": "[",
     "color": "dark_gray",
     "looks_like": "touring_suit",
-    "covers": [ "leg_l", "leg_r", "arm_l", "arm_r", "torso" ],
-    "coverage": 95,
-    "encumbrance": 12,
     "warmth": 15,
     "material_thickness": 2,
-    "flags": [ "POCKETS", "OVERSIZE" ]
+    "flags": [ "POCKETS", "OVERSIZE" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r", "arm_l", "arm_r", "torso" ], "encumbrance": 12 }
   },
   {
     "id": "armguard_xllarmor",
@@ -681,12 +675,10 @@
     "symbol": "[",
     "color": "dark_gray",
     "looks_like": "cuirass_lightplate",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 80,
-    "encumbrance": 30,
     "warmth": 5,
     "material_thickness": 10,
-    "flags": [ "BELTED" ]
+    "flags": [ "BELTED" ],
+    "armor": { "coverage": 80, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 30 }
   },
   {
     "id": "armor_xltire",
@@ -713,13 +705,11 @@
     "symbol": "[",
     "color": "dark_gray",
     "looks_like": "cuirass_lightplate",
-    "covers": [ "torso" ],
-    "coverage": 80,
-    "encumbrance": 10,
     "warmth": 20,
     "material_thickness": 4,
     "environmental_protection": 1,
-    "flags": [ "BELTED", "WATER_FRIENDLY" ]
+    "flags": [ "BELTED", "WATER_FRIENDLY" ],
+    "armor": { "coverage": 80, "covers": [ "torso" ], "encumbrance": 10 }
   },
   {
     "id": "conductive_suit",
@@ -734,12 +724,14 @@
     "symbol": "[",
     "color": "light_gray",
     "looks_like": "chainmail_suit",
-    "covers": [ "torso", "head", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r" ],
-    "coverage": 100,
-    "encumbrance": 15,
     "warmth": 15,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "HELMET_COMPAT", "ELECTRIC_IMMUNE" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "HELMET_COMPAT", "ELECTRIC_IMMUNE" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "head", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r" ],
+      "encumbrance": 15
+    }
   },
   {
     "id": "backpack_floating",
@@ -749,7 +741,7 @@
     "description": "A small backpack with a special rail system designed to reduce the load felt by the wearer when moving up and down.  Good storage for very little encumbrance.",
     "weight": "833 g",
     "price": "78 USD",
-    "encumbrance": 7
+    "armor": { "encumbrance": 7 }
   },
   {
     "id": "rucksack_floating",
@@ -759,6 +751,6 @@
     "description": "A huge military rucksack with a special rail system designed to reduce the load felt by the wearer when moving up and down, provides a lot of storage for moderate encumbrance.",
     "weight": "1440 g",
     "price": "184 USD",
-    "encumbrance": 14
+    "armor": { "encumbrance": 14 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/More_Makeshift_Stuff/mod_armor.json
+++ b/data/Unleash_The_Mods/Working_mods/More_Makeshift_Stuff/mod_armor.json
@@ -6,7 +6,6 @@
     "name": { "str": "makeshift wooden cuirass", "str_pl": "makeshift wooden cuirasses" },
     "weight": "8500 g",
     "color": "brown",
-    "covers": [ "torso" ],
     "to_hit": -5,
     "symbol": "[",
     "description": "A makeshift wooden cuirass, actually just a bunch of boards fastened somewhat tight with strings.",
@@ -14,11 +13,10 @@
     "material": [ "wood" ],
     "volume": "5 L",
     "warmth": 5,
-    "encumbrance": 18,
     "bashing": 8,
     "flags": [ "OUTER", "FRAGILE" ],
-    "coverage": 65,
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 65, "covers": [ "torso" ], "encumbrance": 18 }
   },
   {
     "id": "woodrass_two",
@@ -27,7 +25,6 @@
     "name": { "str": "elaborate wooden cuirass", "str_pl": "elaborate wooden cuirasses" },
     "weight": "8500 g",
     "color": "brown",
-    "covers": [ "torso" ],
     "to_hit": -5,
     "symbol": "[",
     "description": "An elaborate wooden cuirass, more thin, flexible and with shoulderpads for better coverage.",
@@ -35,11 +32,10 @@
     "material": [ "wood" ],
     "volume": "5 L",
     "warmth": 5,
-    "encumbrance": 14,
     "bashing": 8,
     "flags": [ "OUTER", "FRAGILE" ],
-    "coverage": 90,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 90, "covers": [ "torso" ], "encumbrance": 14 }
   },
   {
     "id": "woodrass_three",
@@ -48,7 +44,6 @@
     "name": { "str": "wooden laminar cuirass", "str_pl": "wooden laminar cuirasses" },
     "weight": "8000 g",
     "color": "brown",
-    "covers": [ "torso" ],
     "to_hit": -5,
     "symbol": "[",
     "description": "An armor made from thin wooden sheets with carefully cut grooves sewn onto a cloth undershirt.",
@@ -56,11 +51,10 @@
     "material": [ "wood", "cotton" ],
     "volume": "5500 ml",
     "warmth": 15,
-    "encumbrance": 18,
     "bashing": 2,
     "flags": [ "OUTER", "FRAGILE" ],
-    "coverage": 90,
-    "material_thickness": 4
+    "material_thickness": 4,
+    "armor": { "coverage": 90, "covers": [ "torso" ], "encumbrance": 18 }
   },
   {
     "id": "woodrass_four",
@@ -69,7 +63,6 @@
     "name": { "str": "wooden laminar suit" },
     "weight": "12000 g",
     "color": "brown",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
     "to_hit": -5,
     "symbol": "[",
     "description": "A suit of armor made from thin wooden sheets with carefully cut grooves sewn onto a cloth gambeson.",
@@ -77,11 +70,10 @@
     "material": [ "wood", "cotton" ],
     "volume": "8500 ml",
     "warmth": 15,
-    "encumbrance": 18,
     "bashing": 2,
     "flags": [ "OUTER", "FRAGILE" ],
-    "coverage": 90,
-    "material_thickness": 4
+    "material_thickness": 4,
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 18 }
   },
   {
     "id": "wiremail_chest",
@@ -90,7 +82,6 @@
     "name": { "str": "wire mail shirt" },
     "weight": "4600 g",
     "color": "light_gray",
-    "covers": [ "torso" ],
     "to_hit": -5,
     "symbol": "[",
     "description": "A shirt made out of wires, coiled around and sewn into fabric. Not even close to a proper mail, but better than just clothing.",
@@ -98,10 +89,9 @@
     "material": [ "cotton", "steel" ],
     "volume": "3500 ml",
     "warmth": 10,
-    "encumbrance": 5,
     "flags": [ "FRAGILE" ],
-    "coverage": 90,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 90, "covers": [ "torso" ], "encumbrance": 5 }
   },
   {
     "id": "wiremail_arms",
@@ -110,7 +100,6 @@
     "name": { "str": "wire mail sleeves" },
     "weight": "1700 g",
     "color": "light_gray",
-    "covers": [ "hand_l", "hand_r" ],
     "to_hit": -5,
     "symbol": "[",
     "description": "A pair of sleeves made out of wires, coiled around and sewn into fabric. Sacrifices coverage to leave the elbow unencumbered. Not even close to a proper mail, but better than just clothing.",
@@ -118,10 +107,9 @@
     "material": [ "cotton", "steel" ],
     "volume": "1500 ml",
     "warmth": 10,
-    "encumbrance": 5,
     "flags": [ "FRAGILE" ],
-    "coverage": 80,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 80, "covers": [ "hand_l", "hand_r" ], "encumbrance": 5 }
   },
   {
     "id": "wiremail_legs",
@@ -130,7 +118,6 @@
     "name": { "str": "wire mail leggins" },
     "weight": "2400 g",
     "color": "light_gray",
-    "covers": [ "leg_l", "leg_r" ],
     "to_hit": -5,
     "symbol": "[",
     "description": "A pair of leggins made out of wires, coiled around and sewn into fabric. Sacrifices coverage to leave the knee unencumbered. Not even close to a proper mail, but better than just clothing.",
@@ -138,10 +125,9 @@
     "material": [ "cotton", "steel" ],
     "volume": "2 L",
     "warmth": 10,
-    "encumbrance": 5,
     "flags": [ "FRAGILE" ],
-    "coverage": 80,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 80, "covers": [ "leg_l", "leg_r" ], "encumbrance": 5 }
   },
   {
     "id": "wooden_helm",
@@ -150,7 +136,6 @@
     "name": { "str": "wooden helmet" },
     "weight": "1800 g",
     "color": "brown",
-    "covers": [ "head" ],
     "techniques": [ "WBLOCK_1" ],
     "to_hit": -1,
     "symbol": "[",
@@ -159,11 +144,10 @@
     "material": [ "wood" ],
     "volume": "1750 ml",
     "warmth": 15,
-    "encumbrance": 30,
     "bashing": 8,
     "flags": [ "FRAGILE" ],
-    "coverage": 75,
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 75, "covers": [ "head" ], "encumbrance": 30 }
   },
   {
     "id": "bottle_vambraces",
@@ -172,17 +156,15 @@
     "name": { "str": "bottle vambraces" },
     "weight": "30 g",
     "color": "white",
-    "covers": [ "hand_l", "hand_r" ],
     "symbol": "[",
     "description": "Have a spare bottle? Cut it in half, stuff inside some padding, fasten it with rags or string and use as vambraces. Hey, it's better than nothing.",
     "price": "50 cent",
     "material": [ "plastic" ],
     "volume": "500 ml",
     "warmth": 0,
-    "encumbrance": 3,
     "flags": [ "BELTED", "WATER_FRIENDLY" ],
-    "coverage": 25,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 25, "covers": [ "hand_l", "hand_r" ], "encumbrance": 3 }
   },
   {
     "id": "plastic_chest",
@@ -191,7 +173,6 @@
     "name": { "str": "plastic breastplate" },
     "weight": "1400 g",
     "color": "dark_gray",
-    "covers": [ "torso" ],
     "to_hit": -5,
     "symbol": "[",
     "description": "A makeshift plastic breastplate with some padding. Not as good as factory-made football armor, but it's way less bulky and covers more torso area.",
@@ -200,10 +181,9 @@
     "volume": "2750 ml",
     "warmth": 10,
     "environmental_protection": 3,
-    "encumbrance": 10,
     "flags": [ "OUTER" ],
-    "coverage": 65,
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 65, "covers": [ "torso" ], "encumbrance": 10 }
   },
   {
     "id": "plastic_sheath",
@@ -215,14 +195,12 @@
     "description": "A plastic sheath with a fastening strap and using rags as inner padding. A bit more clumsy to use than the regular sheath. Activate to sheathe/draw a weapon.",
     "price": "30 USD",
     "material": [ "plastic" ],
-    "covers": [ "leg_l", "leg_r" ],
     "volume": "500 ml",
     "warmth": 0,
-    "encumbrance": 1,
-    "coverage": 5,
     "material_thickness": 1,
     "flags": [ "WAIST", "OVERSIZE", "SHEATH_KNIFE" ],
-    "use_action": { "type": "holster", "holster_prompt": "Sheath knife", "holster_msg": "You sheath your %s" }
+    "use_action": { "type": "holster", "holster_prompt": "Sheath knife", "holster_msg": "You sheath your %s" },
+    "armor": { "coverage": 5, "covers": [ "leg_l", "leg_r" ], "encumbrance": 1 }
   },
   {
     "id": "can_vambraces",
@@ -231,17 +209,15 @@
     "name": { "str": "tin can vambraces" },
     "weight": "800 g",
     "color": "blue",
-    "covers": [ "hand_l", "hand_r" ],
     "symbol": "[",
     "description": "A pair of tin cans with removed bottoms and cut open along the side to allow wearing them on wrists. Some rags are wrapped around the sharp sides and to hold it firmly.",
     "price": "20 cent",
     "material": [ "iron" ],
     "volume": "500 ml",
     "warmth": 0,
-    "encumbrance": 6,
     "flags": [ "BELTED" ],
-    "coverage": 25,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 25, "covers": [ "hand_l", "hand_r" ], "encumbrance": 6 }
   },
   {
     "id": "linothorax",
@@ -250,7 +226,6 @@
     "name": { "str": "linothorax", "str_pl": "linothoraxes" },
     "weight": "3500 g",
     "color": "white",
-    "covers": [ "torso" ],
     "to_hit": -5,
     "symbol": "[",
     "description": "A semi-historical(it would be neat to add small pockets) replica of linothorax. Strong, light and comfortable; it has only one flaw - it will fall apart under the rain, and the only way of waterproofing you can think of is the beeswax. ",
@@ -258,9 +233,7 @@
     "material": [ "cotton" ],
     "volume": "5 L",
     "warmth": 10,
-    "encumbrance": 6,
     "flags": [ "OUTER", "STURDY" ],
-    "coverage": 95,
     "material_thickness": 8,
     "pocket_data": [
       {
@@ -270,7 +243,8 @@
         "max_item_length": "40 cm",
         "moves": 40
       }
-    ]
+    ],
+    "armor": { "coverage": 95, "covers": [ "torso" ], "encumbrance": 6 }
   },
   {
     "id": "sandbag_vest",
@@ -279,7 +253,6 @@
     "name": { "str": "sandbag vest" },
     "weight": "3300 g",
     "color": "dark_gray",
-    "covers": [ "torso" ],
     "to_hit": -5,
     "symbol": "[",
     "description": "A vest with dozens of sand-filled pockets. Kinda prone to ripping, and when it happens the sand disperses, making it impossible to repair, only make a new one.",
@@ -287,10 +260,9 @@
     "material": [ "powder" ],
     "volume": "4500 ml",
     "warmth": 10,
-    "encumbrance": 6,
     "flags": [ "OUTER", "FRAGILE" ],
-    "coverage": 85,
-    "material_thickness": 5
+    "material_thickness": 5,
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": 6 }
   },
   {
     "id": "cardboard_visor",
@@ -299,18 +271,16 @@
     "name": { "str": "cardboard visor" },
     "weight": "30 g",
     "color": "brown",
-    "covers": [ "head" ],
     "symbol": "[",
     "description": "A cardboard visor. Protects from sun glare.",
     "price": "20 cent",
     "material": [ "paper" ],
     "volume": "250 ml",
     "warmth": 0,
-    "encumbrance": 10,
     "flags": [ "OUTER", "FRAGILE", "SUN_GLASSES" ],
     "qualities": [ [ "GLARE", 1 ] ],
-    "coverage": 10,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 10, "covers": [ "head" ], "encumbrance": 10 }
   },
   {
     "id": "woodrass_five",
@@ -319,7 +289,6 @@
     "name": { "str": "wooden scale cuirass", "str_pl": "wooden scale cuirasses" },
     "weight": "8000 g",
     "color": "brown",
-    "covers": [ "torso" ],
     "to_hit": -5,
     "symbol": "[",
     "description": "An armor made from wooden scales with carefully drilled holes sewn onto a cloth undershirt.",
@@ -327,11 +296,10 @@
     "material": [ "wood", "cotton" ],
     "volume": "5500 ml",
     "warmth": 15,
-    "encumbrance": 14,
     "bashing": 2,
     "flags": [ "OUTER", "FRAGILE" ],
-    "coverage": 95,
-    "material_thickness": 4
+    "material_thickness": 4,
+    "armor": { "coverage": 95, "covers": [ "torso" ], "encumbrance": 14 }
   },
   {
     "id": "woodrass_six",
@@ -340,7 +308,6 @@
     "name": { "str": "wooden scale suit" },
     "weight": "12000 g",
     "color": "brown",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
     "to_hit": -5,
     "symbol": "[",
     "description": "A suit of armor made from wooden scales with carefully drilled holes sewn onto a cloth gambeson.",
@@ -348,11 +315,10 @@
     "material": [ "wood", "cotton" ],
     "volume": "8500 ml",
     "warmth": 15,
-    "encumbrance": 14,
     "bashing": 2,
     "flags": [ "OUTER", "FRAGILE" ],
-    "coverage": 95,
-    "material_thickness": 4
+    "material_thickness": 4,
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 14 }
   },
   {
     "id": "metal_skullcap",
@@ -361,7 +327,6 @@
     "name": { "str": "makeshift metal skullcap" },
     "weight": "800 g",
     "color": "light_gray",
-    "covers": [ "head" ],
     "to_hit": -2,
     "symbol": "[",
     "description": "A skullcap hammered out of metal sheet.",
@@ -369,11 +334,10 @@
     "material": [ "iron" ],
     "volume": "1 L",
     "warmth": 10,
-    "encumbrance": 25,
     "bashing": 4,
     "flags": [ "FRAGILE" ],
-    "coverage": 60,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 60, "covers": [ "head" ], "encumbrance": 25 }
   },
   {
     "id": "metal_vest",
@@ -382,7 +346,6 @@
     "name": { "str": "metal sheet vest" },
     "weight": "2600 g",
     "color": "light_gray",
-    "covers": [ "torso" ],
     "to_hit": -5,
     "symbol": "[",
     "description": "A vest with two thin, but nevertheless inflexible metal sheets sealed inside its big pockets.",
@@ -390,11 +353,10 @@
     "material": [ "cotton", "iron" ],
     "volume": "3500 ml",
     "warmth": 10,
-    "encumbrance": 15,
     "bashing": 4,
     "flags": [ "OUTER", "FRAGILE" ],
-    "coverage": 75,
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 75, "covers": [ "torso" ], "encumbrance": 15 }
   },
   {
     "id": "blanket_poncho",
@@ -403,7 +365,6 @@
     "name": { "str": "blanket poncho" },
     "weight": "1100 g",
     "color": "light_gray",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
     "to_hit": -5,
     "symbol": "[",
     "description": "A blanket with a hole for the head and a belt. Less encumbering to wear, but also less warm.",
@@ -411,10 +372,9 @@
     "material": [ "cotton" ],
     "volume": "2500 ml",
     "warmth": 35,
-    "encumbrance": 20,
     "flags": [ "OVERSIZE", "OUTER", "POCKETS" ],
-    "coverage": 75,
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 75, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 20 }
   },
   {
     "id": "wooden_mask",
@@ -423,7 +383,6 @@
     "name": { "str": "wooden mask" },
     "weight": "550 g",
     "color": "light_gray",
-    "covers": [ "eyes", "mouth" ],
     "to_hit": -5,
     "symbol": "[",
     "description": "A plain wooden mask. Looks kinda... creepy.",
@@ -431,9 +390,8 @@
     "material": [ "wood" ],
     "volume": "500 ml",
     "warmth": 0,
-    "encumbrance": 9,
-    "coverage": 75,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 75, "covers": [ "eyes", "mouth" ], "encumbrance": 9 }
   },
   {
     "id": "tire_armguards",
@@ -442,7 +400,6 @@
     "name": { "str": "tire arm guards" },
     "weight": "1400 g",
     "color": "black",
-    "covers": [ "hand_l", "hand_r" ],
     "symbol": "[",
     "description": "A pair of arm guards cut from a thick motorbike tire.",
     "price": "5 USD",
@@ -450,10 +407,9 @@
     "volume": "1 L",
     "warmth": 20,
     "environmental_protection": 3,
-    "encumbrance": 10,
     "flags": [ "STURDY", "BELTED", "BLOCK_WHILE_WORN" ],
-    "coverage": 80,
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 80, "covers": [ "hand_l", "hand_r" ], "encumbrance": 10 }
   },
   {
     "id": "tire_legguards",
@@ -462,7 +418,6 @@
     "name": { "str": "tire leg guards" },
     "weight": "2200 g",
     "color": "black",
-    "covers": [ "leg_l", "leg_r" ],
     "symbol": "[",
     "description": "A pair of leg guards cut from a thick automobile tire.",
     "price": "5 USD",
@@ -470,10 +425,9 @@
     "volume": "2 L",
     "warmth": 20,
     "environmental_protection": 3,
-    "encumbrance": 6,
     "flags": [ "STURDY", "BELTED" ],
-    "coverage": 75,
-    "material_thickness": 4
+    "material_thickness": 4,
+    "armor": { "coverage": 75, "covers": [ "leg_l", "leg_r" ], "encumbrance": 6 }
   },
   {
     "id": "wire_holster",
@@ -482,7 +436,6 @@
     "name": { "str": "wire holster" },
     "weight": "50 g",
     "color": "blue",
-    "covers": [ "torso" ],
     "symbol": "[",
     "description": "Also called coat hanger or jamaican holster, this is just a piece of wire with one end going into a barrel and the other one belted to pants. For small firearms only.",
     "price": "5 USD",
@@ -490,11 +443,10 @@
     "volume": "250 ml",
     "warmth": 0,
     "environmental_protection": 0,
-    "encumbrance": 0,
     "flags": [ "WAIST", "OVERSIZE", "NO_QUICKDRAW" ],
-    "coverage": 0,
     "material_thickness": 1,
-    "use_action": { "type": "holster", "holster_prompt": "holster pistol", "holster_msg": "You holster your %s" }
+    "use_action": { "type": "holster", "holster_prompt": "holster pistol", "holster_msg": "You holster your %s" },
+    "armor": { "coverage": 0, "covers": [ "torso" ], "encumbrance": 0 }
   },
   {
     "id": "patch_pants",
@@ -502,7 +454,6 @@
     "name": { "str": "patchwork pants", "str_pl": "pants" },
     "weight": "600 g",
     "color": "brown",
-    "covers": [ "leg_l", "leg_r" ],
     "to_hit": 1,
     "symbol": "[",
     "description": "A pair of makeshift patchwork pants. ",
@@ -510,10 +461,9 @@
     "material": [ "cotton" ],
     "volume": "2 L",
     "warmth": 15,
-    "encumbrance": 11,
     "flags": [ "VARSIZE" ],
-    "coverage": 95,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r" ], "encumbrance": 11 }
   },
   {
     "id": "shield_wicker",
@@ -528,11 +478,9 @@
     "material": [ "veggy" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 70,
-    "encumbrance": 5,
     "material_thickness": 5,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN", "STURDY" ]
+    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN", "STURDY" ],
+    "armor": { "coverage": 70, "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 5 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/More_Makeshift_Stuff/mod_tools_armor.json
+++ b/data/Unleash_The_Mods/Working_mods/More_Makeshift_Stuff/mod_tools_armor.json
@@ -12,15 +12,13 @@
     "weight": "2100 g",
     "volume": "2500 ml",
     "use_action": { "type": "transform", "moves": 100, "msg": "You open your visor", "target": "visored_helm_open" },
-    "covers": [ "head", "eyes", "mouth" ],
     "techniques": [ "WBLOCK_1" ],
     "flags": [ "VARSIZE" ],
     "warmth": 10,
     "environmental_protection": 1,
-    "encumbrance": 35,
     "bashing": 10,
-    "coverage": 95,
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 95, "covers": [ "head", "eyes", "mouth" ], "encumbrance": 35 }
   },
   {
     "id": "visored_helm_open",
@@ -35,15 +33,13 @@
     "weight": "2100 g",
     "volume": "2500 ml",
     "use_action": { "type": "transform", "moves": 100, "msg": "You lower your visor", "target": "visored_helm" },
-    "covers": [ "head" ],
     "techniques": [ "WBLOCK_1" ],
     "flags": [ "VARSIZE" ],
     "warmth": 10,
     "environmental_protection": 1,
-    "encumbrance": 35,
     "bashing": 10,
-    "coverage": 95,
     "qualities": [ [ "GLARE", 1 ] ],
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 95, "covers": [ "head" ], "encumbrance": 35 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/More_Military/items/armor.json
+++ b/data/Unleash_The_Mods/Working_mods/More_Military/items/armor.json
@@ -46,9 +46,8 @@
     "type": "ARMOR",
     "name": { "str": "H.E.C.U tactical fingerless gloves." },
     "description": "Although not as protective as its full covered conterpart, it allows for better dexterty which the H.E.C.U finds it more important.",
-    "encumbrance": 10,
-    "coverage": 50,
-    "warmth": 15
+    "warmth": 15,
+    "armor": { "coverage": 50, "encumbrance": 10 }
   },
   {
     "id": "hecu_backpack",

--- a/data/Unleash_The_Mods/Working_mods/More_Military/items/tool_armor.json
+++ b/data/Unleash_The_Mods/Working_mods/More_Military/items/tool_armor.json
@@ -23,9 +23,6 @@
     "material": [ "plastic" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "eyes", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 40,
     "warmth": 20,
     "material_thickness": 2,
     "environmental_protection": 16,
@@ -41,7 +38,8 @@
       "USE_UPS",
       "NO_UNLOAD",
       "NO_RELOAD"
-    ]
+    ],
+    "armor": { "coverage": 100, "covers": [ "eyes", "mouth" ], "encumbrance": 40 }
   },
   {
     "id": "hecu_gasmask_on",
@@ -62,9 +60,6 @@
     "material": [ "plastic" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "eyes", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 30,
     "warmth": 20,
     "material_thickness": 2,
     "environmental_protection": 16,
@@ -82,7 +77,8 @@
       "USE_UPS",
       "NO_UNLOAD",
       "NO_RELOAD"
-    ]
+    ],
+    "armor": { "coverage": 100, "covers": [ "eyes", "mouth" ], "encumbrance": 30 }
   },
   {
     "id": "pcv",
@@ -98,7 +94,6 @@
     "material": [ "kevlar" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "torso" ],
     "ammo": [ "battery" ],
     "max_charges": 0,
     "initial_charges": 0,
@@ -110,8 +105,6 @@
       "need_charges": 1,
       "need_charges_msg": "Insuficient power..."
     },
-    "coverage": 85,
-    "encumbrance": 7,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "2 kg", "moves": 40 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "2 kg", "moves": 40 }
@@ -119,7 +112,8 @@
     "warmth": 10,
     "material_thickness": 4,
     "environmental_protection": 4,
-    "flags": [ "WATER_FRIENDLY", "STURDY", "VARSIZE", "USE_UPS", "NO_UNLOAD", "NO_RELOAD", "OUTER" ]
+    "flags": [ "WATER_FRIENDLY", "STURDY", "VARSIZE", "USE_UPS", "NO_UNLOAD", "NO_RELOAD", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": 7 }
   },
   {
     "id": "pcv_on",
@@ -135,9 +129,6 @@
     "material": [ "kevlar" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "torso" ],
-    "coverage": 85,
-    "encumbrance": 7,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "2 kg", "moves": 40 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "2 kg", "moves": 40 }
@@ -163,7 +154,8 @@
       "NO_UNLOAD",
       "NO_RELOAD",
       "OUTER"
-    ]
+    ],
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": 7 }
   },
   {
     "id": "hecu_jacket",
@@ -203,9 +195,8 @@
     "type": "ARMOR",
     "name": { "str": "H.E.C.U tactical fingerless gloves." },
     "description": "Although not as protective as its full covered conterpart, it allows for better dexterty which the H.E.C.U finds it more important.",
-    "encumbrance": 10,
-    "coverage": 50,
-    "warmth": 15
+    "warmth": 15,
+    "armor": { "coverage": 50, "encumbrance": 10 }
   },
   {
     "id": "hecu_backpack",

--- a/data/Unleash_The_Mods/Working_mods/Mutamans_stuff/item.json
+++ b/data/Unleash_The_Mods/Working_mods/Mutamans_stuff/item.json
@@ -46,10 +46,6 @@
     "symbol": "U",
     "looks_like": "55gal_drum",
     "color": "light_gray",
-    "covers": [ "torso" ],
-    "coverage": 20,
-    "encumbrance": 40,
-    "max_encumbrance": 40,
     "warmth": 0,
     "material_thickness": 1,
     "pocket_data": [
@@ -64,7 +60,8 @@
         "moves": 600
       }
     ],
-    "flags": [ "OVERSIZE", "WATER_FRIENDLY", "ONLY_ONE" ]
+    "flags": [ "OVERSIZE", "WATER_FRIENDLY", "ONLY_ONE" ],
+    "armor": { "coverage": 20, "covers": [ "torso" ], "encumbrance": [ 40, 40 ] }
   },
   {
     "id": "100L_drum_pack",
@@ -80,10 +77,6 @@
     "symbol": "U",
     "looks_like": "30gal_drum",
     "color": "light_gray",
-    "covers": [ "torso" ],
-    "coverage": 20,
-    "encumbrance": 20,
-    "max_encumbrance": 20,
     "warmth": 0,
     "material_thickness": 1,
     "pocket_data": [
@@ -98,7 +91,8 @@
         "moves": 600
       }
     ],
-    "flags": [ "OVERSIZE", "WATER_FRIENDLY", "ONLY_ONE" ]
+    "flags": [ "OVERSIZE", "WATER_FRIENDLY", "ONLY_ONE" ],
+    "armor": { "coverage": 20, "covers": [ "torso" ], "encumbrance": [ 20, 20 ] }
   },
   {
     "id": "fan_suit",
@@ -124,9 +118,7 @@
       "need_charges": 1,
       "need_charges_msg": "The %s's batteries are dead."
     },
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r", "hand_l", "hand_r", "head", "foot_l", "foot_r", "mouth" ],
     "warmth": 10,
-    "coverage": 100,
     "material_thickness": 1,
     "pocket_data": [
       {
@@ -145,7 +137,11 @@
           "medium_disposable_cell"
         ]
       }
-    ]
+    ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r", "hand_l", "hand_r", "head", "foot_l", "foot_r", "mouth" ]
+    }
   },
   {
     "id": "fan_suit_on",
@@ -194,7 +190,6 @@
     "material": [ "rubber", "plastic", "copper" ],
     "weight": "864 g",
     "volume": "2 L",
-    "encumbrance": 10,
     "charges_per_use": 3,
     "ammo": [ "battery" ],
     "use_action": {
@@ -205,9 +200,7 @@
       "need_charges": 1,
       "need_charges_msg": "The %s's batteries are dead."
     },
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r", "hand_l", "hand_r", "head", "foot_l", "foot_r", "mouth" ],
     "warmth": 10,
-    "coverage": 100,
     "material_thickness": 2,
     "pocket_data": [
       {
@@ -226,7 +219,12 @@
           "medium_disposable_cell"
         ]
       }
-    ]
+    ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r", "hand_l", "hand_r", "head", "foot_l", "foot_r", "mouth" ],
+      "encumbrance": 10
+    }
   },
   {
     "id": "emr_suit_on",
@@ -255,7 +253,6 @@
     "material": [ "rubber", "plastic", "copper" ],
     "weight": "864 g",
     "volume": "2 L",
-    "encumbrance": 15,
     "charges_per_use": 5,
     "ammo": [ "battery" ],
     "use_action": {
@@ -266,9 +263,7 @@
       "need_charges": 1,
       "need_charges_msg": "The %s's batteries are dead."
     },
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r", "hand_l", "hand_r", "head", "foot_l", "foot_r", "mouth" ],
     "warmth": 10,
-    "coverage": 100,
     "material_thickness": 2,
     "pocket_data": [
       {
@@ -287,7 +282,12 @@
           "heavy_disposable_cell"
         ]
       }
-    ]
+    ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r", "hand_l", "hand_r", "head", "foot_l", "foot_r", "mouth" ],
+      "encumbrance": 15
+    }
   },
   {
     "id": "lnemr_suit_on",

--- a/data/Unleash_The_Mods/Working_mods/Mutated_Arsenal/Mutated_arsenal.json
+++ b/data/Unleash_The_Mods/Working_mods/Mutated_Arsenal/Mutated_arsenal.json
@@ -13,9 +13,6 @@
     "material": [ "hardsteel", "steel" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 60,
     "warmth": 60,
     "power_armor": true,
     "material_thickness": 12,
@@ -30,7 +27,12 @@
         "moves": 200
       }
     ],
-    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE", "ALLOWS_NATURAL_ATTACKS" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 60
+    }
   },
   {
     "id": "power_armor_mutant_on",
@@ -44,7 +46,6 @@
     "power_draw": 4000000,
     "revert_to": "power_armor_basic",
     "use_action": { "type": "transform", "menu_text": "Turn off", "msg": "Your power armor disengages.", "target": "power_armor_mutant" },
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -53,7 +54,8 @@
         "max_contains_weight": "15 kg",
         "moves": 200
       }
-    ]
+    ],
+    "armor": { "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ] }
   },
   {
     "id": "power_armor_helmet_mutant",
@@ -69,14 +71,12 @@
     "material": [ "hardsteel", "steel" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "head", "eyes", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 60,
     "warmth": 60,
     "power_armor": true,
     "material_thickness": 12,
     "environmental_protection": 16,
     "qualities": [ [ "GLARE", 2 ] ],
-    "flags": [ "OVERSIZE", "VARSIZE", "WATCH", "WATERPROOF", "STURDY", "PARTIAL_DEAF", "THERMOMETER", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "OVERSIZE", "VARSIZE", "WATCH", "WATERPROOF", "STURDY", "PARTIAL_DEAF", "THERMOMETER", "ALLOWS_NATURAL_ATTACKS" ],
+    "armor": { "coverage": 100, "covers": [ "head", "eyes", "mouth" ], "encumbrance": 60 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/NBC_Items_Pack/armor/nbc_armor.json
+++ b/data/Unleash_The_Mods/Working_mods/NBC_Items_Pack/armor/nbc_armor.json
@@ -48,11 +48,8 @@
       "need_charges": 1,
       "need_charges_msg": "The %s needs a filter before it becomes useful."
     },
-    "covers": [ "eyes", "mouth" ],
     "warmth": 15,
     "environmental_protection": 3,
-    "encumbrance": 2,
-    "coverage": 100,
     "material_thickness": 1,
     "pocket_data": [
       {
@@ -63,7 +60,8 @@
         "max_contains_weight": "20 kg",
         "item_restriction": [ "sm_filter_1a" ]
       }
-    ]
+    ],
+    "armor": { "coverage": 100, "covers": [ "eyes", "mouth" ], "encumbrance": 2 }
   },
   {
     "id": "mask_gp5_act",
@@ -87,12 +85,10 @@
     "turns_per_charge": 10,
     "revert_to": "mask_gp5",
     "use_action": { "type": "transform", "target": "mask_gp5", "msg": "It's getting hard to breathe, this filter is used up." },
-    "covers": [ "eyes", "mouth" ],
     "warmth": 15,
     "environmental_protection": 10,
-    "encumbrance": 2,
-    "coverage": 100,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 100, "covers": [ "eyes", "mouth" ], "encumbrance": 2 }
   },
   {
     "id": "mask_hosed",
@@ -119,8 +115,6 @@
     "volume": "1500 ml",
     "to_hit": -3,
     "warmth": 30,
-    "encumbrance": 3,
-    "coverage": 100,
     "material_thickness": 1,
     "environmental_protection": 3,
     "environmental_protection_with_filter": 10,
@@ -128,7 +122,7 @@
     "ammo": [ "filter_open_1" ],
     "revert_to": "mask_hosed",
     "use_action": [ "GASMASK" ],
-    "covers": [ "eyes", "mouth" ]
+    "armor": { "coverage": 100, "covers": [ "eyes", "mouth" ], "encumbrance": 3 }
   },
   {
     "id": "mask_hosed_act",
@@ -156,12 +150,10 @@
       "target": "mask_hosed",
       "msg": "The filter has expired and will no longer protect against airborne contaminants."
     },
-    "covers": [ "eyes", "mouth" ],
     "warmth": 15,
     "environmental_protection": 15,
-    "encumbrance": 3,
-    "coverage": 100,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 100, "covers": [ "eyes", "mouth" ], "encumbrance": 3 }
   },
   {
     "id": "mask_pbf",
@@ -193,11 +185,8 @@
       "need_charges": 2,
       "need_charges_msg": "The %s needs a filter."
     },
-    "covers": [ "eyes", "mouth" ],
     "warmth": 30,
     "environmental_protection": 5,
-    "encumbrance": 2,
-    "coverage": 100,
     "material_thickness": 2,
     "pocket_data": [
       {
@@ -208,7 +197,8 @@
         "max_contains_weight": "20 kg",
         "item_restriction": [ "cheek_filter" ]
       }
-    ]
+    ],
+    "armor": { "coverage": 100, "covers": [ "eyes", "mouth" ], "encumbrance": 2 }
   },
   {
     "id": "mask_pbf_act",
@@ -236,12 +226,10 @@
       "target": "mask_pbf_exp",
       "msg": "The filters have expired and will no longer protect against airborne contaminants."
     },
-    "covers": [ "eyes", "mouth" ],
     "warmth": 30,
     "environmental_protection": 20,
-    "encumbrance": 2,
-    "coverage": 100,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 100, "covers": [ "eyes", "mouth" ], "encumbrance": 2 }
   },
   {
     "id": "mask_pbf_exp",
@@ -259,12 +247,10 @@
     "bashing": 0,
     "cutting": 0,
     "to_hit": -3,
-    "covers": [ "eyes", "mouth" ],
     "warmth": 30,
     "environmental_protection": 5,
-    "encumbrance": 2,
-    "coverage": 100,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 100, "covers": [ "eyes", "mouth" ], "encumbrance": 2 }
   },
   {
     "id": "mask_4a",
@@ -296,11 +282,8 @@
       "need_charges": 1,
       "need_charges_msg": "The %s needs a filter."
     },
-    "covers": [ "eyes", "mouth" ],
     "warmth": 30,
     "environmental_protection": 5,
-    "encumbrance": 2,
-    "coverage": 100,
     "material_thickness": 2,
     "pocket_data": [
       {
@@ -311,7 +294,8 @@
         "max_contains_weight": "20 kg",
         "item_restriction": [ "sm_filter_1b" ]
       }
-    ]
+    ],
+    "armor": { "coverage": 100, "covers": [ "eyes", "mouth" ], "encumbrance": 2 }
   },
   {
     "id": "mask_4a_act",
@@ -339,12 +323,10 @@
       "target": "mask_4a",
       "msg": "The filter has expired and will no longer protect against airborne contaminants."
     },
-    "covers": [ "eyes", "mouth" ],
     "warmth": 30,
     "environmental_protection": 15,
-    "encumbrance": 2,
-    "coverage": 100,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 100, "covers": [ "eyes", "mouth" ], "encumbrance": 2 }
   },
   {
     "id": "mask_m40",
@@ -376,11 +358,8 @@
       "need_charges": 1,
       "need_charges_msg": "The %s needs a filter."
     },
-    "covers": [ "eyes", "mouth" ],
     "warmth": 30,
     "environmental_protection": 10,
-    "encumbrance": 2,
-    "coverage": 100,
     "material_thickness": 2,
     "pocket_data": [
       {
@@ -391,7 +370,8 @@
         "max_contains_weight": "20 kg",
         "item_restriction": [ "sm_filter_1b" ]
       }
-    ]
+    ],
+    "armor": { "coverage": 100, "covers": [ "eyes", "mouth" ], "encumbrance": 2 }
   },
   {
     "id": "mask_m40_act",
@@ -419,12 +399,10 @@
       "target": "mask_m40",
       "msg": "The filter has expired and will no longer protect against airborne contaminants."
     },
-    "covers": [ "eyes", "mouth" ],
     "warmth": 30,
     "environmental_protection": 20,
-    "encumbrance": 2,
-    "coverage": 100,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 100, "covers": [ "eyes", "mouth" ], "encumbrance": 2 }
   },
   {
     "id": "sub_suit",
@@ -432,7 +410,6 @@
     "name": { "str": "submarine escape suit" },
     "weight": "4280 g",
     "color": "light_red",
-    "covers": [ "head", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
     "to_hit": -8,
     "symbol": "[",
     "description": "An orange full body suit normally only found on submarines, this suit is meant to be worn with the IP-4 rebreather.",
@@ -443,11 +420,14 @@
     "warmth": 40,
     "phase": "solid",
     "environmental_protection": 20,
-    "encumbrance": 5,
     "bashing": 5,
     "flags": [ "WATERPROOF", "WATER_FRIENDLY", "RAINPROOF", "STURDY", "OVERSIZE", "VARSIZE", "ELECTRIC_IMMUNE", "OUTER" ],
-    "coverage": 100,
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": {
+      "coverage": 100,
+      "covers": [ "head", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 5
+    }
   },
   {
     "id": "ozk_suit",
@@ -455,7 +435,6 @@
     "name": { "str": "OZK chemical suit" },
     "weight": "4280 g",
     "color": "light_green",
-    "covers": [ "head", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
     "to_hit": -8,
     "symbol": "[",
     "description": "Mint green NBC suit from military surplus store. Made of rubberized canvas, provides good environmental resistance. Comes with pockets for the Geiger counter and ushanka hat.",
@@ -466,17 +445,20 @@
     "warmth": 10,
     "phase": "solid",
     "environmental_protection": 20,
-    "encumbrance": 3,
     "bashing": 5,
     "flags": [ "WATERPROOF", "RAINPROOF", "STURDY", "OVERSIZE", "VARSIZE", "RAD_RESIST", "ACID_RESIST", "OUTER" ],
-    "coverage": 100,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "1250 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "1250 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "1250 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "1250 kg", "moves": 80 }
     ],
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": {
+      "coverage": 100,
+      "covers": [ "head", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 3
+    }
   },
   {
     "id": "l1_suit",
@@ -484,7 +466,6 @@
     "name": { "str": "L-1 NBC suit" },
     "weight": "5000 g",
     "color": "dark_gray",
-    "covers": [ "head", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
     "to_hit": -8,
     "symbol": "[",
     "description": "Premium gray NBC suit from military surplus store. Has enough pockets to hold the CBRN kit, spare vodka, and bear cubs.",
@@ -495,17 +476,20 @@
     "warmth": 40,
     "phase": "solid",
     "environmental_protection": 30,
-    "encumbrance": 5,
     "bashing": 5,
     "flags": [ "WATERPROOF", "RAINPROOF", "STURDY", "OVERSIZE", "VARSIZE", "RAD_PROOF", "ACIDPROOF", "OUTER" ],
-    "coverage": 100,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "2500 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "2500 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "2500 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "2500 kg", "moves": 80 }
     ],
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": {
+      "coverage": 100,
+      "covers": [ "head", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 5
+    }
   },
   {
     "id": "filter_bag",
@@ -513,7 +497,6 @@
     "name": { "str": "filter bag" },
     "weight": "297 g",
     "color": "green",
-    "covers": [ "torso" ],
     "to_hit": 1,
     "symbol": "[",
     "description": "Bag for carrying extra gas mask filters. Sometimes mistaken for a purse.",
@@ -524,12 +507,11 @@
     "warmth": 0,
     "phase": "solid",
     "environmental_protection": 0,
-    "encumbrance": 0,
     "bashing": 1,
-    "coverage": 10,
     "flags": [ "BELTED" ],
     "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "2000 ml", "max_contains_weight": "2500 kg", "moves": 80 } ],
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 10, "covers": [ "torso" ], "encumbrance": 0 }
   },
   {
     "id": "large_filter_bag",
@@ -537,7 +519,6 @@
     "name": { "str": "military filter bag" },
     "weight": "594 g",
     "color": "green",
-    "covers": [ "torso" ],
     "to_hit": 1,
     "symbol": "[",
     "description": "Bag for carrying extra gas mask filters. This is the large military version.",
@@ -548,15 +529,14 @@
     "warmth": 0,
     "phase": "solid",
     "environmental_protection": 0,
-    "encumbrance": 0,
     "bashing": 1,
-    "coverage": 10,
     "flags": [ "BELTED" ],
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2000 ml", "max_contains_weight": "2500 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2000 ml", "max_contains_weight": "2500 kg", "moves": 80 }
     ],
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 10, "covers": [ "torso" ], "encumbrance": 0 }
   },
   {
     "id": "holdout_suit",
@@ -564,7 +544,6 @@
     "name": { "str": "last resort poncho" },
     "weight": "500 g",
     "color": "light_cyan",
-    "covers": [ "head", "torso", "arm_l", "arm_r" ],
     "to_hit": -8,
     "symbol": "[",
     "description": "A last minute chemical poncho for when you don't have more effective equipment when the acid rain comes.",
@@ -575,10 +554,9 @@
     "warmth": 15,
     "phase": "solid",
     "environmental_protection": 5,
-    "encumbrance": 5,
     "bashing": 5,
     "flags": [ "RAINPROOF", "OVERSIZE", "ACID_RESIST", "OUTER", "HOOD" ],
-    "coverage": 95,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 95, "covers": [ "head", "torso", "arm_l", "arm_r" ], "encumbrance": 5 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Nanites/n_armor.json
+++ b/data/Unleash_The_Mods/Working_mods/Nanites/n_armor.json
@@ -9,15 +9,14 @@
     "weight": "4 g",
     "to_hit": 0,
     "color": "light_gray",
-    "encumbrance": 0,
     "price": "10 USD",
     "material": [ "nanites" ],
-    "coverage": 0,
     "symbol": "[",
     "bashing": 0,
     "cutting": 0,
     "warmth": 0,
     "environmental_protection": 0,
-    "phase": "solid"
+    "phase": "solid",
+    "armor": { "coverage": 0, "encumbrance": 0 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Nechronica_Redux/nec_Armor.json
+++ b/data/Unleash_The_Mods/Working_mods/Nechronica_Redux/nec_Armor.json
@@ -13,9 +13,6 @@
     "looks_like": "briefcase",
     "symbol": "[",
     "color": "white",
-    "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ],
-    "coverage": 50,
-    "encumbrance": 30,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "5 L", "max_contains_weight": "10 kg", "moves": 90 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "5 L", "max_contains_weight": "10 kg", "moves": 90 }
@@ -23,7 +20,8 @@
     "warmth": 5,
     "material_thickness": 2,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "WATER_FRIENDLY", "STURDY", "OVERSIZE", "BELTED", "RESTRICT_HANDS", "DURABLE_MELEE" ]
+    "flags": [ "WATER_FRIENDLY", "STURDY", "OVERSIZE", "BELTED", "RESTRICT_HANDS", "DURABLE_MELEE" ],
+    "armor": { "coverage": 50, "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ], "encumbrance": 30 }
   },
   {
     "id": "nec_coffin",
@@ -38,9 +36,6 @@
     "material": [ "steel", "wood" ],
     "symbol": "[",
     "color": "black",
-    "covers": [ "torso" ],
-    "coverage": 50,
-    "encumbrance": 35,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "17500 ml", "max_contains_weight": "35 kg", "moves": 110 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "17500 ml", "max_contains_weight": "35 kg", "moves": 110 }
@@ -48,7 +43,8 @@
     "warmth": 5,
     "material_thickness": 3,
     "techniques": [ "WBLOCK_3" ],
-    "flags": [ "WATER_FRIENDLY", "STURDY", "BELTED", "OVERSIZE", "DURABLE_MELEE" ]
+    "flags": [ "WATER_FRIENDLY", "STURDY", "BELTED", "OVERSIZE", "DURABLE_MELEE" ],
+    "armor": { "coverage": 50, "covers": [ "torso" ], "encumbrance": 35 }
   },
   {
     "id": "nec_ribbon",
@@ -74,10 +70,8 @@
     "material": [ "cotton", "plastic" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso" ],
-    "coverage": 5,
-    "encumbrance": 0,
-    "flags": [ "BELTED" ]
+    "flags": [ "BELTED" ],
+    "armor": { "coverage": 5, "covers": [ "torso" ], "encumbrance": 0 }
   },
   {
     "id": "nec_gothic_dress",
@@ -91,12 +85,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r" ],
-    "coverage": 90,
-    "encumbrance": 20,
     "warmth": 20,
     "material_thickness": 3,
-    "flags": [ "VARSIZE", "SUPER_FANCY" ]
+    "flags": [ "VARSIZE", "SUPER_FANCY" ],
+    "armor": { "coverage": 90, "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r" ], "encumbrance": 20 }
   },
   {
     "id": "nec_gothic_headdress",
@@ -109,12 +101,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "head" ],
-    "coverage": 20,
-    "encumbrance": 5,
     "warmth": 5,
     "material_thickness": 1,
-    "flags": [ "FANCY" ]
+    "flags": [ "FANCY" ],
+    "armor": { "coverage": 20, "covers": [ "head" ], "encumbrance": 5 }
   },
   {
     "id": "nec_sgothic_dress",
@@ -128,7 +118,6 @@
     "material": [ "kevlar", "cotton" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r" ],
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "5 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "5 kg", "moves": 75 },
@@ -142,12 +131,11 @@
       }
     ],
     "environmental_protection": 1,
-    "coverage": 95,
-    "encumbrance": 18,
     "warmth": 25,
     "material_thickness": 4,
     "use_action": { "type": "holster" },
-    "flags": [ "VARSIZE", "SUPER_FANCY", "OVERSIZE", "WATERPROOF", "RAINPROOF", "STURDY", "POCKETS" ]
+    "flags": [ "VARSIZE", "SUPER_FANCY", "OVERSIZE", "WATERPROOF", "RAINPROOF", "STURDY", "POCKETS" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r" ], "encumbrance": 18 }
   },
   {
     "id": "nec_panier",
@@ -160,11 +148,10 @@
     "description": "An underskirt meant to be worn under a dress. It keeps the skirt puffy by way of wires.",
     "price": "5 USD",
     "material": [ "cotton" ],
-    "covers": [ "leg_l", "leg_r" ],
     "warmth": 5,
-    "encumbrance": 5,
     "volume": "250 ml",
     "flags": [ "OVERSIZE" ],
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "covers": [ "leg_l", "leg_r" ], "encumbrance": 5 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Nimian_Manufacture/nm_armor.json
+++ b/data/Unleash_The_Mods/Working_mods/Nimian_Manufacture/nm_armor.json
@@ -11,15 +11,12 @@
     "color": "blue",
     "symbol": "[",
     "material": [ "plastic" ],
-    "covers": [ "eyes" ],
     "price": "375 USD",
     "cutting": 0,
     "phase": "solid",
     "to_hit": 1,
     "warmth": 0,
-    "encumbrance": 0,
     "bashing": 0,
-    "coverage": 1,
     "material_thickness": 9,
     "max_charges": 100,
     "initial_charges": 100,
@@ -27,6 +24,7 @@
     "turns_per_charge": 0,
     "ammo": [ "battery" ],
     "use_action": "WEATHER_TOOL",
-    "flags": [ "WATCH", "WATERPROOF", "STURDY", "THERMOMETER", "SUPER_FANCY", "SKINTIGHT", "OVERSIZE", "HYGROMETER", "BAROMETER" ]
+    "flags": [ "WATCH", "WATERPROOF", "STURDY", "THERMOMETER", "SUPER_FANCY", "SKINTIGHT", "OVERSIZE", "HYGROMETER", "BAROMETER" ],
+    "armor": { "coverage": 1, "covers": [ "eyes" ], "encumbrance": 0 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/OP_Pack/armor.json
+++ b/data/Unleash_The_Mods/Working_mods/OP_Pack/armor.json
@@ -11,9 +11,6 @@
     "material": [ "omni_alloy" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "torso" ],
-    "coverage": 100,
-    "encumbrance": 0,
     "warmth": 0,
     "material_thickness": 99,
     "environmental_protection": 9999,
@@ -28,7 +25,8 @@
         "spoil_multiplier": 0.01
       }
     ],
-    "flags": [ "BELTED", "WATERPROOF", "TRADER_AVOID", "TARDIS" ]
+    "flags": [ "BELTED", "WATERPROOF", "TRADER_AVOID", "TARDIS" ],
+    "armor": { "coverage": 100, "covers": [ "torso" ], "encumbrance": 0 }
   },
   {
     "id": "omni_bag",
@@ -42,9 +40,6 @@
     "material": [ "omni_alloy" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "torso" ],
-    "coverage": 100,
-    "encumbrance": 0,
     "warmth": 0,
     "material_thickness": 99,
     "environmental_protection": 0,
@@ -59,7 +54,8 @@
         "spoil_multiplier": 0.01
       }
     ],
-    "flags": [ "BELTED", "WATERPROOF", "TRADER_AVOID", "TARDIS" ]
+    "flags": [ "BELTED", "WATERPROOF", "TRADER_AVOID", "TARDIS" ],
+    "armor": { "coverage": 100, "covers": [ "torso" ], "encumbrance": 0 }
   },
   {
     "id": "omni_armor",
@@ -80,9 +76,6 @@
     "material": [ "omni_alloy" ],
     "symbol": "[",
     "color": "green",
-    "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 0,
     "warmth": 100,
     "material_thickness": 999,
     "environmental_protection": 9999,
@@ -112,7 +105,12 @@
       "SLOWS_THIRST",
       "TRADER_AVOID",
       "TARDIS"
-    ]
+    ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "foot_l", "foot_r" ],
+      "encumbrance": 0
+    }
   },
   {
     "id": "omni_armor_on",
@@ -133,9 +131,6 @@
     "material": [ "omni_alloy" ],
     "symbol": "[",
     "color": "green",
-    "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 0,
     "warmth": 100,
     "material_thickness": 999,
     "environmental_protection": 9999,
@@ -166,7 +161,12 @@
       "TRADER_AVOID",
       "LIGHT_1000",
       "TARDIS"
-    ]
+    ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "foot_l", "foot_r" ],
+      "encumbrance": 0
+    }
   },
   {
     "id": "omni_armor_helm",
@@ -187,9 +187,6 @@
     "material": [ "omni_alloy" ],
     "symbol": "[",
     "color": "green",
-    "covers": [ "head", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 0,
     "warmth": 100,
     "material_thickness": 999,
     "environmental_protection": 9999,
@@ -203,7 +200,8 @@
       "TRADER_AVOID",
       "PARTIAL_DEAF",
       "TARDIS"
-    ]
+    ],
+    "armor": { "coverage": 100, "covers": [ "head", "mouth" ], "encumbrance": 0 }
   },
   {
     "id": "omni_armor_helm_on",
@@ -224,9 +222,6 @@
     "material": [ "omni_alloy" ],
     "symbol": "[",
     "color": "green",
-    "covers": [ "head", "mouth", "eyes" ],
-    "coverage": 100,
-    "encumbrance": 0,
     "warmth": 100,
     "material_thickness": 999,
     "environmental_protection": 9999,
@@ -245,6 +240,7 @@
       "SWIM_GOGGLES",
       "SUN_GLASSES",
       "VARSIZE"
-    ]
+    ],
+    "armor": { "coverage": 100, "covers": [ "head", "mouth", "eyes" ], "encumbrance": 0 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/OSRS/items/adamant.json
+++ b/data/Unleash_The_Mods/Working_mods/OSRS/items/adamant.json
@@ -364,14 +364,12 @@
     "material": [ "osrs_adamantite" ],
     "symbol": "[",
     "color": "green",
-    "covers": [ "head", "eyes", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 40,
     "warmth": 10,
     "material_thickness": 1,
     "environmental_protection": 1,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "STURDY", "HELMET_COMPAT" ]
+    "flags": [ "STURDY", "HELMET_COMPAT" ],
+    "armor": { "coverage": 100, "covers": [ "head", "eyes", "mouth" ], "encumbrance": 40 }
   },
   {
     "id": "osrs_chainmail_adamant",
@@ -387,11 +385,9 @@
     "symbol": "[",
     "looks_like": "chainmail_vest",
     "color": "green",
-    "covers": [ "torso" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "material_thickness": 2,
-    "flags": [ "STURDY" ]
+    "flags": [ "STURDY" ],
+    "armor": { "coverage": 95, "covers": [ "torso" ], "encumbrance": 20 }
   },
   {
     "id": "osrs_platelegs_adamant",
@@ -407,12 +403,10 @@
     "symbol": "[",
     "looks_like": "legguard_hard",
     "color": "green",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "warmth": 20,
     "material_thickness": 2,
-    "flags": [ "STURDY" ]
+    "flags": [ "STURDY" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r" ], "encumbrance": 20 }
   },
   {
     "id": "osrs_shield_square_adamant",
@@ -427,12 +421,10 @@
     "material": [ "osrs_adamantite" ],
     "symbol": "[",
     "color": "green",
-    "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 70,
-    "encumbrance": 28,
     "material_thickness": 1,
     "techniques": [ "WBLOCK_3" ],
-    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ]
+    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ],
+    "armor": { "coverage": 70, "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 28 }
   },
   {
     "id": "osrs_plateskirt_adamant",
@@ -448,12 +440,10 @@
     "symbol": "[",
     "looks_like": "legguard_hard",
     "color": "green",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "warmth": 20,
     "material_thickness": 2,
-    "flags": [ "STURDY" ]
+    "flags": [ "STURDY" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r" ], "encumbrance": 20 }
   },
   {
     "id": "osrs_platebody_adamant",
@@ -469,12 +459,10 @@
     "symbol": "[",
     "looks_like": "chestguard_hard",
     "color": "green",
-    "covers": [ "torso" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "warmth": 20,
     "material_thickness": 3,
-    "flags": [ "VARSIZE", "OUTER", "STURDY" ]
+    "flags": [ "VARSIZE", "OUTER", "STURDY" ],
+    "armor": { "coverage": 95, "covers": [ "torso" ], "encumbrance": 20 }
   },
   {
     "id": "osrs_shield_kite_adamant",
@@ -490,12 +478,10 @@
     "material": [ "osrs_adamantite" ],
     "symbol": "[",
     "color": "green",
-    "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 60,
-    "encumbrance": 24,
     "material_thickness": 1,
     "techniques": [ "WBLOCK_3" ],
-    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ]
+    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ],
+    "armor": { "coverage": 60, "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 24 }
   },
   {
     "id": "osrs_crossbow_limbs_adamant",

--- a/data/Unleash_The_Mods/Working_mods/OSRS/items/bronze.json
+++ b/data/Unleash_The_Mods/Working_mods/OSRS/items/bronze.json
@@ -363,14 +363,12 @@
     "material": [ "osrs_bronze" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "head", "eyes", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 40,
     "warmth": 10,
     "material_thickness": 1,
     "environmental_protection": 1,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "STURDY", "HELMET_COMPAT" ]
+    "flags": [ "STURDY", "HELMET_COMPAT" ],
+    "armor": { "coverage": 100, "covers": [ "head", "eyes", "mouth" ], "encumbrance": 40 }
   },
   {
     "id": "osrs_chainmail_bronze",
@@ -386,11 +384,9 @@
     "symbol": "[",
     "looks_like": "chainmail_vest",
     "color": "brown",
-    "covers": [ "torso" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "material_thickness": 2,
-    "flags": [ "STURDY" ]
+    "flags": [ "STURDY" ],
+    "armor": { "coverage": 95, "covers": [ "torso" ], "encumbrance": 20 }
   },
   {
     "id": "osrs_platelegs_bronze",
@@ -406,12 +402,10 @@
     "symbol": "[",
     "looks_like": "legguard_hard",
     "color": "brown",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "warmth": 20,
     "material_thickness": 2,
-    "flags": [ "STURDY" ]
+    "flags": [ "STURDY" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r" ], "encumbrance": 20 }
   },
   {
     "id": "osrs_shield_square_bronze",
@@ -426,12 +420,10 @@
     "material": [ "osrs_bronze" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 70,
-    "encumbrance": 28,
     "material_thickness": 1,
     "techniques": [ "WBLOCK_3" ],
-    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ]
+    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ],
+    "armor": { "coverage": 70, "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 28 }
   },
   {
     "id": "osrs_plateskirt_bronze",
@@ -447,12 +439,10 @@
     "symbol": "[",
     "looks_like": "legguard_hard",
     "color": "brown",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "warmth": 20,
     "material_thickness": 2,
-    "flags": [ "STURDY" ]
+    "flags": [ "STURDY" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r" ], "encumbrance": 20 }
   },
   {
     "id": "osrs_platebody_bronze",
@@ -468,12 +458,10 @@
     "symbol": "[",
     "looks_like": "chestguard_hard",
     "color": "brown",
-    "covers": [ "torso" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "warmth": 20,
     "material_thickness": 3,
-    "flags": [ "VARSIZE", "OUTER", "STURDY" ]
+    "flags": [ "VARSIZE", "OUTER", "STURDY" ],
+    "armor": { "coverage": 95, "covers": [ "torso" ], "encumbrance": 20 }
   },
   {
     "id": "osrs_shield_kite_bronze",
@@ -489,12 +477,10 @@
     "material": [ "osrs_bronze" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 60,
-    "encumbrance": 24,
     "material_thickness": 1,
     "techniques": [ "WBLOCK_3" ],
-    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ]
+    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ],
+    "armor": { "coverage": 60, "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 24 }
   },
   {
     "id": "osrs_crossbow_limbs_bronze",

--- a/data/Unleash_The_Mods/Working_mods/OSRS/items/iron.json
+++ b/data/Unleash_The_Mods/Working_mods/OSRS/items/iron.json
@@ -364,14 +364,12 @@
     "material": [ "osrs_iron" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "head", "eyes", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 40,
     "warmth": 10,
     "material_thickness": 1,
     "environmental_protection": 1,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "STURDY", "HELMET_COMPAT" ]
+    "flags": [ "STURDY", "HELMET_COMPAT" ],
+    "armor": { "coverage": 100, "covers": [ "head", "eyes", "mouth" ], "encumbrance": 40 }
   },
   {
     "id": "osrs_chainmail_iron",
@@ -387,11 +385,9 @@
     "symbol": "[",
     "looks_like": "chainmail_vest",
     "color": "dark_gray",
-    "covers": [ "torso" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "material_thickness": 2,
-    "flags": [ "STURDY" ]
+    "flags": [ "STURDY" ],
+    "armor": { "coverage": 95, "covers": [ "torso" ], "encumbrance": 20 }
   },
   {
     "id": "osrs_platelegs_iron",
@@ -407,12 +403,10 @@
     "symbol": "[",
     "looks_like": "legguard_hard",
     "color": "dark_gray",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "warmth": 20,
     "material_thickness": 2,
-    "flags": [ "STURDY" ]
+    "flags": [ "STURDY" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r" ], "encumbrance": 20 }
   },
   {
     "id": "osrs_shield_square_iron",
@@ -427,12 +421,10 @@
     "material": [ "osrs_iron" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 70,
-    "encumbrance": 28,
     "material_thickness": 1,
     "techniques": [ "WBLOCK_3" ],
-    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ]
+    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ],
+    "armor": { "coverage": 70, "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 28 }
   },
   {
     "id": "osrs_plateskirt_iron",
@@ -448,12 +440,10 @@
     "symbol": "[",
     "looks_like": "legguard_hard",
     "color": "dark_gray",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "warmth": 20,
     "material_thickness": 2,
-    "flags": [ "STURDY" ]
+    "flags": [ "STURDY" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r" ], "encumbrance": 20 }
   },
   {
     "id": "osrs_platebody_iron",
@@ -469,12 +459,10 @@
     "symbol": "[",
     "looks_like": "chestguard_hard",
     "color": "dark_gray",
-    "covers": [ "torso" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "warmth": 20,
     "material_thickness": 3,
-    "flags": [ "VARSIZE", "OUTER", "STURDY" ]
+    "flags": [ "VARSIZE", "OUTER", "STURDY" ],
+    "armor": { "coverage": 95, "covers": [ "torso" ], "encumbrance": 20 }
   },
   {
     "id": "osrs_shield_kite_iron",
@@ -490,12 +478,10 @@
     "material": [ "osrs_iron" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 60,
-    "encumbrance": 24,
     "material_thickness": 1,
     "techniques": [ "WBLOCK_3" ],
-    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ]
+    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ],
+    "armor": { "coverage": 60, "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 24 }
   },
   {
     "id": "osrs_crossbow_limbs_iron",

--- a/data/Unleash_The_Mods/Working_mods/OSRS/items/mithril.json
+++ b/data/Unleash_The_Mods/Working_mods/OSRS/items/mithril.json
@@ -364,14 +364,12 @@
     "material": [ "osrs_mithril" ],
     "symbol": "[",
     "color": "cyan",
-    "covers": [ "head", "eyes", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 40,
     "warmth": 10,
     "material_thickness": 1,
     "environmental_protection": 1,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "STURDY", "HELMET_COMPAT" ]
+    "flags": [ "STURDY", "HELMET_COMPAT" ],
+    "armor": { "coverage": 100, "covers": [ "head", "eyes", "mouth" ], "encumbrance": 40 }
   },
   {
     "id": "osrs_chainmail_mithril",
@@ -387,11 +385,9 @@
     "symbol": "[",
     "looks_like": "chainmail_vest",
     "color": "cyan",
-    "covers": [ "torso" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "material_thickness": 2,
-    "flags": [ "STURDY" ]
+    "flags": [ "STURDY" ],
+    "armor": { "coverage": 95, "covers": [ "torso" ], "encumbrance": 20 }
   },
   {
     "id": "osrs_platelegs_mithril",
@@ -407,12 +403,10 @@
     "symbol": "[",
     "looks_like": "legguard_hard",
     "color": "cyan",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "warmth": 20,
     "material_thickness": 2,
-    "flags": [ "STURDY" ]
+    "flags": [ "STURDY" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r" ], "encumbrance": 20 }
   },
   {
     "id": "osrs_shield_square_mithril",
@@ -427,12 +421,10 @@
     "material": [ "osrs_mithril" ],
     "symbol": "[",
     "color": "cyan",
-    "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 70,
-    "encumbrance": 28,
     "material_thickness": 1,
     "techniques": [ "WBLOCK_3" ],
-    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ]
+    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ],
+    "armor": { "coverage": 70, "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 28 }
   },
   {
     "id": "osrs_plateskirt_mithril",
@@ -448,12 +440,10 @@
     "symbol": "[",
     "looks_like": "legguard_hard",
     "color": "cyan",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "warmth": 20,
     "material_thickness": 2,
-    "flags": [ "STURDY" ]
+    "flags": [ "STURDY" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r" ], "encumbrance": 20 }
   },
   {
     "id": "osrs_platebody_mithril",
@@ -469,12 +459,10 @@
     "symbol": "[",
     "looks_like": "chestguard_hard",
     "color": "cyan",
-    "covers": [ "torso" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "warmth": 20,
     "material_thickness": 3,
-    "flags": [ "VARSIZE", "OUTER", "STURDY" ]
+    "flags": [ "VARSIZE", "OUTER", "STURDY" ],
+    "armor": { "coverage": 95, "covers": [ "torso" ], "encumbrance": 20 }
   },
   {
     "id": "osrs_shield_kite_mithril",
@@ -490,12 +478,10 @@
     "material": [ "osrs_mithril" ],
     "symbol": "[",
     "color": "cyan",
-    "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 60,
-    "encumbrance": 24,
     "material_thickness": 1,
     "techniques": [ "WBLOCK_3" ],
-    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ]
+    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ],
+    "armor": { "coverage": 60, "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 24 }
   },
   {
     "id": "osrs_crossbow_limbs_mithril",

--- a/data/Unleash_The_Mods/Working_mods/OSRS/items/runite.json
+++ b/data/Unleash_The_Mods/Working_mods/OSRS/items/runite.json
@@ -364,14 +364,12 @@
     "material": [ "osrs_runite" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "head", "eyes", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 40,
     "warmth": 10,
     "material_thickness": 1,
     "environmental_protection": 1,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "STURDY", "HELMET_COMPAT" ]
+    "flags": [ "STURDY", "HELMET_COMPAT" ],
+    "armor": { "coverage": 100, "covers": [ "head", "eyes", "mouth" ], "encumbrance": 40 }
   },
   {
     "id": "osrs_chainmail_runite",
@@ -387,11 +385,9 @@
     "symbol": "[",
     "looks_like": "chainmail_vest",
     "color": "blue",
-    "covers": [ "torso" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "material_thickness": 2,
-    "flags": [ "STURDY" ]
+    "flags": [ "STURDY" ],
+    "armor": { "coverage": 95, "covers": [ "torso" ], "encumbrance": 20 }
   },
   {
     "id": "osrs_platelegs_runite",
@@ -407,12 +403,10 @@
     "symbol": "[",
     "looks_like": "legguard_hard",
     "color": "blue",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "warmth": 20,
     "material_thickness": 2,
-    "flags": [ "STURDY" ]
+    "flags": [ "STURDY" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r" ], "encumbrance": 20 }
   },
   {
     "id": "osrs_shield_square_runite",
@@ -427,12 +421,10 @@
     "material": [ "osrs_runite" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 70,
-    "encumbrance": 28,
     "material_thickness": 1,
     "techniques": [ "WBLOCK_3" ],
-    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ]
+    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ],
+    "armor": { "coverage": 70, "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 28 }
   },
   {
     "id": "osrs_plateskirt_runite",
@@ -448,12 +440,10 @@
     "symbol": "[",
     "looks_like": "legguard_hard",
     "color": "blue",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "warmth": 20,
     "material_thickness": 2,
-    "flags": [ "STURDY" ]
+    "flags": [ "STURDY" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r" ], "encumbrance": 20 }
   },
   {
     "id": "osrs_platebody_runite",
@@ -469,12 +459,10 @@
     "symbol": "[",
     "looks_like": "chestguard_hard",
     "color": "blue",
-    "covers": [ "torso" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "warmth": 20,
     "material_thickness": 3,
-    "flags": [ "VARSIZE", "OUTER", "STURDY" ]
+    "flags": [ "VARSIZE", "OUTER", "STURDY" ],
+    "armor": { "coverage": 95, "covers": [ "torso" ], "encumbrance": 20 }
   },
   {
     "id": "osrs_shield_kite_runite",
@@ -490,12 +478,10 @@
     "material": [ "osrs_runite" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 60,
-    "encumbrance": 24,
     "material_thickness": 1,
     "techniques": [ "WBLOCK_3" ],
-    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ]
+    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ],
+    "armor": { "coverage": 60, "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 24 }
   },
   {
     "id": "osrs_crossbow_limbs_runite",

--- a/data/Unleash_The_Mods/Working_mods/Odds_N_Ends/oe_armor.json
+++ b/data/Unleash_The_Mods/Working_mods/Odds_N_Ends/oe_armor.json
@@ -12,13 +12,11 @@
     "material": [ "neoprene", "kevlar", "nomex" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 30,
     "warmth": 35,
     "material_thickness": 4,
     "environmental_protection": 8,
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "foot_l", "foot_r" ], "encumbrance": 30 }
   },
   {
     "id": "navy_wetsuit",
@@ -34,12 +32,10 @@
     "material": [ "kevlar", "steel", "neoprene" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r" ],
-    "coverage": 100,
-    "encumbrance": 25,
     "warmth": 35,
     "material_thickness": 5,
     "environmental_protection": 15,
-    "flags": [ "FANCY", "HOOD", "NONCONDUCTIVE", "POCKETS", "RAINPROOF", "STURDY", "VARSIZE", "THERMOMETER", "WATER_FRIENDLY" ]
+    "flags": [ "FANCY", "HOOD", "NONCONDUCTIVE", "POCKETS", "RAINPROOF", "STURDY", "VARSIZE", "THERMOMETER", "WATER_FRIENDLY" ],
+    "armor": { "coverage": 100, "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Odds_N_Ends/oe_tool_armor.json
+++ b/data/Unleash_The_Mods/Working_mods/Odds_N_Ends/oe_tool_armor.json
@@ -26,12 +26,10 @@
       "need_charges": 1,
       "need_charges_msg": "The %s's batteries are dead."
     },
-    "covers": [ "eyes" ],
     "warmth": 30,
     "environmental_protection": 16,
-    "encumbrance": 40,
-    "coverage": 100,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 100, "covers": [ "eyes" ], "encumbrance": 40 }
   },
   {
     "id": "brospec_goggles_on",
@@ -45,9 +43,8 @@
     "ammo": [ "battery" ],
     "revert_to": "brospec_goggles",
     "use_action": { "type": "transform", "menu_text": "Turn off", "msg": "Your %s deactivates.", "target": "brospec_goggles" },
-    "covers": [ "eyes" ],
     "warmth": 55,
-    "encumbrance": 20
+    "armor": { "covers": [ "eyes" ], "encumbrance": 20 }
   },
   {
     "id": "rebreather_navy",
@@ -75,12 +72,10 @@
       "need_charges": 1,
       "need_charges_msg": "The %s's filter is used up."
     },
-    "covers": [ "mouth" ],
     "warmth": 10,
     "environmental_protection": 11,
-    "encumbrance": 25,
-    "coverage": 100,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 100, "covers": [ "mouth" ], "encumbrance": 25 }
   },
   {
     "id": "rebreather_navy_on",
@@ -94,7 +89,7 @@
     "revert_to": "rebreather_navy",
     "use_action": { "type": "transform", "menu_text": "Turn off", "msg": "Your %s deactivates.", "target": "rebreather_navy" },
     "environmental_protection": 18,
-    "encumbrance": 20
+    "armor": { "encumbrance": 20 }
   },
   {
     "id": "wetsuit_earplugs",
@@ -111,12 +106,10 @@
     "volume": "1750 ml",
     "to_hit": -3,
     "use_action": { "type": "transform", "menu_text": "Plug Ears", "msg": "You activate your %s.", "target": "wetsuit_earplugs_on" },
-    "covers": [ "head" ],
     "warmth": 30,
     "environmental_protection": 10,
-    "encumbrance": 20,
-    "coverage": 100,
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 100, "covers": [ "head" ], "encumbrance": 20 }
   },
   {
     "id": "wetsuit_earplugs_on",
@@ -134,11 +127,9 @@
     "to_hit": -3,
     "revert_to": "wetsuit_earplugs",
     "use_action": { "type": "transform", "menu_text": "Deactivate", "msg": "You deactivate your %s.", "target": "wetsuit_earplugs" },
-    "covers": [ "head" ],
     "warmth": 30,
     "environmental_protection": 10,
-    "encumbrance": 20,
-    "coverage": 100,
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 100, "covers": [ "head" ], "encumbrance": 20 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/PoraComp/PoraComp/items/armor.json
+++ b/data/Unleash_The_Mods/Working_mods/PoraComp/PoraComp/items/armor.json
@@ -11,10 +11,8 @@
     "price": "600 USD",
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "torso" ],
     "description": "The answer to the ever evolving challange of the cataclysm, survivor gear is customized for utility and versility. This particular gear set is a long sleeve shirt with plenty of pockets. A nomex underlay protects from the enviroment while kevlar gives a bit of physical protection.",
     "material_thickness": 3,
-    "encumbrance": 16,
     "warmth": 5,
     "environmental_protection": 5,
     "material": [ "nomex", "kevlar" ],
@@ -25,7 +23,8 @@
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1 kg", "moves": 100 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "250 ml", "max_contains_weight": "1 kg", "moves": 100 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "250 ml", "max_contains_weight": "1 kg", "moves": 100 }
-    ]
+    ],
+    "armor": { "covers": [ "torso" ], "encumbrance": 16 }
   },
   {
     "copy-from": "lsurvivor_pants",
@@ -35,7 +34,6 @@
     "name": { "str": "Survivor Bottoms" },
     "description": "The answer to the ever evolving challange of the cataclysm, survivor gear is customized for utility and versility. This particular gear set is a very rugged pair of cargo pants. A nomex underlay protects from the enviroment while kevlar gives a bit of physical protection.",
     "material_thickness": 3,
-    "encumbrance": 16,
     "warmth": 5,
     "environmental_protection": 5,
     "weight": "3000 g",
@@ -43,7 +41,6 @@
     "price": "600 USD",
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "leg_l", "leg_r" ],
     "material": [ "nomex", "kevlar" ],
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "700 ml", "max_contains_weight": "2 kg", "moves": 80 },
@@ -52,7 +49,8 @@
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1 kg", "moves": 100 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "250 ml", "max_contains_weight": "1 kg", "moves": 100 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "250 ml", "max_contains_weight": "1 kg", "moves": 100 }
-    ]
+    ],
+    "armor": { "covers": [ "leg_l", "leg_r" ], "encumbrance": 16 }
   },
   {
     "copy-from": "gloves_lsurvivor",
@@ -62,10 +60,10 @@
     "name": { "str": "Pair of Survivor Gloves" },
     "description": "The answer to the ever evolving challange of the cataclysm, survivor gear is customized for utility and versility. This particular gear set is a pair of nomex lined kevlar gloves. Bumbs along the palm area provide great grip.",
     "material_thickness": 3,
-    "encumbrance": 10,
     "warmth": 5,
     "environmental_protection": 5,
-    "material": [ "nomex", "kevlar" ]
+    "material": [ "nomex", "kevlar" ],
+    "armor": { "encumbrance": 10 }
   },
   {
     "copy-from": "hood_lsurvivor",
@@ -128,11 +126,8 @@
     "price": "1500 USD",
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "torso" ],
     "description": "The answer to the ever evolving challange of the cataclysm, survivor gear is customized for utility and versility. This particular gear set is a chestrig linking leather pouches for extra space and magazine capcity, and kevlar armor plates covering the vital sections. ",
     "material_thickness": 4,
-    "coverage": 90,
-    "encumbrance": 24,
     "warmth": 5,
     "use_action": { "type": "holster", "holster_prompt": "Stash ammo", "holster_msg": "You stash your %s." },
     "environmental_protection": 2,
@@ -143,14 +138,14 @@
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1 kg", "moves": 100 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1 kg", "moves": 100 }
     ],
-    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "BELTED" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "BELTED" ],
+    "armor": { "coverage": 90, "covers": [ "torso" ], "encumbrance": 24 }
   },
   {
     "id": "porawep_survivor_armguards",
     "type": "ARMOR",
     "category": "armor",
     "name": { "str": "Survivor Arm Guards" },
-    "covers": [ "hand_l", "hand_r" ],
     "weight": "1700 g",
     "volume": "3000 ml",
     "price": "1500 USD",
@@ -158,19 +153,17 @@
     "color": "dark_gray",
     "description": "The answer to the ever evolving challange of the cataclysm, survivor gear is customized for utility and versility. This particular gear set is a set of shaped, soft kevlar plates made to protect the arms, linked by leather. While not bulletproof, it will certainly spare you a zombie bite.",
     "material_thickness": 4,
-    "coverage": 80,
-    "encumbrance": 24,
     "warmth": 5,
     "environmental_protection": 2,
     "material": [ "leather", "kevlar" ],
-    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "BELTED" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "BELTED" ],
+    "armor": { "coverage": 80, "covers": [ "hand_l", "hand_r" ], "encumbrance": 24 }
   },
   {
     "id": "porawep_survivor_legguards",
     "type": "ARMOR",
     "category": "armor",
     "name": { "str": "Survivor Leg Guards" },
-    "covers": [ "leg_l", "leg_r" ],
     "weight": "1700 g",
     "volume": "3000 ml",
     "price": "1500 USD",
@@ -178,13 +171,12 @@
     "color": "dark_gray",
     "description": "The answer to the ever evolving challange of the cataclysm, survivor gear is customized for utility and versility. This particular gear set is a set of shaped, soft kevlar plates made to protect the arms. A couple handy pouches can also be used to stash two magazines.",
     "material_thickness": 4,
-    "coverage": 80,
-    "encumbrance": 24,
     "warmth": 5,
     "use_action": { "type": "holster", "holster_prompt": "Stash ammo", "holster_msg": "You stash your %s." },
     "environmental_protection": 2,
     "material": [ "leather", "kevlar" ],
-    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "BELTED" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "BELTED" ],
+    "armor": { "coverage": 80, "covers": [ "leg_l", "leg_r" ], "encumbrance": 24 }
   },
   {
     "//": "Heavy Survivor Armor Changes",
@@ -192,7 +184,6 @@
     "type": "ARMOR",
     "category": "armor",
     "name": { "str": "Survivor Heavy Chestplate" },
-    "covers": [ "torso" ],
     "weight": "4250 g",
     "volume": "6000 ml",
     "price": "2 kUSD",
@@ -200,8 +191,6 @@
     "color": "light_gray",
     "description": "The answer to the ever evolving challange of the cataclysm, survivor gear is customized for utility and versility. This particular gear set is a collection of kevlar pouches filled with hard steel plates , all linked together by straps and buckles.",
     "material_thickness": 4,
-    "coverage": 90,
-    "encumbrance": 30,
     "warmth": 10,
     "environmental_protection": 1,
     "material": [ "steel", "kevlar" ],
@@ -211,6 +200,7 @@
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1 kg", "moves": 100 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1 kg", "moves": 100 }
     ],
-    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "BELTED", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "BELTED", "STURDY" ],
+    "armor": { "coverage": 90, "covers": [ "torso" ], "encumbrance": 30 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/PoraComp/PoraComp/items/clothing.json
+++ b/data/Unleash_The_Mods/Working_mods/PoraComp/PoraComp/items/clothing.json
@@ -7,15 +7,13 @@
     "weight": "140 g",
     "volume": "250 ml",
     "price": "25 USD",
-    "encumbrance": 0,
     "material": [ "kevlar" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [  ],
-    "coverage": 15,
     "material_thickness": 2,
     "use_action": { "type": "holster", "holster_prompt": "Stash UPS", "holster_msg": "You stash your %s." },
-    "flags": [ "WATER_FRIENDLY" ]
+    "flags": [ "WATER_FRIENDLY" ],
+    "armor": { "coverage": 15, "covers": [  ], "encumbrance": 0 }
   },
   {
     "id": "Insulated_2L_Canteen",

--- a/data/Unleash_The_Mods/Working_mods/PoraComp/PoraComp/items/overrides.json
+++ b/data/Unleash_The_Mods/Working_mods/PoraComp/PoraComp/items/overrides.json
@@ -79,9 +79,9 @@
     "material": [ "superalloy", "kevlar" ],
     "symbol": "[",
     "color": "light_gray",
-    "coverage": 90,
     "warmth": 0,
     "environmental_protection": 6,
-    "flags": [ "OVERSIZE", "HOOD", "WATERPROOF", "OUTER", "VARSIZE" ]
+    "flags": [ "OVERSIZE", "HOOD", "WATERPROOF", "OUTER", "VARSIZE" ],
+    "armor": { "coverage": 90 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/PoraComp/PoraComp/obsolete/items/armor.json
+++ b/data/Unleash_The_Mods/Working_mods/PoraComp/PoraComp/obsolete/items/armor.json
@@ -8,10 +8,10 @@
     "name": { "str": "Survivor Suit" },
     "description": "The answer to the ever evolving challange of the cataclysm, survivor gear is customized for utility and versility. This particular gear set is a pair of cargo pants and a pocketed long sleeved shirt. A nomex underlay protects from the enviroment while kevlar gives a bit of physical protection.",
     "material_thickness": 4,
-    "encumbrance": 16,
     "warmth": 5,
     "environmental_protection": 5,
-    "material": [ "cotton", "nomex", "kevlar" ]
+    "material": [ "cotton", "nomex", "kevlar" ],
+    "armor": { "encumbrance": 16 }
   },
   {
     "copy-from": "survivor_suit",
@@ -21,12 +21,11 @@
     "name": { "str": "Survivor Plating" },
     "description": "The answer to the ever evolving challange of the cataclysm, survivor gear is customized for utility and versility. This particular gear set is a chestrig linking leather pouches for extra space and magazine capcity, and kevlar armor plates covering the vital sections. ",
     "material_thickness": 4,
-    "coverage": 90,
-    "encumbrance": 20,
     "warmth": 5,
     "use_action": { "type": "holster", "holster_prompt": "Stash ammo", "holster_msg": "You stash your %s." },
     "environmental_protection": 2,
     "material": [ "leather", "kevlar" ],
-    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "BELTED" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "BELTED" ],
+    "armor": { "coverage": 90, "encumbrance": 20 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Project_APEX/items/suit/modules.json
+++ b/data/Unleash_The_Mods/Working_mods/Project_APEX/items/suit/modules.json
@@ -8,31 +8,30 @@
     "color": "light_gray",
     "volume": "1 ml",
     "weight": "0 g",
-    "coverage": 0,
-    "covers": [ "torso" ],
     "price": "10 kUSD",
-    "flags": [ "TRADER_AVOID", "ONLY_ONE", "SEMITANGIBLE", "ALLOWS_NATURAL_ATTACKS", "ZERO_WEIGHT" ]
+    "flags": [ "TRADER_AVOID", "ONLY_ONE", "SEMITANGIBLE", "ALLOWS_NATURAL_ATTACKS", "ZERO_WEIGHT" ],
+    "armor": { "coverage": 0, "covers": [ "torso" ] }
   },
   {
     "name": { "str": "APEX suit module (system)" },
     "abstract": "apex_module_system",
     "type": "ARMOR",
     "copy-from": "apex_module",
-    "covers": [ "torso" ]
+    "armor": { "covers": [ "torso" ] }
   },
   {
     "name": { "str": "APEX suit module (cortex)" },
     "abstract": "apex_module_cortex",
     "type": "ARMOR",
     "copy-from": "apex_module",
-    "covers": [ "head" ]
+    "armor": { "covers": [ "head" ] }
   },
   {
     "name": { "str": "APEX suit module (mobility)" },
     "abstract": "apex_module_mobility",
     "type": "ARMOR",
     "copy-from": "apex_module",
-    "covers": [ "head" ]
+    "armor": { "covers": [ "head" ] }
   },
   {
     "id": "apex_module_strength",

--- a/data/Unleash_The_Mods/Working_mods/Project_APEX/items/suit/suits.json
+++ b/data/Unleash_The_Mods/Working_mods/Project_APEX/items/suit/suits.json
@@ -3,12 +3,14 @@
     "abstract": "apex_suit",
     "type": "ARMOR",
     "name": { "str": "APEX suit" },
-    "covers": [ "head", "mouth", "eyes", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
     "looks_like": "rm13_armor_on",
     "symbol": "[",
     "color": "light_gray",
     "warmth": 15,
-    "coverage": 100
+    "armor": {
+      "coverage": 100,
+      "covers": [ "head", "mouth", "eyes", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
+    }
   },
   {
     "id": "apex_mk0",
@@ -20,10 +22,10 @@
     "material": [ "nanofiber" ],
     "price": "5 kUSD",
     "volume": "5 L",
-    "encumbrance": 15,
     "material_thickness": 3,
     "environmental_protection": 5,
-    "flags": [ "ELECTRIC_IMMUNE", "RAINPROOF", "STURDY", "OUTER", "ONLY_ONE", "FIT" ]
+    "flags": [ "ELECTRIC_IMMUNE", "RAINPROOF", "STURDY", "OUTER", "ONLY_ONE", "FIT" ],
+    "armor": { "encumbrance": 15 }
   },
   {
     "id": "apex_mki",
@@ -35,7 +37,6 @@
     "material": [ "nanofiber" ],
     "price": "10 kUSD",
     "volume": "6 L",
-    "encumbrance": 8,
     "material_thickness": 5,
     "environmental_protection": 10,
     "flags": [
@@ -50,7 +51,8 @@
       "WATER_FRIENDLY",
       "ONLY_ONE",
       "FIT"
-    ]
+    ],
+    "armor": { "encumbrance": 8 }
   },
   {
     "id": "apex_mkii",
@@ -62,7 +64,6 @@
     "description": "TBD",
     "price": "10 kUSD",
     "volume": "8 L",
-    "encumbrance": 4,
     "material_thickness": 7,
     "environmental_protection": 20,
     "flags": [
@@ -83,7 +84,8 @@
       "WATCH",
       "ONLY_ONE",
       "FIT"
-    ]
+    ],
+    "armor": { "encumbrance": 4 }
   },
   {
     "id": "apex_mkiii",
@@ -95,7 +97,6 @@
     "description": "TBD",
     "price": "10 kUSD",
     "volume": "1 L",
-    "encumbrance": 0,
     "material_thickness": 2,
     "environmental_protection": 40,
     "flags": [
@@ -116,6 +117,7 @@
       "WATCH",
       "ONLY_ONE",
       "SEMITANGIBLE"
-    ]
+    ],
+    "armor": { "encumbrance": 0 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Project_Kawaii/items.json
+++ b/data/Unleash_The_Mods/Working_mods/Project_Kawaii/items.json
@@ -10,16 +10,14 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 75,
-    "encumbrance": 7,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "2 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "2 kg", "moves": 75 }
     ],
     "warmth": 15,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 75, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 7 }
   },
   {
     "id": "kawaii_maid_dress_ex",
@@ -32,9 +30,6 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 80,
-    "encumbrance": 20,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "8 L", "max_contains_weight": "16 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "8 L", "max_contains_weight": "16 kg", "moves": 75 },
@@ -50,7 +45,8 @@
       "msg": "You modify the maid outfit to better protect against the cold.",
       "target": "kawaii_maid_dress_ex2",
       "menu_text": "Add thermal lining"
-    }
+    },
+    "armor": { "coverage": 80, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 20 }
   },
   {
     "id": "kawaii_maid_dress_ex2",
@@ -63,9 +59,6 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "8 L", "max_contains_weight": "16 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "8 L", "max_contains_weight": "16 kg", "moves": 75 },
@@ -81,7 +74,8 @@
       "msg": "You modify the maid outfit to better protect against the heat.",
       "target": "kawaii_maid_dress_ex",
       "menu_text": "Remove thermal lining"
-    }
+    },
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 20 }
   },
   {
     "id": "kawaii_maid_dress_lss",
@@ -95,9 +89,6 @@
     "material": [ "kevlar", "cotton" ],
     "symbol": "[",
     "color": "green",
-    "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r" ],
-    "coverage": 100,
-    "encumbrance": 15,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "4 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "4 kg", "moves": 75 },
@@ -120,7 +111,8 @@
       "active": true,
       "need_charges": 1,
       "need_charges_msg": "The uniform does not have enough power left."
-    }
+    },
+    "armor": { "coverage": 100, "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r" ], "encumbrance": 15 }
   },
   {
     "id": "kawaii_maid_dress_lss1",
@@ -134,9 +126,6 @@
     "material": [ "kevlar", "cotton" ],
     "symbol": "[",
     "color": "green",
-    "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r" ],
-    "coverage": 100,
-    "encumbrance": 25,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "5 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "5 kg", "moves": 75 },
@@ -159,7 +148,8 @@
       "active": true,
       "need_charges": 1,
       "need_charges_msg": "The uniform does not have enough power left."
-    }
+    },
+    "armor": { "coverage": 100, "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "kawaii_maid_dress_lss2",
@@ -173,9 +163,6 @@
     "material": [ "kevlar", "cotton" ],
     "symbol": "[",
     "color": "green",
-    "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r" ],
-    "coverage": 100,
-    "encumbrance": 15,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "5 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "5 kg", "moves": 75 },
@@ -195,7 +182,8 @@
       "msg": "You turn off the uniform's climate control systems.",
       "target": "kawaii_maid_dress_lss",
       "menu_text": "Change climate control settings"
-    }
+    },
+    "armor": { "coverage": 100, "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r" ], "encumbrance": 15 }
   },
   {
     "id": "kawaii_maid_dress_long",
@@ -208,9 +196,6 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 85,
-    "encumbrance": 20,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "6 L", "max_contains_weight": "12 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "6 L", "max_contains_weight": "12 kg", "moves": 75 },
@@ -219,7 +204,8 @@
     ],
     "warmth": 40,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 85, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 20 }
   },
   {
     "id": "kawaii_wedding_dress",
@@ -232,12 +218,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 85,
-    "encumbrance": 7,
     "warmth": 10,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 85, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 7 }
   },
   {
     "id": "kawaii_sister_dress",
@@ -250,16 +234,14 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 85,
-    "encumbrance": 7,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "2 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "2 kg", "moves": 75 }
     ],
     "warmth": 5,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 85, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 7 }
   },
   {
     "id": "kawaii_raincoat",
@@ -272,13 +254,11 @@
     "material": [ "plastic", "cotton" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "torso", "arm_l", "arm_r", "head" ],
-    "coverage": 95,
-    "encumbrance": 10,
     "warmth": 5,
     "material_thickness": 1,
     "flags": [ "VARSIZE", "POCKETS", "WATERPROOF", "RAINPROOF", "HOOD", "OUTER", "FANCY" ],
-    "use_action": { "type": "transform", "msg": "You take off the hood.", "target": "kawaii_raincoat_off", "menu_text": "Toggle hood" }
+    "use_action": { "type": "transform", "msg": "You take off the hood.", "target": "kawaii_raincoat_off", "menu_text": "Toggle hood" },
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r", "head" ], "encumbrance": 10 }
   },
   {
     "id": "kawaii_raincoat_off",
@@ -291,13 +271,11 @@
     "material": [ "plastic", "cotton" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 85,
-    "encumbrance": 7,
     "warmth": 5,
     "material_thickness": 1,
     "flags": [ "VARSIZE", "POCKETS", "WATERPROOF", "RAINPROOF", "HOOD", "OUTER", "FANCY" ],
-    "use_action": { "type": "transform", "msg": "You put on the hood.", "target": "kawaii_raincoat", "menu_text": "Toggle hood" }
+    "use_action": { "type": "transform", "msg": "You put on the hood.", "target": "kawaii_raincoat", "menu_text": "Toggle hood" },
+    "armor": { "coverage": 85, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 7 }
   },
   {
     "id": "kawaii_sailor_fuku",
@@ -310,16 +288,14 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 85,
-    "encumbrance": 5,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "2 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "2 kg", "moves": 75 }
     ],
     "warmth": 5,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 85, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 5 }
   },
   {
     "id": "kawaii_maid_panties",
@@ -332,11 +308,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 15,
     "warmth": 0,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "SKINTIGHT", "FANCY" ]
+    "flags": [ "VARSIZE", "SKINTIGHT", "FANCY" ],
+    "armor": { "coverage": 15, "covers": [ "leg_l", "leg_r" ] }
   },
   {
     "id": "kawaii_maid_bra",
@@ -349,11 +324,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "torso" ],
-    "coverage": 15,
     "warmth": 0,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "SKINTIGHT", "FANCY" ]
+    "flags": [ "VARSIZE", "SKINTIGHT", "FANCY" ],
+    "armor": { "coverage": 15, "covers": [ "torso" ] }
   },
   {
     "id": "kawaii_maid_simapan_pink",
@@ -366,11 +340,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 15,
     "warmth": 5,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "SKINTIGHT", "FANCY" ]
+    "flags": [ "VARSIZE", "SKINTIGHT", "FANCY" ],
+    "armor": { "coverage": 15, "covers": [ "leg_l", "leg_r" ] }
   },
   {
     "id": "kawaii_maid_simabura_pink",
@@ -383,11 +356,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "torso" ],
-    "coverage": 15,
     "warmth": 5,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "SKINTIGHT", "FANCY" ]
+    "flags": [ "VARSIZE", "SKINTIGHT", "FANCY" ],
+    "armor": { "coverage": 15, "covers": [ "torso" ] }
   },
   {
     "id": "kawaii_maid_simapan_green",
@@ -400,11 +372,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 15,
     "warmth": 5,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "SKINTIGHT", "FANCY" ]
+    "flags": [ "VARSIZE", "SKINTIGHT", "FANCY" ],
+    "armor": { "coverage": 15, "covers": [ "leg_l", "leg_r" ] }
   },
   {
     "id": "kawaii_maid_simabura_green",
@@ -417,11 +388,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "torso" ],
-    "coverage": 15,
     "warmth": 5,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "SKINTIGHT", "FANCY" ]
+    "flags": [ "VARSIZE", "SKINTIGHT", "FANCY" ],
+    "armor": { "coverage": 15, "covers": [ "torso" ] }
   },
   {
     "id": "kawaii_bikini_bottom_black",
@@ -434,11 +404,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "light_red",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 15,
     "warmth": 5,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "SKINTIGHT", "WATER_FRIENDLY" ]
+    "flags": [ "VARSIZE", "SKINTIGHT", "WATER_FRIENDLY" ],
+    "armor": { "coverage": 15, "covers": [ "leg_l", "leg_r" ] }
   },
   {
     "id": "kawaii_bikini_top_black",
@@ -451,10 +420,9 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "light_red",
-    "covers": [ "torso" ],
-    "coverage": 10,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "WATER_FRIENDLY", "SKINTIGHT" ]
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "SKINTIGHT" ],
+    "armor": { "coverage": 10, "covers": [ "torso" ] }
   },
   {
     "id": "kawaii_tailskirt_mini",
@@ -467,10 +435,9 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "pink",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 7,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 7, "covers": [ "leg_l", "leg_r" ] }
   },
   {
     "id": "kawaii_vest",
@@ -483,16 +450,14 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "torso" ],
-    "coverage": 60,
-    "encumbrance": 5,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "3 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "3 kg", "moves": 75 }
     ],
     "warmth": 5,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "WAIST" ]
+    "flags": [ "VARSIZE", "WAIST" ],
+    "armor": { "coverage": 60, "covers": [ "torso" ], "encumbrance": 5 }
   },
   {
     "id": "kawaii_maid_hat",
@@ -505,9 +470,6 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "head" ],
-    "coverage": 25,
-    "encumbrance": 3,
     "warmth": 0,
     "material_thickness": 1,
     "flags": [ "VARSIZE", "FANCY", "WATERPROOF", "RAINPROOF", "SKINTIGHT" ],
@@ -516,7 +478,8 @@
       "msg": "Your pride as a maid prevents the cold from bothering your head.",
       "target": "kawaii_maid_hat_kiai",
       "menu_text": "Channel spirit"
-    }
+    },
+    "armor": { "coverage": 25, "covers": [ "head" ], "encumbrance": 3 }
   },
   {
     "id": "kawaii_maid_hat_kiai",
@@ -529,9 +492,6 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "head" ],
-    "coverage": 25,
-    "encumbrance": 3,
     "warmth": 30,
     "material_thickness": 1,
     "flags": [ "VARSIZE", "FANCY", "WATERPROOF", "RAINPROOF", "SKINTIGHT" ],
@@ -540,7 +500,8 @@
       "msg": "You stop channeling your spirit into te headpiece",
       "target": "kawaii_maid_hat",
       "menu_text": "Stop channeling spirit"
-    }
+    },
+    "armor": { "coverage": 25, "covers": [ "head" ], "encumbrance": 3 }
   },
   {
     "id": "kawaii_maid_hat_thermal_off",
@@ -554,9 +515,6 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "head" ],
-    "coverage": 25,
-    "encumbrance": 3,
     "warmth": 40,
     "material_thickness": 3,
     "flags": [ "VARSIZE", "FANCY", "WATERPROOF", "RAINPROOF", "SKINTIGHT" ],
@@ -572,7 +530,8 @@
       "menu_text": "Activate heater",
       "need_charges": 1,
       "need_charges_msg": "%s does not have enough power left."
-    }
+    },
+    "armor": { "coverage": 25, "covers": [ "head" ], "encumbrance": 3 }
   },
   {
     "id": "kawaii_maid_hat_thermal_on",
@@ -586,9 +545,6 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "head" ],
-    "coverage": 25,
-    "encumbrance": 3,
     "warmth": 80,
     "material_thickness": 3,
     "flags": [ "VARSIZE", "FANCY", "WATERPROOF", "RAINPROOF", "SKINTIGHT" ],
@@ -602,7 +558,8 @@
       "msg": "You deactivate the headdress' heating systems",
       "target": "kawaii_maid_hat_thermal_off",
       "menu_text": "Deactivate heater"
-    }
+    },
+    "armor": { "coverage": 25, "covers": [ "head" ], "encumbrance": 3 }
   },
   {
     "id": "kawaii_maid_hat_lss",
@@ -616,9 +573,6 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "head" ],
-    "coverage": 100,
-    "encumbrance": 10,
     "warmth": 40,
     "material_thickness": 5,
     "flags": [ "VARSIZE", "FANCY", "WATERPROOF", "RAINPROOF", "SKINTIGHT", "STURDY" ],
@@ -636,7 +590,8 @@
       "menu_text": "Change climate control settings",
       "need_charges": 1,
       "need_charges_msg": "%s does not have enough power left."
-    }
+    },
+    "armor": { "coverage": 100, "covers": [ "head" ], "encumbrance": 10 }
   },
   {
     "id": "kawaii_maid_hat_lss1",
@@ -650,9 +605,6 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "head" ],
-    "coverage": 100,
-    "encumbrance": 10,
     "warmth": 80,
     "material_thickness": 5,
     "flags": [ "VARSIZE", "FANCY", "WATERPROOF", "RAINPROOF", "SKINTIGHT", "STURDY" ],
@@ -671,7 +623,8 @@
       "menu_text": "Change climate control settings",
       "need_charges": 1,
       "need_charges_msg": "%s does not have enough power left."
-    }
+    },
+    "armor": { "coverage": 100, "covers": [ "head" ], "encumbrance": 10 }
   },
   {
     "id": "kawaii_maid_hat_lss2",
@@ -685,9 +638,6 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "head" ],
-    "coverage": 100,
-    "encumbrance": 10,
     "warmth": 0,
     "material_thickness": 5,
     "flags": [ "VARSIZE", "FANCY", "WATERPROOF", "RAINPROOF", "SKINTIGHT", "STURDY" ],
@@ -703,7 +653,8 @@
       "msg": "You deactivate the headdress' climate control.",
       "target": "kawaii_maid_hat_lss",
       "menu_text": "Change climate control settings"
-    }
+    },
+    "armor": { "coverage": 100, "covers": [ "head" ], "encumbrance": 10 }
   },
   {
     "id": "kawaii_hitec_megane",
@@ -716,8 +667,6 @@
     "material": [ "glass", "plastic" ],
     "symbol": "[",
     "color": "cyan",
-    "covers": [ "eyes" ],
-    "coverage": 75,
     "material_thickness": 2,
     "environmental_protection": 6,
     "qualities": [ [ "GLARE", 2 ] ],
@@ -734,7 +683,8 @@
       "active": true,
       "need_charges": 1,
       "need_charges_msg": "%s does not have enough power left."
-    }
+    },
+    "armor": { "coverage": 75, "covers": [ "eyes" ] }
   },
   {
     "id": "kawaii_hitec_megane_nv",
@@ -747,8 +697,6 @@
     "material": [ "glass", "plastic" ],
     "symbol": "[",
     "color": "cyan",
-    "covers": [ "eyes" ],
-    "coverage": 75,
     "material_thickness": 2,
     "environmental_protection": 6,
     "flags": [ "WATER_FRIENDLY", "FANCY", "FIX_NEARSIGHT", "FIX_FARSIGHT", "GNV_EFFECT" ],
@@ -765,7 +713,8 @@
       "active": true,
       "need_charges": 1,
       "need_charges_msg": "%s does not have enough power left."
-    }
+    },
+    "armor": { "coverage": 75, "covers": [ "eyes" ] }
   },
   {
     "id": "kawaii_hitec_megane_ir",
@@ -778,8 +727,6 @@
     "material": [ "glass", "plastic" ],
     "symbol": "[",
     "color": "cyan",
-    "covers": [ "eyes" ],
-    "coverage": 75,
     "material_thickness": 2,
     "environmental_protection": 6,
     "flags": [ "WATER_FRIENDLY", "FANCY", "FIX_NEARSIGHT", "FIX_FARSIGHT", "IR_EFFECT" ],
@@ -793,7 +740,8 @@
       "menu_text": "Toggle vision mode",
       "msg": "You switch the glasses to blinder mode.",
       "target": "kawaii_hitec_megane_blind"
-    }
+    },
+    "armor": { "coverage": 75, "covers": [ "eyes" ] }
   },
   {
     "id": "kawaii_hitec_megane_blind",
@@ -806,8 +754,6 @@
     "material": [ "glass", "plastic" ],
     "symbol": "[",
     "color": "cyan",
-    "covers": [ "eyes" ],
-    "coverage": 75,
     "material_thickness": 2,
     "environmental_protection": 6,
     "flags": [ "WATER_FRIENDLY", "FANCY", "FIX_NEARSIGHT", "FIX_FARSIGHT", "BLIND" ],
@@ -820,7 +766,8 @@
       "menu_text": "Toggle vision mode",
       "msg": "You return the glasses to its default mode.",
       "target": "kawaii_hitec_megane"
-    }
+    },
+    "armor": { "coverage": 75, "covers": [ "eyes" ] }
   },
   {
     "id": "kawaii_maid_megane_01",
@@ -833,8 +780,6 @@
     "material": [ "glass", "plastic" ],
     "symbol": "[",
     "color": "cyan",
-    "covers": [ "eyes" ],
-    "coverage": 75,
     "material_thickness": 1,
     "environmental_protection": 1,
     "flags": [ "WATER_FRIENDLY", "FANCY", "FIX_NEARSIGHT", "FIX_FARSIGHT" ],
@@ -843,7 +788,8 @@
       "msg": "You lower the glasses",
       "target": "kawaii_maid_megane_02",
       "menu_text": "Adjust the glasses"
-    }
+    },
+    "armor": { "coverage": 75, "covers": [ "eyes" ] }
   },
   {
     "id": "kawaii_maid_megane_02",
@@ -856,8 +802,6 @@
     "material": [ "glass", "plastic" ],
     "symbol": "[",
     "color": "cyan",
-    "covers": [ "eyes" ],
-    "coverage": 75,
     "material_thickness": 1,
     "environmental_protection": 1,
     "flags": [ "WATER_FRIENDLY", "FANCY", "FIX_NEARSIGHT", "FIX_FARSIGHT" ],
@@ -866,7 +810,8 @@
       "msg": "You raise the glasses",
       "target": "kawaii_maid_megane_01",
       "menu_text": "Adjust the glasses"
-    }
+    },
+    "armor": { "coverage": 75, "covers": [ "eyes" ] }
   },
   {
     "id": "kawaii_maid_megane_03",
@@ -879,8 +824,6 @@
     "material": [ "glass", "plastic" ],
     "symbol": "[",
     "color": "cyan",
-    "covers": [ "eyes" ],
-    "coverage": 75,
     "material_thickness": 1,
     "environmental_protection": 1,
     "flags": [ "WATER_FRIENDLY", "FANCY", "FIX_NEARSIGHT", "FIX_FARSIGHT" ],
@@ -889,7 +832,8 @@
       "msg": "You lower the glasses",
       "target": "kawaii_maid_megane_04",
       "menu_text": "Adjust the glasses"
-    }
+    },
+    "armor": { "coverage": 75, "covers": [ "eyes" ] }
   },
   {
     "id": "kawaii_maid_megane_04",
@@ -902,8 +846,6 @@
     "material": [ "glass", "plastic" ],
     "symbol": "[",
     "color": "cyan",
-    "covers": [ "eyes" ],
-    "coverage": 75,
     "material_thickness": 1,
     "environmental_protection": 1,
     "flags": [ "WATER_FRIENDLY", "FANCY", "FIX_NEARSIGHT", "FIX_FARSIGHT" ],
@@ -912,7 +854,8 @@
       "msg": "You raise the glasses",
       "target": "kawaii_maid_megane_03",
       "menu_text": "Adjust the glasses"
-    }
+    },
+    "armor": { "coverage": 75, "covers": [ "eyes" ] }
   },
   {
     "id": "kawaii_maid_megane_05",
@@ -925,11 +868,10 @@
     "material": [ "glass", "plastic" ],
     "symbol": "[",
     "color": "cyan",
-    "covers": [ "eyes" ],
-    "coverage": 75,
     "material_thickness": 1,
     "environmental_protection": 1,
-    "flags": [ "WATER_FRIENDLY", "FANCY", "FIX_NEARSIGHT", "FIX_FARSIGHT" ]
+    "flags": [ "WATER_FRIENDLY", "FANCY", "FIX_NEARSIGHT", "FIX_FARSIGHT" ],
+    "armor": { "coverage": 75, "covers": [ "eyes" ] }
   },
   {
     "id": "kawaii_maid_megane_06",
@@ -942,11 +884,10 @@
     "material": [ "glass", "plastic" ],
     "symbol": "[",
     "color": "cyan",
-    "covers": [ "eyes" ],
-    "coverage": 75,
     "material_thickness": 1,
     "environmental_protection": 1,
-    "flags": [ "WATER_FRIENDLY", "FANCY", "FIX_NEARSIGHT", "FIX_FARSIGHT" ]
+    "flags": [ "WATER_FRIENDLY", "FANCY", "FIX_NEARSIGHT", "FIX_FARSIGHT" ],
+    "armor": { "coverage": 75, "covers": [ "eyes" ] }
   },
   {
     "id": "kawaii_maid_megane_07",
@@ -959,11 +900,10 @@
     "material": [ "glass", "plastic" ],
     "symbol": "[",
     "color": "cyan",
-    "covers": [ "eyes" ],
-    "coverage": 75,
     "material_thickness": 1,
     "environmental_protection": 1,
-    "flags": [ "WATER_FRIENDLY", "FANCY", "FIX_NEARSIGHT", "FIX_FARSIGHT" ]
+    "flags": [ "WATER_FRIENDLY", "FANCY", "FIX_NEARSIGHT", "FIX_FARSIGHT" ],
+    "armor": { "coverage": 75, "covers": [ "eyes" ] }
   },
   {
     "id": "kawaii_maid_megane_08",
@@ -976,11 +916,10 @@
     "material": [ "glass", "plastic" ],
     "symbol": "[",
     "color": "cyan",
-    "covers": [ "eyes" ],
-    "coverage": 75,
     "material_thickness": 1,
     "environmental_protection": 1,
-    "flags": [ "WATER_FRIENDLY", "FANCY", "FIX_NEARSIGHT", "FIX_FARSIGHT" ]
+    "flags": [ "WATER_FRIENDLY", "FANCY", "FIX_NEARSIGHT", "FIX_FARSIGHT" ],
+    "armor": { "coverage": 75, "covers": [ "eyes" ] }
   },
   {
     "id": "kawaii_maid_megane_09",
@@ -993,11 +932,10 @@
     "material": [ "glass", "plastic" ],
     "symbol": "[",
     "color": "cyan",
-    "covers": [ "eyes" ],
-    "coverage": 75,
     "material_thickness": 1,
     "environmental_protection": 1,
-    "flags": [ "WATER_FRIENDLY", "FANCY", "FIX_NEARSIGHT", "FIX_FARSIGHT" ]
+    "flags": [ "WATER_FRIENDLY", "FANCY", "FIX_NEARSIGHT", "FIX_FARSIGHT" ],
+    "armor": { "coverage": 75, "covers": [ "eyes" ] }
   },
   {
     "id": "kawaii_hat_cotton",
@@ -1010,11 +948,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "head" ],
-    "coverage": 65,
     "warmth": 20,
     "material_thickness": 1,
-    "flags": [ "VARSIZE" ]
+    "flags": [ "VARSIZE" ],
+    "armor": { "coverage": 65, "covers": [ "head" ] }
   },
   {
     "id": "kawaii_balclava",
@@ -1027,12 +964,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "head", "mouth" ],
-    "coverage": 95,
-    "encumbrance": 5,
     "warmth": 25,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "SKINTIGHT" ]
+    "flags": [ "VARSIZE", "SKINTIGHT" ],
+    "armor": { "coverage": 95, "covers": [ "head", "mouth" ], "encumbrance": 5 }
   },
   {
     "id": "kawaii_wedding_veil_a",
@@ -1045,12 +980,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "head" ],
-    "coverage": 70,
-    "encumbrance": 5,
     "warmth": 15,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 70, "covers": [ "head" ], "encumbrance": 5 }
   },
   {
     "id": "kawaii_wedding_veil_b",
@@ -1063,12 +996,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "head" ],
-    "coverage": 70,
-    "encumbrance": 5,
     "warmth": 15,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 70, "covers": [ "head" ], "encumbrance": 5 }
   },
   {
     "id": "kawaii_sister_veil",
@@ -1081,12 +1012,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "head" ],
-    "coverage": 95,
-    "encumbrance": 5,
     "warmth": 5,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 95, "covers": [ "head" ], "encumbrance": 5 }
   },
   {
     "id": "kawaii_wig_01",
@@ -1108,9 +1037,6 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "torso" ],
-    "coverage": 30,
-    "encumbrance": 30,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "12 L", "max_contains_weight": "24 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "12 L", "max_contains_weight": "24 kg", "moves": 75 },
@@ -1119,7 +1045,8 @@
     ],
     "warmth": 0,
     "material_thickness": 2,
-    "flags": [ "BELTED" ]
+    "flags": [ "BELTED" ],
+    "armor": { "coverage": 30, "covers": [ "torso" ], "encumbrance": 30 }
   },
   {
     "id": "kawaii_maid_hardcase_mini",
@@ -1132,9 +1059,6 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "torso" ],
-    "coverage": 15,
-    "encumbrance": 15,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "8 L", "max_contains_weight": "16 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "8 L", "max_contains_weight": "16 kg", "moves": 75 },
@@ -1143,7 +1067,8 @@
     ],
     "warmth": 0,
     "material_thickness": 2,
-    "flags": [ "BELTED" ]
+    "flags": [ "BELTED" ],
+    "armor": { "coverage": 15, "covers": [ "torso" ], "encumbrance": 15 }
   },
   {
     "id": "kawaii_maid_hardcase_slim",
@@ -1156,9 +1081,6 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "torso" ],
-    "coverage": 10,
-    "encumbrance": 8,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "4 L", "max_contains_weight": "6 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "4 L", "max_contains_weight": "6 kg", "moves": 75 },
@@ -1167,7 +1089,8 @@
     ],
     "warmth": 0,
     "material_thickness": 2,
-    "flags": [ "BELTED" ]
+    "flags": [ "BELTED" ],
+    "armor": { "coverage": 10, "covers": [ "torso" ], "encumbrance": 8 }
   },
   {
     "id": "kawaii_secretpoach",
@@ -1180,15 +1103,13 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "leg_l" ],
-    "coverage": 5,
-    "encumbrance": 2,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "2 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "2 kg", "moves": 75 }
     ],
     "material_thickness": 2,
-    "flags": [ "WAIST", "WATER_FRIENDLY" ]
+    "flags": [ "WAIST", "WATER_FRIENDLY" ],
+    "armor": { "coverage": 5, "covers": [ "leg_l" ], "encumbrance": 2 }
   },
   {
     "id": "kawaii_maid_niso_thick",
@@ -1201,12 +1122,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 75,
-    "encumbrance": 10,
     "warmth": 35,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "SKINTIGHT", "FANCY" ]
+    "flags": [ "VARSIZE", "SKINTIGHT", "FANCY" ],
+    "armor": { "coverage": 75, "covers": [ "foot_l", "foot_r" ], "encumbrance": 10 }
   },
   {
     "id": "kawaii_maid_niso_thin",
@@ -1219,12 +1138,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 75,
-    "encumbrance": 5,
     "warmth": 2,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "SKINTIGHT", "FANCY" ]
+    "flags": [ "VARSIZE", "SKINTIGHT", "FANCY" ],
+    "armor": { "coverage": 75, "covers": [ "foot_l", "foot_r" ], "encumbrance": 5 }
   },
   {
     "id": "kawaii_tights_black",
@@ -1237,12 +1154,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "foot_l", "foot_r", "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 15,
     "warmth": 40,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "SKINTIGHT", "FANCY" ]
+    "flags": [ "VARSIZE", "SKINTIGHT", "FANCY" ],
+    "armor": { "coverage": 95, "covers": [ "foot_l", "foot_r", "leg_l", "leg_r" ], "encumbrance": 15 }
   },
   {
     "id": "kawaii_tights_white",
@@ -1255,12 +1170,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "foot_l", "foot_r", "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 15,
     "warmth": 40,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "SKINTIGHT", "FANCY" ]
+    "flags": [ "VARSIZE", "SKINTIGHT", "FANCY" ],
+    "armor": { "coverage": 95, "covers": [ "foot_l", "foot_r", "leg_l", "leg_r" ], "encumbrance": 15 }
   },
   {
     "id": "kawaii_socks_white",
@@ -1273,12 +1186,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 50,
-    "encumbrance": 2,
     "warmth": 5,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "SKINTIGHT" ]
+    "flags": [ "VARSIZE", "SKINTIGHT" ],
+    "armor": { "coverage": 50, "covers": [ "foot_l", "foot_r" ], "encumbrance": 2 }
   },
   {
     "id": "kawaii_maid_garter",
@@ -1291,12 +1202,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 10,
-    "encumbrance": 0,
     "warmth": 0,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "SKINTIGHT" ]
+    "flags": [ "VARSIZE", "SKINTIGHT" ],
+    "armor": { "coverage": 10, "covers": [ "leg_l", "leg_r" ], "encumbrance": 0 }
   },
   {
     "id": "kawaii_dress_shoes",
@@ -1309,12 +1218,10 @@
     "material": [ "leather" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 60,
-    "encumbrance": 5,
     "warmth": 5,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 60, "covers": [ "foot_l", "foot_r" ], "encumbrance": 5 }
   },
   {
     "id": "kawaii_loafer",
@@ -1327,12 +1234,10 @@
     "material": [ "leather" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 60,
-    "encumbrance": 5,
     "warmth": 5,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 60, "covers": [ "foot_l", "foot_r" ], "encumbrance": 5 }
   },
   {
     "id": "kawaii_boots",
@@ -1345,13 +1250,11 @@
     "material": [ "leather" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 90,
     "warmth": 20,
-    "encumbrance": 12,
     "material_thickness": 3,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "FANCY", "WATERPROOF" ]
+    "flags": [ "VARSIZE", "FANCY", "WATERPROOF" ],
+    "armor": { "coverage": 90, "covers": [ "foot_l", "foot_r" ], "encumbrance": 12 }
   },
   {
     "id": "kawaii_boots_hi",
@@ -1364,13 +1267,11 @@
     "material": [ "kevlar", "nomex" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 100,
     "warmth": 30,
-    "encumbrance": 5,
     "material_thickness": 7,
     "environmental_protection": 10,
-    "flags": [ "VARSIZE", "FANCY", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "FANCY", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "foot_l", "foot_r" ], "encumbrance": 5 }
   },
   {
     "id": "kawaii_shoes_hi",
@@ -1383,13 +1284,11 @@
     "material": [ "kevlar", "nomex" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 100,
     "warmth": 2,
-    "encumbrance": 0,
     "material_thickness": 5,
     "environmental_protection": 10,
-    "flags": [ "VARSIZE", "FANCY", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "FANCY", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "foot_l", "foot_r" ], "encumbrance": 0 }
   },
   {
     "id": "kawaii_scarf",
@@ -1404,13 +1303,11 @@
     "weight": "60 g",
     "volume": "500 ml",
     "use_action": { "type": "transform", "msg": "You loosen the scarf.", "target": "kawaii_scarf_loose", "menu_text": "Adjust scarf" },
-    "covers": [ "mouth" ],
     "flags": [ "OUTER", "FANCY" ],
     "warmth": 60,
     "environmental_protection": 3,
-    "encumbrance": 15,
-    "coverage": 85,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 85, "covers": [ "mouth" ], "encumbrance": 15 }
   },
   {
     "id": "kawaii_scarf_loose",
@@ -1431,12 +1328,10 @@
       "target": "kawaii_scarf",
       "menu_text": "Adjust scarf"
     },
-    "covers": [ "mouth" ],
     "flags": [ "OUTER", "ALLOWS_NATURAL_ATTACKS", "FANCY" ],
     "warmth": 20,
     "environmental_protection": 3,
-    "encumbrance": 10,
-    "coverage": 45,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 45, "covers": [ "mouth" ], "encumbrance": 10 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Reapermod/armor.json
+++ b/data/Unleash_The_Mods/Working_mods/Reapermod/armor.json
@@ -11,15 +11,13 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r" ],
-    "coverage": 80,
-    "encumbrance": 5,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "3 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "3 kg", "moves": 75 }
     ],
     "warmth": 20,
     "material_thickness": 3,
-    "flags": [ "VARSIZE", "OUTER", "HOOD", "WATER_FRIENDLY", "FANCY" ]
+    "flags": [ "VARSIZE", "OUTER", "HOOD", "WATER_FRIENDLY", "FANCY" ],
+    "armor": { "coverage": 80, "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r" ], "encumbrance": 5 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Reds_Odd_Additions/Items/armor.json
+++ b/data/Unleash_The_Mods/Working_mods/Reds_Odd_Additions/Items/armor.json
@@ -10,9 +10,6 @@
     "material": [ "essence_bacon_material" ],
     "symbol": "[",
     "color": "red",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 100,
-    "encumbrance": 40,
     "warmth": 65,
     "material_thickness": 5,
     "environmental_protection": 25,
@@ -25,7 +22,8 @@
         "moves": 75
       }
     ],
-    "flags": [ "SKINTIGHT", "NONCONDUCTIVE" ]
+    "flags": [ "SKINTIGHT", "NONCONDUCTIVE" ],
+    "armor": { "coverage": 100, "covers": [ "leg_l", "leg_r" ], "encumbrance": 40 }
   },
   {
     "id": "afro",
@@ -38,12 +36,10 @@
     "material": [ "essence_bash_material" ],
     "symbol": "n",
     "color": "light_gray",
-    "covers": [ "head" ],
-    "coverage": 100,
-    "encumbrance": 100,
     "warmth": 30,
     "material_thickness": 5,
-    "flags": [ "NONCONDUCTIVE", "FANCY" ]
+    "flags": [ "NONCONDUCTIVE", "FANCY" ],
+    "armor": { "coverage": 100, "covers": [ "head" ], "encumbrance": 100 }
   },
   {
     "id": "immortal_loincloth",
@@ -56,10 +52,9 @@
     "material": [ "cotton" ],
     "symbol": "-",
     "color": "brown",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 5,
     "material_thickness": 999,
-    "flags": [ "VARSIZE" ]
+    "flags": [ "VARSIZE" ],
+    "armor": { "coverage": 5, "covers": [ "leg_l", "leg_r" ] }
   },
   {
     "id": "plutonium_chestplate",
@@ -72,11 +67,9 @@
     "material": [ "scale_plutonium_material" ],
     "symbol": "I",
     "color": "red",
-    "covers": [ "torso" ],
-    "coverage": 85,
     "material_thickness": 5,
     "flags": [ "OUTER", "FANCY" ],
     "environmental_protection": 30,
-    "encumbrance": 10
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": 10 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Road_Warrior_Mod/items/armor.json
+++ b/data/Unleash_The_Mods/Working_mods/Road_Warrior_Mod/items/armor.json
@@ -5,7 +5,6 @@
     "name": { "str": "road warrior jacket" },
     "weight": "1550 g",
     "color": "dark_gray",
-    "covers": [ "torso", "arm_l", "arm_r" ],
     "to_hit": 1,
     "symbol": "[",
     "description": "A tough leather jacket, equipped and armored to deal with the threats of the post-apocalytic world.",
@@ -16,16 +15,15 @@
     "warmth": 30,
     "phase": "solid",
     "environmental_protection": 1,
-    "encumbrance": 16,
     "bashing": 0,
     "flags": [ "VARSIZE", "POCKETS", "OUTER" ],
-    "coverage": 90,
     "material_thickness": 4,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1 L", "max_contains_weight": "3 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "2 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "2 kg", "moves": 80 }
-    ]
+    ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 16 }
   },
   {
     "id": "badge_MFP",
@@ -37,16 +35,15 @@
     "weight": "60 g",
     "to_hit": 0,
     "color": "yellow",
-    "encumbrance": 0,
     "price": "50 USD",
     "material": [ "silver", "bronze" ],
-    "coverage": 0,
     "symbol": "[",
     "bashing": 0,
     "cutting": 0,
     "warmth": 0,
     "environmental_protection": 0,
-    "phase": "solid"
+    "phase": "solid",
+    "armor": { "coverage": 0, "encumbrance": 0 }
   },
   {
     "id": "leg_brace",
@@ -60,14 +57,12 @@
     "description": "A leather leg brace held together with steel pivots and rivets. Designed to help the wearer walk better.",
     "to_hit": -1,
     "material": [ "leather", "steel" ],
-    "covers": [ "leg_l", "leg_r" ],
     "flags": [ "VARSIZE", "OVERSIZE" ],
-    "coverage": 15,
     "cutting": 0,
     "bashing": 0,
     "warmth": 0,
     "phase": "solid",
-    "encumbrance": 1,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 15, "covers": [ "leg_l", "leg_r" ], "encumbrance": 1 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Rubber_bands/sheath.json
+++ b/data/Unleash_The_Mods/Working_mods/Rubber_bands/sheath.json
@@ -11,10 +11,9 @@
     "symbol": "|",
     "looks_like": "scabbard",
     "color": "brown",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 5,
     "material_thickness": 1,
     "use_action": { "type": "holster", "holster_prompt": "Sheath knife", "holster_msg": "You sheath your %s" },
-    "flags": [ "WAIST", "OVERSIZE", "WATER_FRIENDLY", "SHEATH_KNIFE" ]
+    "flags": [ "WAIST", "OVERSIZE", "WATER_FRIENDLY", "SHEATH_KNIFE" ],
+    "armor": { "coverage": 5, "covers": [ "leg_l", "leg_r" ] }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Scaly_duds/Armour.json
+++ b/data/Unleash_The_Mods/Working_mods/Scaly_duds/Armour.json
@@ -12,8 +12,6 @@
     "material": [ "snake_leather" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso" ],
-    "coverage": 5,
     "material_thickness": 2,
     "pocket_data": [
       {
@@ -26,7 +24,8 @@
       }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Stick what into your belt", "holster_msg": "You tuck your %s into your %s" },
-    "flags": [ "WAIST", "WATER_FRIENDLY", "FANCY" ]
+    "flags": [ "WAIST", "WATER_FRIENDLY", "FANCY" ],
+    "armor": { "coverage": 5, "covers": [ "torso" ] }
   },
   {
     "id": "allig_belt",
@@ -41,8 +40,6 @@
     "material": [ "allig_leather" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "torso" ],
-    "coverage": 10,
     "material_thickness": 3,
     "pocket_data": [
       {
@@ -55,7 +52,8 @@
       }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Stick what into your belt", "holster_msg": "You tuck your %s into your %s" },
-    "flags": [ "WAIST", "WATER_FRIENDLY", "FANCY" ]
+    "flags": [ "WAIST", "WATER_FRIENDLY", "FANCY" ],
+    "armor": { "coverage": 10, "covers": [ "torso" ] }
   },
   {
     "id": "snake_boots",
@@ -72,13 +70,11 @@
     "symbol": "[",
     "looks_like": "boots",
     "color": "brown",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 90,
-    "encumbrance": 12,
     "warmth": 12,
     "material_thickness": 3,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "WATERPROOF", "FANCY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "FANCY" ],
+    "armor": { "coverage": 90, "covers": [ "foot_l", "foot_r" ], "encumbrance": 12 }
   },
   {
     "id": "allig_boots",
@@ -95,13 +91,11 @@
     "symbol": "[",
     "looks_like": "boots",
     "color": "dark_gray",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 90,
-    "encumbrance": 15,
     "warmth": 15,
     "material_thickness": 4,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "WATERPROOF", "FANCY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "FANCY" ],
+    "armor": { "coverage": 90, "covers": [ "foot_l", "foot_r" ], "encumbrance": 15 }
   },
   {
     "id": "heavy_allig_boots",
@@ -118,13 +112,11 @@
     "symbol": "[",
     "looks_like": "boots",
     "color": "dark_gray",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 25,
     "warmth": 20,
     "material_thickness": 5,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "foot_l", "foot_r" ], "encumbrance": 25 }
   },
   {
     "id": "snake_gloves",
@@ -142,13 +134,11 @@
     "symbol": "[",
     "looks_like": "gloves_leather",
     "color": "brown",
-    "covers": [ "hand_l", "hand_r" ],
-    "coverage": 95,
-    "encumbrance": 7,
     "warmth": 14,
     "material_thickness": 3,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "OVERSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "OVERSIZE", "FANCY" ],
+    "armor": { "coverage": 95, "covers": [ "hand_l", "hand_r" ], "encumbrance": 7 }
   },
   {
     "id": "allig_gloves",
@@ -166,13 +156,11 @@
     "symbol": "[",
     "looks_like": "gloves_leather",
     "color": "dark_gray",
-    "covers": [ "hand_l", "hand_r" ],
-    "coverage": 95,
-    "encumbrance": 9,
     "warmth": 16,
     "material_thickness": 4,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "STURDY", "OVERSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "STURDY", "OVERSIZE", "FANCY" ],
+    "armor": { "coverage": 95, "covers": [ "hand_l", "hand_r" ], "encumbrance": 9 }
   },
   {
     "id": "heavy_allig_gloves",
@@ -190,13 +178,11 @@
     "symbol": "[",
     "looks_like": "gloves_leather",
     "color": "dark_gray",
-    "covers": [ "hand_l", "hand_r" ],
-    "coverage": 95,
-    "encumbrance": 12,
     "warmth": 18,
     "material_thickness": 5,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "STURDY", "OVERSIZE" ]
+    "flags": [ "VARSIZE", "STURDY", "OVERSIZE" ],
+    "armor": { "coverage": 95, "covers": [ "hand_l", "hand_r" ], "encumbrance": 12 }
   },
   {
     "id": "snake_cloak",
@@ -212,13 +198,11 @@
     "symbol": "[",
     "looks_like": "cloak",
     "color": "brown",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 65,
-    "encumbrance": 4,
     "warmth": -15,
     "material_thickness": 2,
     "environmental_protection": 3,
-    "flags": [ "OVERSIZE", "HOOD", "OUTER", "WATERPROOF", "RAINPROOF" ]
+    "flags": [ "OVERSIZE", "HOOD", "OUTER", "WATERPROOF", "RAINPROOF" ],
+    "armor": { "coverage": 65, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 4 }
   },
   {
     "id": "allig_cloak",
@@ -234,13 +218,11 @@
     "symbol": "[",
     "looks_like": "cloak",
     "color": "dark_gray",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 65,
-    "encumbrance": 6,
     "warmth": -5,
     "material_thickness": 4,
     "environmental_protection": 3,
-    "flags": [ "OVERSIZE", "HOOD", "OUTER", "WATERPROOF", "RAINPROOF" ]
+    "flags": [ "OVERSIZE", "HOOD", "OUTER", "WATERPROOF", "RAINPROOF" ],
+    "armor": { "coverage": 65, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 6 }
   },
   {
     "id": "heavy_allig_cloak",
@@ -256,13 +238,11 @@
     "symbol": "[",
     "looks_like": "cloak",
     "color": "dark_gray",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 65,
-    "encumbrance": 10,
     "warmth": 15,
     "material_thickness": 5,
     "environmental_protection": 3,
-    "flags": [ "OVERSIZE", "HOOD", "OUTER", "WATERPROOF", "RAINPROOF" ]
+    "flags": [ "OVERSIZE", "HOOD", "OUTER", "WATERPROOF", "RAINPROOF" ],
+    "armor": { "coverage": 65, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 10 }
   },
   {
     "id": "snake_loincloth",
@@ -277,10 +257,9 @@
     "symbol": "[",
     "looks_like": "loincloth",
     "color": "brown",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 5,
     "material_thickness": 3,
-    "flags": [ "VARSIZE", "SKINTIGHT", "OVERSIZE" ]
+    "flags": [ "VARSIZE", "SKINTIGHT", "OVERSIZE" ],
+    "armor": { "coverage": 5, "covers": [ "leg_l", "leg_r" ] }
   },
   {
     "id": "allig_loincloth",
@@ -295,10 +274,9 @@
     "symbol": "[",
     "looks_like": "loincloth",
     "color": "dark_gray",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 5,
     "material_thickness": 4,
-    "flags": [ "VARSIZE", "SKINTIGHT", "OVERSIZE" ]
+    "flags": [ "VARSIZE", "SKINTIGHT", "OVERSIZE" ],
+    "armor": { "coverage": 5, "covers": [ "leg_l", "leg_r" ] }
   },
   {
     "id": "snake_pants",
@@ -314,17 +292,14 @@
     "symbol": "[",
     "looks_like": "pants",
     "color": "brown",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 12,
-    "max_encumbrance": 14,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "350 ml", "max_contains_weight": "1 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "350 ml", "max_contains_weight": "1 kg", "moves": 80 }
     ],
     "warmth": 15,
     "material_thickness": 3,
-    "flags": [ "VARSIZE" ]
+    "flags": [ "VARSIZE" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r" ], "encumbrance": [ 12, 14 ] }
   },
   {
     "id": "allig_pants",
@@ -340,17 +315,14 @@
     "symbol": "[",
     "looks_like": "pants",
     "color": "brown",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 15,
-    "max_encumbrance": 17,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "350 ml", "max_contains_weight": "1 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "350 ml", "max_contains_weight": "1 kg", "moves": 80 }
     ],
     "warmth": 20,
     "material_thickness": 4,
-    "flags": [ "VARSIZE" ]
+    "flags": [ "VARSIZE" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r" ], "encumbrance": [ 15, 17 ] }
   },
   {
     "id": "heavy_allig_pants",
@@ -366,17 +338,14 @@
     "symbol": "[",
     "looks_like": "pants",
     "color": "brown",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 18,
-    "max_encumbrance": 20,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "350 ml", "max_contains_weight": "1 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "350 ml", "max_contains_weight": "1 kg", "moves": 80 }
     ],
     "warmth": 25,
     "material_thickness": 5,
-    "flags": [ "VARSIZE", "STURDY" ]
+    "flags": [ "VARSIZE", "STURDY" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r" ], "encumbrance": [ 18, 20 ] }
   },
   {
     "id": "snake_jacket",
@@ -392,10 +361,6 @@
     "symbol": "[",
     "looks_like": "jacket_leather",
     "color": "brown",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 90,
-    "encumbrance": 9,
-    "max_encumbrance": 14,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "700 ml", "max_contains_weight": "3 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "700 ml", "max_contains_weight": "3 kg", "moves": 80 }
@@ -403,7 +368,8 @@
     "warmth": 20,
     "material_thickness": 3,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "FANCY" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "FANCY" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": [ 9, 14 ] }
   },
   {
     "id": "allig_jacket",
@@ -419,10 +385,6 @@
     "symbol": "[",
     "looks_like": "jacket_leather",
     "color": "dark_gray",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 90,
-    "encumbrance": 10,
-    "max_encumbrance": 15,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "700 ml", "max_contains_weight": "3 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "700 ml", "max_contains_weight": "3 kg", "moves": 80 }
@@ -430,7 +392,8 @@
     "warmth": 25,
     "material_thickness": 4,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "FANCY" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "FANCY" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": [ 10, 15 ] }
   },
   {
     "id": "heavy_allig_jacket",
@@ -446,10 +409,6 @@
     "symbol": "[",
     "looks_like": "jacket_leather",
     "color": "dark_gray",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 90,
-    "encumbrance": 15,
-    "max_encumbrance": 20,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "700 ml", "max_contains_weight": "3 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "700 ml", "max_contains_weight": "3 kg", "moves": 80 }
@@ -457,7 +416,8 @@
     "warmth": 30,
     "material_thickness": 5,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "STURDY" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "STURDY" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": [ 15, 20 ] }
   },
   {
     "id": "sleeveless_snake_duster",
@@ -473,10 +433,6 @@
     "symbol": "[",
     "looks_like": "duster_leather",
     "color": "brown",
-    "covers": [ "torso", "leg_l", "leg_r" ],
-    "coverage": 90,
-    "encumbrance": 7,
-    "max_encumbrance": 15,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "4 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "4 kg", "moves": 80 },
@@ -488,7 +444,8 @@
     "warmth": 25,
     "material_thickness": 3,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "WATERPROOF", "RAINPROOF", "FANCY" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "WATERPROOF", "RAINPROOF", "FANCY" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "leg_l", "leg_r" ], "encumbrance": [ 7, 15 ] }
   },
   {
     "id": "sleeveless_allig_duster",
@@ -504,10 +461,6 @@
     "symbol": "[",
     "looks_like": "duster_leather",
     "color": "dark_gray",
-    "covers": [ "torso", "leg_l", "leg_r" ],
-    "coverage": 90,
-    "encumbrance": 8,
-    "max_encumbrance": 17,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "4 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "4 kg", "moves": 80 },
@@ -519,7 +472,8 @@
     "warmth": 30,
     "material_thickness": 4,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "WATERPROOF", "RAINPROOF", "FANCY" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "WATERPROOF", "RAINPROOF", "FANCY" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "leg_l", "leg_r" ], "encumbrance": [ 8, 17 ] }
   },
   {
     "id": "sleeveless_heavy_allig_duster",
@@ -535,10 +489,6 @@
     "symbol": "[",
     "looks_like": "duster_leather",
     "color": "dark_gray",
-    "covers": [ "torso", "leg_l", "leg_r" ],
-    "coverage": 90,
-    "encumbrance": 10,
-    "max_encumbrance": 20,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "4 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "4 kg", "moves": 80 },
@@ -550,7 +500,8 @@
     "warmth": 35,
     "material_thickness": 5,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "WATERPROOF", "RAINPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "WATERPROOF", "RAINPROOF", "STURDY" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "leg_l", "leg_r" ], "encumbrance": [ 10, 20 ] }
   },
   {
     "id": "snake_duster",
@@ -566,10 +517,6 @@
     "symbol": "[",
     "looks_like": "duster_leather",
     "color": "brown",
-    "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ],
-    "coverage": 90,
-    "encumbrance": 7,
-    "max_encumbrance": 15,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "4 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "4 kg", "moves": 80 },
@@ -581,7 +528,8 @@
     "warmth": 25,
     "material_thickness": 3,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "WATERPROOF", "RAINPROOF", "FANCY" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "WATERPROOF", "RAINPROOF", "FANCY" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ], "encumbrance": [ 7, 15 ] }
   },
   {
     "id": "allig_duster",
@@ -597,10 +545,6 @@
     "symbol": "[",
     "looks_like": "duster_leather",
     "color": "dark_gray",
-    "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ],
-    "coverage": 90,
-    "encumbrance": 8,
-    "max_encumbrance": 17,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "4 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "4 kg", "moves": 80 },
@@ -612,7 +556,8 @@
     "warmth": 30,
     "material_thickness": 4,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "WATERPROOF", "RAINPROOF", "FANCY" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "WATERPROOF", "RAINPROOF", "FANCY" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ], "encumbrance": [ 8, 17 ] }
   },
   {
     "id": "heavy_allig_duster",
@@ -628,10 +573,6 @@
     "symbol": "[",
     "looks_like": "duster_leather",
     "color": "dark_gray",
-    "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ],
-    "coverage": 90,
-    "encumbrance": 10,
-    "max_encumbrance": 20,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "4 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "4 kg", "moves": 80 },
@@ -643,7 +584,8 @@
     "warmth": 35,
     "material_thickness": 5,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "WATERPROOF", "RAINPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "WATERPROOF", "RAINPROOF", "STURDY" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ], "encumbrance": [ 10, 20 ] }
   },
   {
     "id": "snake_hood",
@@ -658,12 +600,11 @@
     "symbol": "[",
     "looks_like": "hood_rain",
     "color": "brown",
-    "covers": [ "head" ],
-    "coverage": 100,
     "warmth": 4,
     "material_thickness": 3,
     "environmental_protection": 1,
-    "flags": [ "WATERPROOF", "OUTER", "HELMET_COMPAT", "FANCY" ]
+    "flags": [ "WATERPROOF", "OUTER", "HELMET_COMPAT", "FANCY" ],
+    "armor": { "coverage": 100, "covers": [ "head" ] }
   },
   {
     "id": "allig_hood",
@@ -678,12 +619,11 @@
     "symbol": "[",
     "looks_like": "hood_rain",
     "color": "dark_gray",
-    "covers": [ "head" ],
-    "coverage": 100,
     "warmth": 6,
     "material_thickness": 4,
     "environmental_protection": 1,
-    "flags": [ "WATERPROOF", "OUTER", "HELMET_COMPAT", "FANCY" ]
+    "flags": [ "WATERPROOF", "OUTER", "HELMET_COMPAT", "FANCY" ],
+    "armor": { "coverage": 100, "covers": [ "head" ] }
   },
   {
     "id": "heavy_allig_hood",
@@ -698,11 +638,10 @@
     "symbol": "[",
     "looks_like": "hood_rain",
     "color": "dark_gray",
-    "covers": [ "head" ],
-    "coverage": 100,
     "warmth": 10,
     "material_thickness": 5,
     "environmental_protection": 1,
-    "flags": [ "WATERPROOF", "OUTER", "HELMET_COMPAT", "STURDY" ]
+    "flags": [ "WATERPROOF", "OUTER", "HELMET_COMPAT", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "head" ] }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Secronom/Modification_Files/Items/secro_power_armor_armaments.json
+++ b/data/Unleash_The_Mods/Working_mods/Secronom/Modification_Files/Items/secro_power_armor_armaments.json
@@ -12,8 +12,6 @@
     "material": [ "secro_null" ],
     "symbol": "%",
     "color": "light_red",
-    "coverage": 0,
-    "encumbrance": 0,
     "power_armor": true,
     "material_thickness": 1,
     "use_action": {
@@ -23,7 +21,8 @@
       "need_worn": true,
       "level": 0
     },
-    "flags": [ "NO_TAKEOFF", "POWERARMOR_COMPATIBLE" ]
+    "flags": [ "NO_TAKEOFF", "POWERARMOR_COMPATIBLE" ],
+    "armor": { "coverage": 0, "encumbrance": 0 }
   },
   {
     "id": "secro_power_armor_flesh_morphed_fite_blades",
@@ -38,8 +37,6 @@
     "material": [ "secro_null" ],
     "symbol": "%",
     "color": "light_red_white",
-    "coverage": 0,
-    "encumbrance": 0,
     "power_armor": true,
     "material_thickness": 1,
     "relic_data": {
@@ -66,7 +63,8 @@
         }
       ]
     },
-    "flags": [ "NO_TAKEOFF", "ONLY_ONE", "POWERARMOR_COMPATIBLE" ]
+    "flags": [ "NO_TAKEOFF", "ONLY_ONE", "POWERARMOR_COMPATIBLE" ],
+    "armor": { "coverage": 0, "encumbrance": 0 }
   },
   {
     "id": "secro_power_armor_flesh_morph_fite_tentacles",
@@ -81,8 +79,6 @@
     "material": [ "secro_null" ],
     "symbol": "%",
     "color": "light_red",
-    "coverage": 0,
-    "encumbrance": 0,
     "power_armor": true,
     "material_thickness": 1,
     "use_action": {
@@ -92,7 +88,8 @@
       "need_worn": true,
       "level": 0
     },
-    "flags": [ "NO_TAKEOFF", "POWERARMOR_COMPATIBLE" ]
+    "flags": [ "NO_TAKEOFF", "POWERARMOR_COMPATIBLE" ],
+    "armor": { "coverage": 0, "encumbrance": 0 }
   },
   {
     "id": "secro_power_armor_flesh_morphed_fite_tentacles",
@@ -107,8 +104,6 @@
     "material": [ "secro_null" ],
     "symbol": "%",
     "color": "light_red_white",
-    "coverage": 0,
-    "encumbrance": 0,
     "power_armor": true,
     "material_thickness": 1,
     "use_action": {
@@ -142,7 +137,8 @@
         }
       ]
     },
-    "flags": [ "NO_TAKEOFF", "ONLY_ONE", "POWERARMOR_COMPATIBLE" ]
+    "flags": [ "NO_TAKEOFF", "ONLY_ONE", "POWERARMOR_COMPATIBLE" ],
+    "armor": { "coverage": 0, "encumbrance": 0 }
   },
   {
     "id": "secro_power_armor_flesh_morph_fite_fleshpound",
@@ -157,8 +153,6 @@
     "material": [ "secro_null" ],
     "symbol": "%",
     "color": "light_red",
-    "coverage": 0,
-    "encumbrance": 0,
     "power_armor": true,
     "material_thickness": 1,
     "use_action": {
@@ -168,7 +162,8 @@
       "need_worn": true,
       "level": 0
     },
-    "flags": [ "NO_TAKEOFF", "POWERARMOR_COMPATIBLE" ]
+    "flags": [ "NO_TAKEOFF", "POWERARMOR_COMPATIBLE" ],
+    "armor": { "coverage": 0, "encumbrance": 0 }
   },
   {
     "id": "secro_power_armor_flesh_morphed_fite_fleshpound",
@@ -183,8 +178,6 @@
     "material": [ "secro_null" ],
     "symbol": "%",
     "color": "light_red_white",
-    "coverage": 0,
-    "encumbrance": 0,
     "power_armor": true,
     "material_thickness": 1,
     "relic_data": {
@@ -209,7 +202,8 @@
         }
       ]
     },
-    "flags": [ "NO_TAKEOFF", "ONLY_ONE", "POWERARMOR_COMPATIBLE" ]
+    "flags": [ "NO_TAKEOFF", "ONLY_ONE", "POWERARMOR_COMPATIBLE" ],
+    "armor": { "coverage": 0, "encumbrance": 0 }
   },
   {
     "id": "secro_power_armor_flesh_morph_fite_jawarms",
@@ -224,8 +218,6 @@
     "material": [ "secro_null" ],
     "symbol": "%",
     "color": "light_red",
-    "coverage": 0,
-    "encumbrance": 0,
     "power_armor": true,
     "material_thickness": 1,
     "use_action": {
@@ -235,7 +227,8 @@
       "need_worn": true,
       "level": 0
     },
-    "flags": [ "NO_TAKEOFF", "POWERARMOR_COMPATIBLE" ]
+    "flags": [ "NO_TAKEOFF", "POWERARMOR_COMPATIBLE" ],
+    "armor": { "coverage": 0, "encumbrance": 0 }
   },
   {
     "id": "secro_power_armor_flesh_morphed_fite_jawarms",
@@ -250,8 +243,6 @@
     "material": [ "secro_null" ],
     "symbol": "%",
     "color": "light_red_white",
-    "coverage": 0,
-    "encumbrance": 0,
     "power_armor": true,
     "material_thickness": 1,
     "relic_data": {
@@ -279,7 +270,8 @@
         }
       ]
     },
-    "flags": [ "NO_TAKEOFF", "ONLY_ONE", "POWERARMOR_COMPATIBLE" ]
+    "flags": [ "NO_TAKEOFF", "ONLY_ONE", "POWERARMOR_COMPATIBLE" ],
+    "armor": { "coverage": 0, "encumbrance": 0 }
   },
   {
     "id": "secro_power_armor_flesh_morph_gun_spit",
@@ -294,8 +286,6 @@
     "material": [ "secro_null" ],
     "symbol": "%",
     "color": "cyan",
-    "coverage": 0,
-    "encumbrance": 0,
     "power_armor": true,
     "material_thickness": 1,
     "use_action": {
@@ -305,7 +295,8 @@
       "need_worn": true,
       "level": 0
     },
-    "flags": [ "NO_TAKEOFF", "POWERARMOR_COMPATIBLE" ]
+    "flags": [ "NO_TAKEOFF", "POWERARMOR_COMPATIBLE" ],
+    "armor": { "coverage": 0, "encumbrance": 0 }
   },
   {
     "id": "secro_power_armor_flesh_morphed_gun_spit",
@@ -320,8 +311,6 @@
     "material": [ "secro_null" ],
     "symbol": "%",
     "color": "cyan_white",
-    "coverage": 0,
-    "encumbrance": 0,
     "power_armor": true,
     "material_thickness": 1,
     "use_action": {
@@ -342,7 +331,8 @@
         }
       ]
     },
-    "flags": [ "NO_TAKEOFF", "ONLY_ONE", "POWERARMOR_COMPATIBLE" ]
+    "flags": [ "NO_TAKEOFF", "ONLY_ONE", "POWERARMOR_COMPATIBLE" ],
+    "armor": { "coverage": 0, "encumbrance": 0 }
   },
   {
     "id": "secro_power_armor_flesh_morph_gun_bonelance",
@@ -357,8 +347,6 @@
     "material": [ "secro_null" ],
     "symbol": "%",
     "color": "cyan",
-    "coverage": 0,
-    "encumbrance": 0,
     "power_armor": true,
     "material_thickness": 1,
     "use_action": {
@@ -368,7 +356,8 @@
       "need_worn": true,
       "level": 0
     },
-    "flags": [ "NO_TAKEOFF", "POWERARMOR_COMPATIBLE" ]
+    "flags": [ "NO_TAKEOFF", "POWERARMOR_COMPATIBLE" ],
+    "armor": { "coverage": 0, "encumbrance": 0 }
   },
   {
     "id": "secro_power_armor_flesh_morphed_gun_bonelance",
@@ -383,8 +372,6 @@
     "material": [ "secro_null" ],
     "symbol": "%",
     "color": "cyan_white",
-    "coverage": 0,
-    "encumbrance": 0,
     "power_armor": true,
     "material_thickness": 1,
     "use_action": {
@@ -397,7 +384,8 @@
     "relic_data": {
       "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "ATTACK_COST", "multiply": 0.1 } ] } ]
     },
-    "flags": [ "NO_TAKEOFF", "ONLY_ONE", "POWERARMOR_COMPATIBLE" ]
+    "flags": [ "NO_TAKEOFF", "ONLY_ONE", "POWERARMOR_COMPATIBLE" ],
+    "armor": { "coverage": 0, "encumbrance": 0 }
   },
   {
     "id": "secro_power_armor_flesh_morph_jugg_bonespikes",
@@ -412,8 +400,6 @@
     "material": [ "secro_null" ],
     "symbol": "%",
     "color": "cyan",
-    "coverage": 0,
-    "encumbrance": 0,
     "power_armor": true,
     "material_thickness": 1,
     "use_action": {
@@ -423,7 +409,8 @@
       "need_worn": true,
       "level": 0
     },
-    "flags": [ "NO_TAKEOFF", "POWERARMOR_COMPATIBLE" ]
+    "flags": [ "NO_TAKEOFF", "POWERARMOR_COMPATIBLE" ],
+    "armor": { "coverage": 0, "encumbrance": 0 }
   },
   {
     "id": "secro_power_armor_flesh_morphed_jugg_bonespikes",
@@ -438,8 +425,6 @@
     "material": [ "secro_null" ],
     "symbol": "%",
     "color": "cyan_white",
-    "coverage": 0,
-    "encumbrance": 0,
     "power_armor": true,
     "material_thickness": 1,
     "use_action": {
@@ -473,7 +458,8 @@
         }
       ]
     },
-    "flags": [ "NO_TAKEOFF", "ONLY_ONE", "POWERARMOR_COMPATIBLE" ]
+    "flags": [ "NO_TAKEOFF", "ONLY_ONE", "POWERARMOR_COMPATIBLE" ],
+    "armor": { "coverage": 0, "encumbrance": 0 }
   },
   {
     "id": "secro_power_armor_flesh_morph_coward_powerlegs",
@@ -488,8 +474,6 @@
     "material": [ "secro_null" ],
     "symbol": "%",
     "color": "light_green",
-    "coverage": 0,
-    "encumbrance": 0,
     "power_armor": true,
     "material_thickness": 1,
     "use_action": {
@@ -499,7 +483,8 @@
       "need_worn": true,
       "level": 0
     },
-    "flags": [ "NO_TAKEOFF", "POWERARMOR_COMPATIBLE" ]
+    "flags": [ "NO_TAKEOFF", "POWERARMOR_COMPATIBLE" ],
+    "armor": { "coverage": 0, "encumbrance": 0 }
   },
   {
     "id": "secro_power_armor_flesh_morphed_coward_powerlegs",
@@ -514,8 +499,6 @@
     "material": [ "secro_null" ],
     "symbol": "%",
     "color": "light_green_white",
-    "coverage": 0,
-    "encumbrance": 0,
     "power_armor": true,
     "material_thickness": 1,
     "relic_data": {
@@ -536,6 +519,7 @@
         }
       ]
     },
-    "flags": [ "NO_TAKEOFF", "ONLY_ONE", "POWERARMOR_COMPATIBLE" ]
+    "flags": [ "NO_TAKEOFF", "ONLY_ONE", "POWERARMOR_COMPATIBLE" ],
+    "armor": { "coverage": 0, "encumbrance": 0 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Secronom/Modification_Files/Items/secro_power_armor_creation.json
+++ b/data/Unleash_The_Mods/Working_mods/Secronom/Modification_Files/Items/secro_power_armor_creation.json
@@ -12,8 +12,6 @@
     "material": [ "flesh" ],
     "symbol": "%",
     "color": "light_red",
-    "coverage": 0,
-    "encumbrance": 0,
     "power_armor": true,
     "material_thickness": 1,
     "use_action": {
@@ -23,7 +21,8 @@
       "need_worn": true,
       "level": 0
     },
-    "flags": [ "NO_TAKEOFF", "POWERARMOR_COMPATIBLE" ]
+    "flags": [ "NO_TAKEOFF", "POWERARMOR_COMPATIBLE" ],
+    "armor": { "coverage": 0, "encumbrance": 0 }
   },
   {
     "id": "secro_power_armor_flesh_created_fite_bspear",
@@ -57,8 +56,6 @@
     "material": [ "flesh" ],
     "symbol": "%",
     "color": "light_red",
-    "coverage": 0,
-    "encumbrance": 0,
     "power_armor": true,
     "material_thickness": 1,
     "use_action": {
@@ -68,7 +65,8 @@
       "need_worn": true,
       "level": 0
     },
-    "flags": [ "NO_TAKEOFF", "POWERARMOR_COMPATIBLE" ]
+    "flags": [ "NO_TAKEOFF", "POWERARMOR_COMPATIBLE" ],
+    "armor": { "coverage": 0, "encumbrance": 0 }
   },
   {
     "id": "secro_power_armor_flesh_created_gun_bonerifle",
@@ -114,8 +112,6 @@
     "material": [ "flesh" ],
     "symbol": "%",
     "color": "light_red",
-    "coverage": 0,
-    "encumbrance": 0,
     "power_armor": true,
     "material_thickness": 1,
     "use_action": {
@@ -125,7 +121,8 @@
       "need_worn": true,
       "level": 0
     },
-    "flags": [ "NO_TAKEOFF", "POWERARMOR_COMPATIBLE" ]
+    "flags": [ "NO_TAKEOFF", "POWERARMOR_COMPATIBLE" ],
+    "armor": { "coverage": 0, "encumbrance": 0 }
   },
   {
     "id": "secro_power_armor_flesh_created_jugg_bpick",

--- a/data/Unleash_The_Mods/Working_mods/Secronom/Modification_Files/Items/secro_power_armor_modules.json
+++ b/data/Unleash_The_Mods/Working_mods/Secronom/Modification_Files/Items/secro_power_armor_modules.json
@@ -15,8 +15,6 @@
     "symbol": "[",
     "looks_like": "power_armor_frame",
     "color": "red",
-    "coverage": 10,
-    "encumbrance": 10,
     "power_armor": true,
     "material_thickness": 1,
     "use_action": {
@@ -28,7 +26,8 @@
     },
     "ammo": [ "battery" ],
     "max_charges": 500,
-    "flags": [ "WATERPROOF", "OUTER", "STURDY", "ELECTRIC_IMMUNE", "POWERARMOR_COMPATIBLE" ]
+    "flags": [ "WATERPROOF", "OUTER", "STURDY", "ELECTRIC_IMMUNE", "POWERARMOR_COMPATIBLE" ],
+    "armor": { "coverage": 10, "encumbrance": 10 }
   },
   {
     "id": "secro_power_armor_module_core_act",
@@ -46,8 +45,6 @@
     "symbol": "[",
     "looks_like": "power_armor_frame",
     "color": "red",
-    "coverage": 10,
-    "encumbrance": 10,
     "power_armor": true,
     "material_thickness": 1,
     "use_action": {
@@ -58,7 +55,8 @@
     },
     "ammo": [ "battery" ],
     "max_charges": 500,
-    "flags": [ "WATERPROOF", "OUTER", "STURDY", "ELECTRIC_IMMUNE", "POWERARMOR_COMPATIBLE" ]
+    "flags": [ "WATERPROOF", "OUTER", "STURDY", "ELECTRIC_IMMUNE", "POWERARMOR_COMPATIBLE" ],
+    "armor": { "coverage": 10, "encumbrance": 10 }
   },
   {
     "id": "secro_power_armor_module_vessel",
@@ -76,8 +74,6 @@
     "symbol": "[",
     "looks_like": "power_armor_frame",
     "color": "red",
-    "coverage": 10,
-    "encumbrance": 10,
     "power_armor": true,
     "material_thickness": 1,
     "charges_per_use": 1,
@@ -90,7 +86,8 @@
     },
     "ammo": [ "battery" ],
     "max_charges": 500,
-    "flags": [ "WATERPROOF", "OUTER", "STURDY", "ELECTRIC_IMMUNE", "POWERARMOR_COMPATIBLE" ]
+    "flags": [ "WATERPROOF", "OUTER", "STURDY", "ELECTRIC_IMMUNE", "POWERARMOR_COMPATIBLE" ],
+    "armor": { "coverage": 10, "encumbrance": 10 }
   },
   {
     "id": "secro_power_armor_module_vessel_act",
@@ -108,8 +105,6 @@
     "symbol": "[",
     "looks_like": "power_armor_frame",
     "color": "red_white",
-    "coverage": 10,
-    "encumbrance": 10,
     "power_armor": true,
     "turns_per_charge": 1,
     "material_thickness": 1,
@@ -134,7 +129,8 @@
     },
     "ammo": [ "battery" ],
     "max_charges": 500,
-    "flags": [ "WATERPROOF", "OUTER", "STURDY", "ELECTRIC_IMMUNE", "NO_UNLOAD", "NO_TAKEOFF", "RECHARGE", "POWERARMOR_COMPATIBLE" ]
+    "flags": [ "WATERPROOF", "OUTER", "STURDY", "ELECTRIC_IMMUNE", "NO_UNLOAD", "NO_TAKEOFF", "RECHARGE", "POWERARMOR_COMPATIBLE" ],
+    "armor": { "coverage": 10, "encumbrance": 10 }
   },
   {
     "id": "secro_power_armor_module_electric",
@@ -152,8 +148,6 @@
     "symbol": "[",
     "looks_like": "power_armor_frame",
     "color": "cyan",
-    "coverage": 10,
-    "encumbrance": 10,
     "power_armor": true,
     "material_thickness": 1,
     "charges_per_use": 1,
@@ -166,7 +160,8 @@
     },
     "ammo": [ "battery" ],
     "max_charges": 500,
-    "flags": [ "WATERPROOF", "OUTER", "STURDY", "ELECTRIC_IMMUNE", "POWERARMOR_COMPATIBLE" ]
+    "flags": [ "WATERPROOF", "OUTER", "STURDY", "ELECTRIC_IMMUNE", "POWERARMOR_COMPATIBLE" ],
+    "armor": { "coverage": 10, "encumbrance": 10 }
   },
   {
     "id": "secro_power_armor_module_electric_act",
@@ -184,8 +179,6 @@
     "symbol": "[",
     "looks_like": "power_armor_frame",
     "color": "cyan_white",
-    "coverage": 10,
-    "encumbrance": 10,
     "power_armor": true,
     "turns_per_charge": 1,
     "material_thickness": 1,
@@ -223,7 +216,8 @@
     },
     "ammo": [ "battery" ],
     "max_charges": 500,
-    "flags": [ "WATERPROOF", "OUTER", "STURDY", "ELECTRIC_IMMUNE", "NO_UNLOAD", "NO_TAKEOFF", "RECHARGE", "POWERARMOR_COMPATIBLE" ]
+    "flags": [ "WATERPROOF", "OUTER", "STURDY", "ELECTRIC_IMMUNE", "NO_UNLOAD", "NO_TAKEOFF", "RECHARGE", "POWERARMOR_COMPATIBLE" ],
+    "armor": { "coverage": 10, "encumbrance": 10 }
   },
   {
     "id": "secro_power_armor_module_pulsar",
@@ -241,8 +235,6 @@
     "symbol": "[",
     "looks_like": "power_armor_frame",
     "color": "dark_gray",
-    "coverage": 10,
-    "encumbrance": 10,
     "power_armor": true,
     "material_thickness": 1,
     "charges_per_use": 1,
@@ -255,7 +247,8 @@
     },
     "ammo": [ "battery" ],
     "max_charges": 500,
-    "flags": [ "WATERPROOF", "OUTER", "STURDY", "ELECTRIC_IMMUNE", "POWERARMOR_COMPATIBLE" ]
+    "flags": [ "WATERPROOF", "OUTER", "STURDY", "ELECTRIC_IMMUNE", "POWERARMOR_COMPATIBLE" ],
+    "armor": { "coverage": 10, "encumbrance": 10 }
   },
   {
     "id": "secro_power_armor_module_pulsar_act",
@@ -273,8 +266,6 @@
     "symbol": "[",
     "looks_like": "power_armor_frame",
     "color": "dark_gray_white",
-    "coverage": 10,
-    "encumbrance": 10,
     "power_armor": true,
     "turns_per_charge": 1,
     "material_thickness": 1,
@@ -305,7 +296,8 @@
     },
     "ammo": [ "battery" ],
     "max_charges": 500,
-    "flags": [ "WATERPROOF", "OUTER", "STURDY", "ELECTRIC_IMMUNE", "NO_UNLOAD", "NO_TAKEOFF", "RECHARGE", "POWERARMOR_COMPATIBLE" ]
+    "flags": [ "WATERPROOF", "OUTER", "STURDY", "ELECTRIC_IMMUNE", "NO_UNLOAD", "NO_TAKEOFF", "RECHARGE", "POWERARMOR_COMPATIBLE" ],
+    "armor": { "coverage": 10, "encumbrance": 10 }
   },
   {
     "id": "secro_power_armor_module_optics",
@@ -323,8 +315,6 @@
     "symbol": "[",
     "looks_like": "power_armor_frame",
     "color": "dark_gray",
-    "coverage": 10,
-    "encumbrance": 10,
     "power_armor": true,
     "material_thickness": 1,
     "charges_per_use": 1,
@@ -337,7 +327,8 @@
     },
     "ammo": [ "battery" ],
     "max_charges": 500,
-    "flags": [ "WATERPROOF", "OUTER", "STURDY", "ELECTRIC_IMMUNE", "POWERARMOR_COMPATIBLE" ]
+    "flags": [ "WATERPROOF", "OUTER", "STURDY", "ELECTRIC_IMMUNE", "POWERARMOR_COMPATIBLE" ],
+    "armor": { "coverage": 10, "encumbrance": 10 }
   },
   {
     "id": "secro_power_armor_module_optics_act",
@@ -355,8 +346,6 @@
     "symbol": "[",
     "looks_like": "power_armor_frame",
     "color": "dark_gray_white",
-    "coverage": 10,
-    "encumbrance": 10,
     "power_armor": true,
     "turns_per_charge": 1,
     "material_thickness": 1,
@@ -379,6 +368,7 @@
     },
     "ammo": [ "battery" ],
     "max_charges": 500,
-    "flags": [ "WATERPROOF", "OUTER", "STURDY", "ELECTRIC_IMMUNE", "NO_UNLOAD", "NO_TAKEOFF", "RECHARGE", "POWERARMOR_COMPATIBLE" ]
+    "flags": [ "WATERPROOF", "OUTER", "STURDY", "ELECTRIC_IMMUNE", "NO_UNLOAD", "NO_TAKEOFF", "RECHARGE", "POWERARMOR_COMPATIBLE" ],
+    "armor": { "coverage": 10, "encumbrance": 10 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Secronom/Modification_Files/Items/secro_power_armors.json
+++ b/data/Unleash_The_Mods/Working_mods/Secronom/Modification_Files/Items/secro_power_armors.json
@@ -15,9 +15,6 @@
     "symbol": "[",
     "looks_like": "power_armor_light",
     "color": "light_red",
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r", "head", "eyes", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 40,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "4 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "4 kg", "moves": 75 }
@@ -49,7 +46,12 @@
         }
       ]
     },
-    "flags": [ "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE", "NO_UNLOAD", "WATCH", "THERMOMETER", "SUN_GLASSES", "OVERSIZE" ]
+    "flags": [ "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE", "NO_UNLOAD", "WATCH", "THERMOMETER", "SUN_GLASSES", "OVERSIZE" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r", "head", "eyes", "mouth" ],
+      "encumbrance": 40
+    }
   },
   {
     "id": "secro_power_armor_atk_on",
@@ -67,9 +69,6 @@
     "symbol": "[",
     "looks_like": "power_armor_light",
     "color": "light_red",
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r", "head", "eyes", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 40,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "4 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "4 kg", "moves": 75 }
@@ -100,7 +99,12 @@
         }
       ]
     },
-    "flags": [ "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE", "NO_UNLOAD", "WATCH", "THERMOMETER", "SUN_GLASSES", "OVERSIZE" ]
+    "flags": [ "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE", "NO_UNLOAD", "WATCH", "THERMOMETER", "SUN_GLASSES", "OVERSIZE" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r", "head", "eyes", "mouth" ],
+      "encumbrance": 40
+    }
   },
   {
     "id": "secro_power_armor_flesh",
@@ -118,9 +122,6 @@
     "symbol": "[",
     "looks_like": "power_armor_light",
     "color": "light_red",
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r", "head", "eyes", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 50,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "5 L", "max_contains_weight": "10 kg", "moves": 85 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "5 L", "max_contains_weight": "10 kg", "moves": 85 },
@@ -153,7 +154,12 @@
       ]
     },
     "qualities": [ [ "SECRO_FLESH_MORPHING", 1 ], [ "SECRO_FLESH_REFORMING", 1 ] ],
-    "flags": [ "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE", "NO_UNLOAD", "SUN_GLASSES", "OVERSIZE" ]
+    "flags": [ "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE", "NO_UNLOAD", "SUN_GLASSES", "OVERSIZE" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r", "head", "eyes", "mouth" ],
+      "encumbrance": 50
+    }
   },
   {
     "id": "secro_power_armor_flesh_fite",
@@ -171,9 +177,6 @@
     "symbol": "[",
     "looks_like": "power_armor_light",
     "color": "light_red_red",
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r", "head", "eyes", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 50,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "5 L", "max_contains_weight": "10 kg", "moves": 85 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "5 L", "max_contains_weight": "10 kg", "moves": 85 },
@@ -207,7 +210,12 @@
       ]
     },
     "qualities": [ [ "SECRO_FLESH_MORPHING", 1 ], [ "SECRO_FLESH_REFORMING", 1 ] ],
-    "flags": [ "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE", "NO_UNLOAD", "SUN_GLASSES", "OVERSIZE" ]
+    "flags": [ "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE", "NO_UNLOAD", "SUN_GLASSES", "OVERSIZE" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r", "head", "eyes", "mouth" ],
+      "encumbrance": 50
+    }
   },
   {
     "id": "secro_power_armor_flesh_tank",
@@ -225,9 +233,6 @@
     "symbol": "[",
     "looks_like": "power_armor_light",
     "color": "light_red_yellow",
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r", "head", "eyes", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 60,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "5 L", "max_contains_weight": "10 kg", "moves": 85 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "5 L", "max_contains_weight": "10 kg", "moves": 85 },
@@ -262,7 +267,12 @@
       ]
     },
     "qualities": [ [ "SECRO_FLESH_MORPHING", 1 ], [ "SECRO_FLESH_REFORMING", 1 ] ],
-    "flags": [ "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE", "NO_UNLOAD", "SUN_GLASSES", "OVERSIZE" ]
+    "flags": [ "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE", "NO_UNLOAD", "SUN_GLASSES", "OVERSIZE" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r", "head", "eyes", "mouth" ],
+      "encumbrance": 60
+    }
   },
   {
     "id": "secro_power_armor_flesh_coward",
@@ -280,9 +290,6 @@
     "symbol": "[",
     "looks_like": "power_armor_light",
     "color": "light_red_green",
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r", "head", "eyes", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 40,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "5 L", "max_contains_weight": "10 kg", "moves": 85 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "5 L", "max_contains_weight": "10 kg", "moves": 85 },
@@ -317,7 +324,12 @@
       ]
     },
     "qualities": [ [ "SECRO_FLESH_MORPHING", 1 ], [ "SECRO_FLESH_REFORMING", 1 ] ],
-    "flags": [ "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE", "NO_UNLOAD", "SUN_GLASSES", "OVERSIZE" ]
+    "flags": [ "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE", "NO_UNLOAD", "SUN_GLASSES", "OVERSIZE" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r", "head", "eyes", "mouth" ],
+      "encumbrance": 40
+    }
   },
   {
     "id": "secro_power_armor_flesh_range",
@@ -335,9 +347,6 @@
     "symbol": "[",
     "looks_like": "power_armor_light",
     "color": "light_red_cyan",
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r", "head", "eyes", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 45,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "5 L", "max_contains_weight": "10 kg", "moves": 85 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "5 L", "max_contains_weight": "10 kg", "moves": 85 },
@@ -370,7 +379,12 @@
       ]
     },
     "qualities": [ [ "SECRO_FLESH_MORPHING", 1 ], [ "SECRO_FLESH_REFORMING", 1 ] ],
-    "flags": [ "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE", "NO_UNLOAD", "SUN_GLASSES", "OVERSIZE" ]
+    "flags": [ "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE", "NO_UNLOAD", "SUN_GLASSES", "OVERSIZE" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r", "head", "eyes", "mouth" ],
+      "encumbrance": 45
+    }
   },
   {
     "id": "secro_power_armor_flesh_infect",
@@ -388,9 +402,6 @@
     "symbol": "[",
     "looks_like": "power_armor_light",
     "color": "light_red_white",
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r", "head", "eyes", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 50,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "5 L", "max_contains_weight": "10 kg", "moves": 85 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "5 L", "max_contains_weight": "10 kg", "moves": 85 },
@@ -441,7 +452,12 @@
       ]
     },
     "qualities": [ [ "SECRO_FLESH_MORPHING", 2 ], [ "SECRO_FLESH_REFORMING", 2 ] ],
-    "flags": [ "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE", "NO_UNLOAD", "SUN_GLASSES", "OVERSIZE" ]
+    "flags": [ "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE", "NO_UNLOAD", "SUN_GLASSES", "OVERSIZE" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r", "head", "eyes", "mouth" ],
+      "encumbrance": 50
+    }
   },
   {
     "id": "secro_power_armor_feed_item",
@@ -456,11 +472,10 @@
     "material": [ "flesh" ],
     "symbol": "%",
     "color": "red",
-    "coverage": 0,
-    "encumbrance": 0,
     "power_armor": true,
     "material_thickness": 1,
     "use_action": { "type": "cast_spell", "spell_id": "secro_power_armor_feed", "no_fail": true, "need_worn": true, "level": 0 },
-    "flags": [ "NO_TAKEOFF", "POWERARMOR_COMPATIBLE" ]
+    "flags": [ "NO_TAKEOFF", "POWERARMOR_COMPATIBLE" ],
+    "armor": { "coverage": 0, "encumbrance": 0 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Secronom/Modification_Files/Monsters/+Essentials/secro_monitem.json
+++ b/data/Unleash_The_Mods/Working_mods/Secronom/Modification_Files/Monsters/+Essentials/secro_monitem.json
@@ -13,9 +13,6 @@
     "material": [ "flesh" ],
     "symbol": "⨨",
     "color": "yellow",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 40,
     "warmth": 0,
     "material_thickness": 1,
     "environmental_protection": 0,
@@ -41,7 +38,8 @@
         }
       ]
     },
-    "flags": [ "PERSONAL", "FRAGILE", "BELTED", "NO_DROP", "NO_TAKEOFF" ]
+    "flags": [ "PERSONAL", "FRAGILE", "BELTED", "NO_DROP", "NO_TAKEOFF" ],
+    "armor": { "coverage": 100, "covers": [ "foot_l", "foot_r" ], "encumbrance": 40 }
   },
   {
     "//": "Eating this vile meat mends your body, even broken limbs! (not head and torso, ofc).",

--- a/data/Unleash_The_Mods/Working_mods/Sierra_Madre_mod/items/armor.json
+++ b/data/Unleash_The_Mods/Working_mods/Sierra_Madre_mod/items/armor.json
@@ -15,9 +15,6 @@
     "symbol": "A",
     "looks_like": "lsurvivor_suit",
     "color": "light_gray",
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 10,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "rigid": true, "max_contains_volume": "6 L", "max_contains_weight": "4 kg", "moves": 100 },
       {
@@ -45,7 +42,12 @@
     "warmth": 20,
     "material_thickness": 4,
     "environmental_protection": 9,
-    "flags": [ "POCKETS", "WATERPROOF", "RAINPROOF", "STURDY", "ELECTRIC_IMMUNE" ]
+    "flags": [ "POCKETS", "WATERPROOF", "RAINPROOF", "STURDY", "ELECTRIC_IMMUNE" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 10
+    }
   },
   {
     "id": "sierra_armor",
@@ -187,12 +189,14 @@
     "symbol": "[",
     "looks_like": "anbc_suit",
     "color": "light_green",
-    "covers": [ "head", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 42,
     "warmth": 45,
     "material_thickness": 6,
     "environmental_protection": 25,
-    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "GAS_PROOF", "RAD_PROOF", "OUTER" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "GAS_PROOF", "RAD_PROOF", "OUTER" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "head", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 42
+    }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Sierra_Madre_mod/items/clothes.json
+++ b/data/Unleash_The_Mods/Working_mods/Sierra_Madre_mod/items/clothes.json
@@ -14,10 +14,6 @@
     "symbol": "[",
     "looks_like": "tux",
     "color": "dark_gray",
-    "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r" ],
-    "coverage": 95,
-    "encumbrance": 13,
-    "max_encumbrance": 17,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "350 ml", "max_contains_weight": "2 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "350 ml", "max_contains_weight": "2 kg", "moves": 80 },
@@ -26,7 +22,8 @@
     ],
     "warmth": 30,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "POCKETS", "SUPER_FANCY" ]
+    "flags": [ "VARSIZE", "POCKETS", "SUPER_FANCY" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r" ], "encumbrance": [ 13, 17 ] }
   },
   {
     "id": "dress_vera",
@@ -42,10 +39,9 @@
     "symbol": "[",
     "looks_like": "dress",
     "color": "black",
-    "covers": [ "torso", "leg_r" ],
-    "coverage": 65,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 65, "covers": [ "torso", "leg_r" ] }
   },
   {
     "id": "suit_sinclair",
@@ -62,10 +58,6 @@
     "symbol": "[",
     "looks_like": "suit",
     "color": "black",
-    "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r" ],
-    "coverage": 95,
-    "encumbrance": 7,
-    "max_encumbrance": 15,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "700 ml", "max_contains_weight": "2 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "700 ml", "max_contains_weight": "2 kg", "moves": 80 },
@@ -78,7 +70,8 @@
     ],
     "warmth": 25,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "FANCY", "POCKETS" ]
+    "flags": [ "VARSIZE", "FANCY", "POCKETS" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r" ], "encumbrance": [ 7, 15 ] }
   },
   {
     "id": "jumpsuit_sierra",
@@ -94,10 +87,6 @@
     "symbol": "[",
     "looks_like": "jumpsuit",
     "color": "light_gray",
-    "covers": [ "leg_l", "leg_r", "arm_l", "arm_r", "torso" ],
-    "coverage": 95,
-    "encumbrance": 1,
-    "max_encumbrance": 2,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "700 ml", "max_contains_weight": "2 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "700 ml", "max_contains_weight": "2 kg", "moves": 80 },
@@ -106,7 +95,8 @@
     ],
     "warmth": 15,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "POCKETS" ]
+    "flags": [ "VARSIZE", "POCKETS" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r", "arm_l", "arm_r", "torso" ], "encumbrance": [ 1, 2 ] }
   },
   {
     "id": "elijah_robe",
@@ -123,9 +113,6 @@
     "symbol": "[",
     "looks_like": "robe",
     "color": "blue",
-    "covers": [ "leg_r", "leg_l", "torso", "arm_l", "arm_r", "head", "hand_l", "hand_r" ],
-    "coverage": 65,
-    "encumbrance": 3,
     "warmth": 50,
     "material_thickness": 4,
     "environmental_protection": 6,
@@ -139,6 +126,11 @@
       { "pocket_type": "CONTAINER", "max_contains_volume": "1200 ml", "max_contains_weight": "4 kg", "moves": 120 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1200 ml", "max_contains_weight": "4 kg", "moves": 120 }
     ],
-    "flags": [ "OVERSIZE", "OUTER", "HELMET_COMPAT", "POCKETS" ]
+    "flags": [ "OVERSIZE", "OUTER", "HELMET_COMPAT", "POCKETS" ],
+    "armor": {
+      "coverage": 65,
+      "covers": [ "leg_r", "leg_l", "torso", "arm_l", "arm_r", "head", "hand_l", "hand_r" ],
+      "encumbrance": 3
+    }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Sierra_Madre_mod/items/misc.json
+++ b/data/Unleash_The_Mods/Working_mods/Sierra_Madre_mod/items/misc.json
@@ -31,10 +31,8 @@
       "menu_text": "Set the collar to explode",
       "type": "transform"
     },
-    "covers": [ "head" ],
-    "coverage": 10,
-    "encumbrance": 10,
-    "flags": [ "RADIO_MODABLE", "RADIO_INVOKE_PROC", "BOMB", "NO_TAKEOFF", "NPC_ACTIVATE" ]
+    "flags": [ "RADIO_MODABLE", "RADIO_INVOKE_PROC", "BOMB", "NO_TAKEOFF", "NPC_ACTIVATE" ],
+    "armor": { "coverage": 10, "covers": [ "head" ], "encumbrance": 10 }
   },
   {
     "id": "collar_armed",
@@ -61,10 +59,8 @@
       "no_deactivate_msg": "The collar is about to explode. While the blast won't be very strong since initially it's been designed to only blow the wearer's head off, it's still strongly encouraged to get away from it.",
       "explosion": { "power": 16, "shrapnel": { "casing_mass": 100, "fragment_mass": 1 } }
     },
-    "covers": [ "head" ],
-    "coverage": 10,
-    "encumbrance": 10,
-    "flags": [ "TRADER_AVOID", "NO_TAKEOFF", "NPC_THROW_NOW" ]
+    "flags": [ "TRADER_AVOID", "NO_TAKEOFF", "NPC_THROW_NOW" ],
+    "armor": { "coverage": 10, "covers": [ "head" ], "encumbrance": 10 }
   },
   {
     "id": "sierra_chip",
@@ -192,9 +188,6 @@
     "to_hit": -1,
     "symbol": "[",
     "color": "blue",
-    "covers": [ "leg_r", "leg_l", "torso", "arm_l", "arm_r", "head", "hand_l", "hand_r", "foot_r", "foot_l" ],
-    "coverage": 65,
-    "encumbrance": 3,
     "relic_data": { "passive_effects": [ { "id": "STAY_THERE" } ] },
     "pocket_data": [
       {
@@ -205,7 +198,12 @@
         "moves": 80
       }
     ],
-    "flags": [ "OVERSIZE", "OUTER", "TARDIS", "STURDY", "NO_TAKEOFF", "TRADER_KEEP", "AURA" ]
+    "flags": [ "OVERSIZE", "OUTER", "TARDIS", "STURDY", "NO_TAKEOFF", "TRADER_KEEP", "AURA" ],
+    "armor": {
+      "coverage": 65,
+      "covers": [ "leg_r", "leg_l", "torso", "arm_l", "arm_r", "head", "hand_l", "hand_r", "foot_r", "foot_l" ],
+      "encumbrance": 3
+    }
   },
   {
     "id": "npc_glue",
@@ -216,8 +214,6 @@
     "volume": "1001 ml",
     "symbol": "~",
     "color": "light_red",
-    "covers": [ "eyes", "mouth" ],
-    "encumbrance": 18,
     "relic_data": { "passive_effects": [ { "id": "STAY_THERE" } ] },
     "pocket_data": [
       {
@@ -228,7 +224,8 @@
         "moves": 80
       }
     ],
-    "flags": [ "NO_TAKEOFF", "TRADER_AVOID", "TRADER_KEEP", "STURDY", "AURA" ]
+    "flags": [ "NO_TAKEOFF", "TRADER_AVOID", "TRADER_KEEP", "STURDY", "AURA" ],
+    "armor": { "covers": [ "eyes", "mouth" ], "encumbrance": 18 }
   },
   {
     "id": "npc_glue2",
@@ -239,8 +236,6 @@
     "volume": "1001 ml",
     "symbol": "~",
     "color": "light_red",
-    "covers": [ "eyes", "mouth" ],
-    "encumbrance": 18,
     "relic_data": { "passive_effects": [ { "id": "STAY_THERE" } ] },
     "pocket_data": [
       {
@@ -251,7 +246,8 @@
         "moves": 80
       }
     ],
-    "flags": [ "NO_TAKEOFF", "TRADER_AVOID", "TRADER_KEEP", "STURDY", "AURA" ]
+    "flags": [ "NO_TAKEOFF", "TRADER_AVOID", "TRADER_KEEP", "STURDY", "AURA" ],
+    "armor": { "covers": [ "eyes", "mouth" ], "encumbrance": 18 }
   },
   {
     "id": "sierra_deck",

--- a/data/Unleash_The_Mods/Working_mods/Survivors_Lost_item/item.json
+++ b/data/Unleash_The_Mods/Working_mods/Survivors_Lost_item/item.json
@@ -6,16 +6,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_normal2",
@@ -24,16 +22,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_normal3",
@@ -42,16 +38,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_normal4",
@@ -60,16 +54,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_normal5",
@@ -78,16 +70,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_army1",
@@ -96,16 +86,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_army2",
@@ -114,16 +102,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_army3",
@@ -132,16 +118,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_army4",
@@ -150,16 +134,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_army5",
@@ -168,16 +150,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_student1",
@@ -186,16 +166,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_student2",
@@ -204,16 +182,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_student3",
@@ -222,16 +198,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_student4",
@@ -240,16 +214,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_student5",
@@ -258,16 +230,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_engineer1",
@@ -276,16 +246,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_engineer2",
@@ -294,16 +262,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_engineer3",
@@ -312,16 +278,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_engineer4",
@@ -330,16 +294,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_engineer5",
@@ -348,16 +310,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_geek1",
@@ -366,16 +326,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_geek2",
@@ -384,16 +342,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_geek3",
@@ -402,16 +358,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_geek4",
@@ -420,16 +374,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_geek5",
@@ -438,16 +390,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_hunter1",
@@ -456,16 +406,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_hunter2",
@@ -474,16 +422,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_hunter3",
@@ -492,16 +438,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_hunter4",
@@ -510,16 +454,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_hunter5",
@@ -528,16 +470,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_in_medicine1",
@@ -546,16 +486,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_in_medicine2",
@@ -564,16 +502,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_in_medicine3",
@@ -582,16 +518,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_in_medicine4",
@@ -600,16 +534,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_in_medicine5",
@@ -618,16 +550,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_smoker1",
@@ -636,16 +566,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_smoker2",
@@ -654,16 +582,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_smoker3",
@@ -672,16 +598,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_smoker4",
@@ -690,16 +614,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_smoker5",
@@ -708,16 +630,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_alcoholism1",
@@ -726,16 +646,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_alcoholism2",
@@ -744,16 +662,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_alcoholism3",
@@ -762,16 +678,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_alcoholism4",
@@ -780,16 +694,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_alcoholism5",
@@ -798,16 +710,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_survivor1",
@@ -816,16 +726,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_survivor2",
@@ -834,16 +742,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_survivor3",
@@ -852,16 +758,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_survivor4",
@@ -870,16 +774,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_survivor5",
@@ -888,16 +790,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_scientist1",
@@ -906,16 +806,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_scientist2",
@@ -924,16 +822,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_scientist3",
@@ -942,16 +838,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_scientist4",
@@ -960,16 +854,14 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "survivor_lost_bag_scientist5",
@@ -978,15 +870,13 @@
     "weight": "10000 g",
     "color": "green",
     "material": [ "cotton", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 25,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 3,
     "symbol": "[",
     "description": "It is a bag that someone had dropped. You can get the items that are included by disassembling.",
     "price": "16 USD",
     "volume": "17500 ml",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "armor": { "coverage": 25, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/TCW_Box/json/armor.json
+++ b/data/Unleash_The_Mods/Working_mods/TCW_Box/json/armor.json
@@ -12,9 +12,6 @@
     "material": [ "paper" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r", "mouth" ],
-    "coverage": 98,
-    "encumbrance": 50,
     "warmth": 5,
     "material_thickness": 1,
     "flags": [ "BELTED" ],
@@ -26,6 +23,11 @@
           "mutations": [ "AEP_INVISIBLE", "AEP_INT_DOWN", "AEP_PER_DOWN", "AEP_DEX_DOWN", "AEP_SPEED_DOWN" ]
         }
       ]
+    },
+    "armor": {
+      "coverage": 98,
+      "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r", "mouth" ],
+      "encumbrance": 50
     }
   },
   {
@@ -54,12 +56,10 @@
     "material": [ "paper" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "head", "mouth" ],
-    "coverage": 98,
-    "encumbrance": 7,
     "warmth": 5,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "HELMET_COMPAT" ]
+    "flags": [ "VARSIZE", "HELMET_COMPAT" ],
+    "armor": { "coverage": 98, "covers": [ "head", "mouth" ], "encumbrance": 7 }
   },
   {
     "result": "SB_L_paper",

--- a/data/Unleash_The_Mods/Working_mods/Thermal_ups/tups_tool_armor.json
+++ b/data/Unleash_The_Mods/Working_mods/Thermal_ups/tups_tool_armor.json
@@ -13,11 +13,10 @@
     "weight": "864 g",
     "volume": "2 L",
     "use_action": { "type": "transform", "msg": "The %s engages.", "target": "thermal_suit_ups_on", "active": true },
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
     "flags": [ "VARSIZE", "SKINTIGHT" ],
     "warmth": 10,
-    "coverage": 100,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 100, "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ] }
   },
   {
     "id": "thermal_suit_ups_on",
@@ -46,10 +45,9 @@
     "volume": "4500 ml",
     "ammo": "battery",
     "use_action": { "type": "transform", "msg": "You activate your %s.", "target": "thermal_outfit_ups_on", "active": true },
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
     "warmth": 10,
-    "coverage": 100,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 100, "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ] }
   },
   {
     "id": "thermal_outfit_ups_on",

--- a/data/Unleash_The_Mods/Working_mods/Throwing/thrownarmor.json
+++ b/data/Unleash_The_Mods/Working_mods/Throwing/thrownarmor.json
@@ -11,9 +11,6 @@
     "symbol": "[",
     "looks_like": "armguards_hard",
     "color": "brown",
-    "covers": [ "arm_l", "arm_r" ],
-    "coverage": 20,
-    "encumbrance": 3,
     "material_thickness": 2,
     "use_action": { "type": "holster", "holster_prompt": "Sheath blade", "holster_msg": "You sheath your %s" },
     "pocket_data": [
@@ -34,7 +31,8 @@
         "flag_restriction": [ "SHEATH_KNIFE", "BELT_CLIP" ]
       }
     ],
-    "flags": [ "VARSIZE", "BELTED", "STURDY", "OUTER", "WATER_FRIENDLY", "BELT_CLIP", "SHEATH_KNIFE" ]
+    "flags": [ "VARSIZE", "BELTED", "STURDY", "OUTER", "WATER_FRIENDLY", "BELT_CLIP", "SHEATH_KNIFE" ],
+    "armor": { "coverage": 20, "covers": [ "arm_l", "arm_r" ], "encumbrance": 3 }
   },
   {
     "id": "knife_bandolier_wrist_strap",
@@ -48,9 +46,6 @@
     "symbol": "[",
     "looks_like": "belt",
     "color": "brown",
-    "covers": [ "hand_l", "hand_r" ],
-    "coverage": 5,
-    "encumbrance": 8,
     "material_thickness": 1,
     "use_action": { "type": "holster", "holster_prompt": "Sheath blade", "holster_msg": "You sheath your %s" },
     "pocket_data": [
@@ -71,7 +66,8 @@
         "flag_restriction": [ "SHEATH_KNIFE", "BELT_CLIP" ]
       }
     ],
-    "flags": [ "VARSIZE", "BELTED", "STURDY", "OUTER", "WATER_FRIENDLY", "BELT_CLIP", "SHEATH_KNIFE" ]
+    "flags": [ "VARSIZE", "BELTED", "STURDY", "OUTER", "WATER_FRIENDLY", "BELT_CLIP", "SHEATH_KNIFE" ],
+    "armor": { "coverage": 5, "covers": [ "hand_l", "hand_r" ], "encumbrance": 8 }
   },
   {
     "id": "chest_knife_bandolier",
@@ -85,9 +81,6 @@
     "symbol": "[",
     "looks_like": "belt",
     "color": "brown",
-    "covers": [ "torso" ],
-    "coverage": 15,
-    "encumbrance": 2,
     "material_thickness": 1,
     "use_action": { "type": "holster", "holster_prompt": "Sheath blade", "holster_msg": "You sheath your %s" },
     "pocket_data": [
@@ -156,7 +149,8 @@
         "flag_restriction": [ "SHEATH_KNIFE", "BELT_CLIP" ]
       }
     ],
-    "flags": [ "VARSIZE", "BELTED", "STURDY", "OUTER", "WATER_FRIENDLY", "BELT_CLIP", "SHEATH_KNIFE" ]
+    "flags": [ "VARSIZE", "BELTED", "STURDY", "OUTER", "WATER_FRIENDLY", "BELT_CLIP", "SHEATH_KNIFE" ],
+    "armor": { "coverage": 15, "covers": [ "torso" ], "encumbrance": 2 }
   },
   {
     "id": "leg_knife_bandolier",
@@ -170,9 +164,6 @@
     "symbol": "[",
     "looks_like": "belt",
     "color": "brown",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 5,
-    "encumbrance": 2,
     "material_thickness": 1,
     "use_action": { "type": "holster", "holster_prompt": "Sheath blade", "holster_msg": "You sheath your %s" },
     "pocket_data": [
@@ -209,7 +200,8 @@
         "flag_restriction": [ "SHEATH_KNIFE", "BELT_CLIP" ]
       }
     ],
-    "flags": [ "VARSIZE", "BELTED", "STURDY", "OUTER", "WATER_FRIENDLY", "BELT_CLIP", "SHEATH_KNIFE" ]
+    "flags": [ "VARSIZE", "BELTED", "STURDY", "OUTER", "WATER_FRIENDLY", "BELT_CLIP", "SHEATH_KNIFE" ],
+    "armor": { "coverage": 5, "covers": [ "leg_l", "leg_r" ], "encumbrance": 2 }
   },
   {
     "id": "leather_belt_loop",
@@ -223,8 +215,6 @@
     "material": [ "leather" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso" ],
-    "coverage": 5,
     "material_thickness": 1,
     "use_action": { "type": "holster", "holster_prompt": "Holster item", "holster_msg": "You put your %s into your %s" },
     "pocket_data": [
@@ -261,6 +251,7 @@
         "flag_restriction": [ "SHEATH_KNIFE", "SHEATH_SWORD", "BELT_CLIP" ]
       }
     ],
-    "flags": [ "WAIST", "WATER_FRIENDLY", "BELT_CLIP", "SHEATH_KNIFE", "SHEATH_SWORD" ]
+    "flags": [ "WAIST", "WATER_FRIENDLY", "BELT_CLIP", "SHEATH_KNIFE", "SHEATH_SWORD" ],
+    "armor": { "coverage": 5, "covers": [ "torso" ] }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Vermilion_Mod/items/armor.json
+++ b/data/Unleash_The_Mods/Working_mods/Vermilion_Mod/items/armor.json
@@ -11,13 +11,15 @@
     "material": [ "kevlar", "nomex" ],
     "symbol": "[",
     "color": "green",
-    "covers": [ "head", "mouth", "eyes", "torso", "arm_l", "arm_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 55,
     "warmth": 55,
     "material_thickness": 6,
     "environmental_protection": 20,
-    "flags": [ "WATERPROOF", "RAINPROOF", "STURDY", "GAS_PROOF", "OUTER" ]
+    "flags": [ "WATERPROOF", "RAINPROOF", "STURDY", "GAS_PROOF", "OUTER" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "head", "mouth", "eyes", "torso", "arm_l", "arm_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 55
+    }
   },
   {
     "id": "skimpy_swimsuit",
@@ -32,13 +34,11 @@
     "material": [ "cotton" ],
     "symbol": "&",
     "color": "light_blue",
-    "covers": [ "torso" ],
-    "coverage": 0,
-    "encumbrance": 0,
     "warmth": 0,
     "material_thickness": 0,
     "environmental_protection": 0,
-    "flags": [ "VARSIZE", "WATER_FRIENDLY", "SKINTIGHT", "SUPER_FANCY", "OVERSIZE" ]
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "SKINTIGHT", "SUPER_FANCY", "OVERSIZE" ],
+    "armor": { "coverage": 0, "covers": [ "torso" ], "encumbrance": 0 }
   },
   {
     "id": "ofuda_top",
@@ -53,13 +53,11 @@
     "material": [ "paper" ],
     "symbol": "&",
     "color": "white",
-    "covers": [ "torso" ],
-    "coverage": 0,
-    "encumbrance": 0,
     "warmth": 0,
     "material_thickness": 0,
     "environmental_protection": 0,
-    "flags": [ "SKINTIGHT", "SUPER_FANCY", "OVERSIZE", "ZERO_WEIGHT" ]
+    "flags": [ "SKINTIGHT", "SUPER_FANCY", "OVERSIZE", "ZERO_WEIGHT" ],
+    "armor": { "coverage": 0, "covers": [ "torso" ], "encumbrance": 0 }
   },
   {
     "id": "ofuda_bottom",
@@ -74,13 +72,11 @@
     "material": [ "paper" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 0,
-    "encumbrance": 0,
     "warmth": 0,
     "material_thickness": 0,
     "environmental_protection": 0,
-    "flags": [ "SKINTIGHT", "SUPER_FANCY", "OVERSIZE", "ZERO_WEIGHT" ]
+    "flags": [ "SKINTIGHT", "SUPER_FANCY", "OVERSIZE", "ZERO_WEIGHT" ],
+    "armor": { "coverage": 0, "covers": [ "leg_l", "leg_r" ], "encumbrance": 0 }
   },
   {
     "id": "pb_eyepatch",
@@ -95,14 +91,12 @@
     "material": [ "neoprene" ],
     "symbol": "[",
     "color": "black",
-    "covers": [ "eyes" ],
-    "coverage": 5,
-    "encumbrance": 8,
     "warmth": 2,
     "material_thickness": 1,
     "environmental_protection": 1,
     "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "PERCEPTION", "add": 2 } ] } ] },
-    "flags": [ "WATER_FRIENDLY", "SKINTIGHT", "OVERSIZE", "FIX_FARSIGHT", "FIX_NEARSIGHT" ]
+    "flags": [ "WATER_FRIENDLY", "SKINTIGHT", "OVERSIZE", "FIX_FARSIGHT", "FIX_NEARSIGHT" ],
+    "armor": { "coverage": 5, "covers": [ "eyes" ], "encumbrance": 8 }
   },
   {
     "id": "pb_armband_staff",
@@ -117,13 +111,11 @@
     "material": [ "plastic" ],
     "symbol": "[",
     "color": "light_green",
-    "covers": [ "arm_l", "arm_r" ],
-    "coverage": 0,
-    "encumbrance": 0,
     "warmth": 0,
     "material_thickness": 1,
     "environmental_protection": 0,
-    "flags": [ "OVERSIZE", "OUTER" ]
+    "flags": [ "OVERSIZE", "OUTER" ],
+    "armor": { "coverage": 0, "covers": [ "arm_l", "arm_r" ], "encumbrance": 0 }
   },
   {
     "id": "pb_armband_medical",
@@ -138,13 +130,11 @@
     "material": [ "plastic" ],
     "symbol": "[",
     "color": "red",
-    "covers": [ "arm_l", "arm_r" ],
-    "coverage": 0,
-    "encumbrance": 0,
     "warmth": 0,
     "material_thickness": 1,
     "environmental_protection": 0,
-    "flags": [ "OVERSIZE", "OUTER" ]
+    "flags": [ "OVERSIZE", "OUTER" ],
+    "armor": { "coverage": 0, "covers": [ "arm_l", "arm_r" ], "encumbrance": 0 }
   },
   {
     "id": "pb_armband_security",
@@ -159,13 +149,11 @@
     "material": [ "plastic" ],
     "symbol": "[",
     "color": "yellow",
-    "covers": [ "arm_l", "arm_r" ],
-    "coverage": 0,
-    "encumbrance": 0,
     "warmth": 0,
     "material_thickness": 1,
     "environmental_protection": 0,
-    "flags": [ "OVERSIZE", "OUTER" ]
+    "flags": [ "OVERSIZE", "OUTER" ],
+    "armor": { "coverage": 0, "covers": [ "arm_l", "arm_r" ], "encumbrance": 0 }
   },
   {
     "id": "pb_armband_science",
@@ -180,13 +168,11 @@
     "material": [ "plastic" ],
     "symbol": "[",
     "color": "light_blue",
-    "covers": [ "arm_l", "arm_r" ],
-    "coverage": 0,
-    "encumbrance": 0,
     "warmth": 0,
     "material_thickness": 1,
     "environmental_protection": 0,
-    "flags": [ "OVERSIZE", "OUTER" ]
+    "flags": [ "OVERSIZE", "OUTER" ],
+    "armor": { "coverage": 0, "covers": [ "arm_l", "arm_r" ], "encumbrance": 0 }
   },
   {
     "id": "pb_security_armor",
@@ -200,13 +186,11 @@
     "material": [ "neoprene", "superalloy" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 25,
     "warmth": 20,
     "material_thickness": 2,
     "environmental_protection": 6,
-    "flags": [ "WATERPROOF", "RAINPROOF", "STURDY", "OVERSIZE" ]
+    "flags": [ "WATERPROOF", "RAINPROOF", "STURDY", "OVERSIZE" ],
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 25 }
   },
   {
     "id": "pb_security_helmet",
@@ -222,13 +206,11 @@
     "material": [ "plastic", "glass" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "head", "mouth", "eyes" ],
-    "coverage": 100,
-    "encumbrance": 20,
     "warmth": 15,
     "material_thickness": 2,
     "environmental_protection": 6,
-    "flags": [ "WATERPROOF", "RAINPROOF", "STURDY", "OVERSIZE", "GAS_PROOF", "SUN_GLASSES", "FLASH_PROTECTION" ]
+    "flags": [ "WATERPROOF", "RAINPROOF", "STURDY", "OVERSIZE", "GAS_PROOF", "SUN_GLASSES", "FLASH_PROTECTION" ],
+    "armor": { "coverage": 100, "covers": [ "head", "mouth", "eyes" ], "encumbrance": 20 }
   },
   {
     "id": "pb_traitor_suit",
@@ -242,9 +224,6 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "torso" ],
-    "coverage": 65,
-    "encumbrance": 15,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "750 ml", "max_contains_weight": "1500 g", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "750 ml", "max_contains_weight": "1500 g", "moves": 75 },
@@ -254,7 +233,8 @@
     "warmth": 5,
     "material_thickness": 1,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "OVERSIZE" ]
+    "flags": [ "VARSIZE", "OVERSIZE" ],
+    "armor": { "coverage": 65, "covers": [ "torso" ], "encumbrance": 15 }
   },
   {
     "id": "pb_traitor_boots",
@@ -270,13 +250,11 @@
     "material": [ "kevlar", "leather", "steel" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 20,
     "warmth": 25,
     "material_thickness": 4,
     "environmental_protection": 3,
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY", "OVERSIZE" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY", "OVERSIZE" ],
+    "armor": { "coverage": 100, "covers": [ "foot_l", "foot_r" ], "encumbrance": 20 }
   },
   {
     "id": "pb_traitor_pants",
@@ -289,9 +267,6 @@
     "material": [ "cotton", "kevlar" ],
     "symbol": "[",
     "color": "green",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 13,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "5 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "5 kg", "moves": 75 }
@@ -299,6 +274,7 @@
     "warmth": 20,
     "material_thickness": 3,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "POCKETS", "STURDY", "OVERSIZE" ]
+    "flags": [ "VARSIZE", "POCKETS", "STURDY", "OVERSIZE" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r" ], "encumbrance": 13 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Warhammer_40K/armor.json
+++ b/data/Unleash_The_Mods/Working_mods/Warhammer_40K/armor.json
@@ -13,14 +13,12 @@
     "material": [ "leather", "steel" ],
     "symbol": "[",
     "color": "green",
-    "covers": [ "head" ],
-    "coverage": 85,
-    "encumbrance": 18,
     "warmth": 18,
     "material_thickness": 8,
     "environmental_protection": 1,
     "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "2 kg", "moves": 30 } ],
-    "flags": [ "VARSIZE", "POCKETS", "STURDY", "WATER_FRIENDLY", "OUTER", "STURDY" ]
+    "flags": [ "VARSIZE", "POCKETS", "STURDY", "WATER_FRIENDLY", "OUTER", "STURDY" ],
+    "armor": { "coverage": 85, "covers": [ "head" ], "encumbrance": 18 }
   },
   {
     "id": "flack_armor",
@@ -36,14 +34,12 @@
     "material": [ "leather", "iron", "steel" ],
     "symbol": "[",
     "color": "green",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 85,
-    "encumbrance": 18,
     "warmth": 18,
     "material_thickness": 10,
     "environmental_protection": 1,
     "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "2 kg", "moves": 30 } ],
-    "flags": [ "VARSIZE", "POCKETS", "STURDY", "WATER_FRIENDLY", "BELTED", "OUTER", "STURDY" ]
+    "flags": [ "VARSIZE", "POCKETS", "STURDY", "WATER_FRIENDLY", "BELTED", "OUTER", "STURDY" ],
+    "armor": { "coverage": 85, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 18 }
   },
   {
     "id": "ig_elbow_pads",
@@ -58,10 +54,9 @@
     "material": [ "steel", "cotton", "kevlar" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "hand_l", "hand_r" ],
-    "coverage": 30,
     "material_thickness": 8,
-    "flags": [ "WATER_FRIENDLY", "BELTED", "STURDY", "VARSIZE" ]
+    "flags": [ "WATER_FRIENDLY", "BELTED", "STURDY", "VARSIZE" ],
+    "armor": { "coverage": 30, "covers": [ "hand_l", "hand_r" ] }
   },
   {
     "id": "ig_leg_pads",
@@ -76,9 +71,8 @@
     "material": [ "steel", "cotton", "kevlar" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 40,
     "material_thickness": 8,
-    "flags": [ "WATER_FRIENDLY", "BELTED", "STURDY", "VARSIZE" ]
+    "flags": [ "WATER_FRIENDLY", "BELTED", "STURDY", "VARSIZE" ],
+    "armor": { "coverage": 40, "covers": [ "leg_l", "leg_r" ] }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Warhammer_40K/clothing.json
+++ b/data/Unleash_The_Mods/Working_mods/Warhammer_40K/clothing.json
@@ -10,10 +10,9 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "green",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 90,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "WATER_FRIENDLY", "SKINTIGHT" ]
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "SKINTIGHT" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ] }
   },
   {
     "id": "comm_hat",
@@ -29,13 +28,11 @@
     "material": [ "leather", "gold" ],
     "symbol": "^",
     "color": "light_gray",
-    "covers": [ "head" ],
-    "coverage": 50,
-    "encumbrance": 4,
     "warmth": 6,
     "material_thickness": 2,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "STURDY" ]
+    "flags": [ "VARSIZE", "STURDY" ],
+    "armor": { "coverage": 50, "covers": [ "head" ], "encumbrance": 4 }
   },
   {
     "id": "comm_cloak",
@@ -51,13 +48,11 @@
     "material": [ "leather", "kevlar", "steel" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 75,
-    "encumbrance": 18,
     "warmth": 24,
     "material_thickness": 8,
     "environmental_protection": 1,
     "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "2 kg", "moves": 30 } ],
-    "flags": [ "VARSIZE", "POCKETS", "STURDY", "WATER_FRIENDLY", "OUTER" ]
+    "flags": [ "VARSIZE", "POCKETS", "STURDY", "WATER_FRIENDLY", "OUTER" ],
+    "armor": { "coverage": 75, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 18 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Wastelands_Mod/items/armor.json
+++ b/data/Unleash_The_Mods/Working_mods/Wastelands_Mod/items/armor.json
@@ -5,7 +5,6 @@
     "name": { "str": "rag shirt" },
     "weight": "100 g",
     "color": "white",
-    "covers": [ "torso" ],
     "to_hit": 0,
     "symbol": "[",
     "description": "A collection of rags stitched together, forming a crude shirt.",
@@ -15,11 +14,10 @@
     "cutting": 0,
     "warmth": 5,
     "phase": "solid",
-    "encumbrance": 5,
     "bashing": 0,
     "flags": [ "VARSIZE" ],
-    "coverage": 90,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 90, "covers": [ "torso" ], "encumbrance": 5 }
   },
   {
     "id": "ragpants",
@@ -27,7 +25,6 @@
     "name": { "str": "rag pants", "str_pl": "rag pants" },
     "weight": "650 g",
     "color": "light_gray",
-    "covers": [ "leg_l", "leg_r" ],
     "to_hit": 0,
     "symbol": "[",
     "description": "A pair of pants made up of a couple rags sewn together. Has a few pockets.",
@@ -37,10 +34,8 @@
     "cutting": 0,
     "warmth": 15,
     "phase": "solid",
-    "encumbrance": 15,
     "bashing": 0,
     "flags": [ "TARDIS", "VARSIZE", "POCKETS" ],
-    "coverage": 95,
     "material_thickness": 1,
     "pocket_data": [
       {
@@ -51,6 +46,7 @@
         "max_item_volume": "32 ml",
         "max_contains_weight": "3750 g"
       }
-    ]
+    ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r" ], "encumbrance": 15 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Wild_Living/aframebackpack.json
+++ b/data/Unleash_The_Mods/Working_mods/Wild_Living/aframebackpack.json
@@ -10,10 +10,6 @@
     "material": [ "veggy" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso" ],
-    "coverage": 15,
-    "encumbrance": 5,
-    "max_encumbrance": 15,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "4 L", "max_contains_weight": "7 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "4 L", "max_contains_weight": "7 kg", "moves": 80 },
@@ -21,7 +17,8 @@
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "3 kg", "moves": 150 }
     ],
     "warmth": 0,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 15, "covers": [ "torso" ], "encumbrance": [ 5, 15 ] }
   },
   {
     "result": "cordage_pouch",
@@ -46,9 +43,6 @@
     "material": [ "veggy" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso" ],
-    "coverage": 10,
-    "encumbrance": 15,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "4 L", "max_contains_weight": "7 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "4 L", "max_contains_weight": "7 kg", "moves": 80 },
@@ -56,7 +50,8 @@
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "3 kg", "moves": 150 }
     ],
     "warmth": 0,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 10, "covers": [ "torso" ], "encumbrance": 15 }
   },
   {
     "result": "birchbark_pouch",
@@ -82,11 +77,9 @@
     "material": [ "wood" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso" ],
-    "coverage": 20,
-    "encumbrance": 12,
     "warmth": 0,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 20, "covers": [ "torso" ], "encumbrance": 12 }
   },
   {
     "result": "backpack_aframe",
@@ -112,9 +105,6 @@
     "material": [ "wood" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso" ],
-    "coverage": 20,
-    "encumbrance": 6,
     "warmth": 0,
     "material_thickness": 1,
     "pocket_data": [
@@ -132,7 +122,8 @@
       }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Attach what to backpack loop?", "holster_msg": "You attach your %s to your %s" },
-    "flags": [ "BELTED" ]
+    "flags": [ "BELTED" ],
+    "armor": { "coverage": 20, "covers": [ "torso" ], "encumbrance": 6 }
   },
   {
     "result": "backpack_aframe_birchbark",
@@ -158,9 +149,6 @@
     "material": [ "wood" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso" ],
-    "coverage": 20,
-    "encumbrance": 6,
     "warmth": 0,
     "material_thickness": 1,
     "pocket_data": [
@@ -178,7 +166,8 @@
       }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Attach what to backpack loop?", "holster_msg": "You attach your %s to your %s" },
-    "flags": [ "BELTED" ]
+    "flags": [ "BELTED" ],
+    "armor": { "coverage": 20, "covers": [ "torso" ], "encumbrance": 6 }
   },
   {
     "result": "backpack_aframe_cordage",

--- a/data/Unleash_The_Mods/Working_mods/Wild_Living/aframes.json
+++ b/data/Unleash_The_Mods/Working_mods/Wild_Living/aframes.json
@@ -10,16 +10,14 @@
     "material": [ "veggy" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso" ],
-    "coverage": 15,
-    "encumbrance": 10,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "4 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "4 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1 L", "max_contains_weight": "2 kg", "moves": 150 }
     ],
     "warmth": 0,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 15, "covers": [ "torso" ], "encumbrance": 10 }
   },
   {
     "result": "cordage_pouch",
@@ -44,16 +42,14 @@
     "material": [ "veggy" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso" ],
-    "coverage": 10,
-    "encumbrance": 20,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "4 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "4 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1 L", "max_contains_weight": "2 kg", "moves": 150 }
     ],
     "warmth": 0,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 10, "covers": [ "torso" ], "encumbrance": 20 }
   },
   {
     "result": "birchbark_pouch",
@@ -79,11 +75,9 @@
     "material": [ "wood" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso" ],
-    "coverage": 20,
-    "encumbrance": 6,
     "warmth": 0,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 20, "covers": [ "torso" ], "encumbrance": 6 }
   },
   {
     "result": "backpack_aframe",
@@ -109,9 +103,6 @@
     "material": [ "wood" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso" ],
-    "coverage": 20,
-    "encumbrance": 6,
     "warmth": 0,
     "material_thickness": 1,
     "pocket_data": [
@@ -128,7 +119,8 @@
       }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Attach what to backpack loop?", "holster_msg": "You attach your %s to your %s" },
-    "flags": [ "BELTED", "TARDIS" ]
+    "flags": [ "BELTED", "TARDIS" ],
+    "armor": { "coverage": 20, "covers": [ "torso" ], "encumbrance": 6 }
   },
   {
     "result": "backpack_aframe_birchbark",
@@ -154,9 +146,6 @@
     "material": [ "wood" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso" ],
-    "coverage": 20,
-    "encumbrance": 6,
     "warmth": 0,
     "material_thickness": 1,
     "pocket_data": [
@@ -173,7 +162,8 @@
       }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Attach what to backpack loop?", "holster_msg": "You attach your %s to your %s" },
-    "flags": [ "BELTED", "TARDIS" ]
+    "flags": [ "BELTED", "TARDIS" ],
+    "armor": { "coverage": 20, "covers": [ "torso" ], "encumbrance": 6 }
   },
   {
     "result": "backpack_aframe_cordage",

--- a/data/Unleash_The_Mods/Working_mods/Wild_Living/fur_backpack.json
+++ b/data/Unleash_The_Mods/Working_mods/Wild_Living/fur_backpack.json
@@ -10,9 +10,6 @@
     "material": [ "fur" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso" ],
-    "coverage": 30,
-    "encumbrance": 18,
     "warmth": 30,
     "material_thickness": 3,
     "pocket_data": [
@@ -30,7 +27,8 @@
       }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Attach what to backpack loop?", "holster_msg": "You attach your %s to your %s" },
-    "flags": [ "BELTED", "WATER_FRIENDLY", "TARDIS" ]
+    "flags": [ "BELTED", "WATER_FRIENDLY", "TARDIS" ],
+    "armor": { "coverage": 30, "covers": [ "torso" ], "encumbrance": 18 }
   },
   {
     "result": "backpack_fur",

--- a/data/Unleash_The_Mods/Working_mods/XEAS/Bag.json
+++ b/data/Unleash_The_Mods/Working_mods/XEAS/Bag.json
@@ -12,10 +12,6 @@
     "symbol": "[",
     "looks_like": "rucksack",
     "color": "light_cyan",
-    "covers": [ "torso" ],
-    "coverage": 1,
-    "encumbrance": 1,
-    "max_encumbrance": 1,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "40 L", "max_contains_weight": "50 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "40 L", "max_contains_weight": "50 kg", "moves": 80 },
@@ -24,7 +20,8 @@
     ],
     "warmth": 1,
     "material_thickness": 2,
-    "flags": [ "BELTED", "WATERPROOF", "STURDY", "POWERARMOR_COMPATIBLE" ]
+    "flags": [ "BELTED", "WATERPROOF", "STURDY", "POWERARMOR_COMPATIBLE" ],
+    "armor": { "coverage": 1, "covers": [ "torso" ], "encumbrance": [ 1, 1 ] }
   },
   {
     "result": "XEAS_bag",

--- a/data/Unleash_The_Mods/Working_mods/XEAS/Boot.json
+++ b/data/Unleash_The_Mods/Working_mods/XEAS/Boot.json
@@ -14,13 +14,11 @@
     "symbol": "[",
     "looks_like": "boots_combat",
     "color": "light_cyan",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 20,
     "warmth": 15,
     "material_thickness": 8,
     "environmental_protection": 8,
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "foot_l", "foot_r" ], "encumbrance": 20 }
   },
   {
     "result": "XEAS_boots",

--- a/data/Unleash_The_Mods/Working_mods/XEAS/Gloves.json
+++ b/data/Unleash_The_Mods/Working_mods/XEAS/Gloves.json
@@ -13,13 +13,11 @@
     "symbol": "[",
     "looks_like": "fire_gauntlets",
     "color": "light_cyan",
-    "covers": [ "hand_l", "hand_r" ],
-    "coverage": 100,
-    "encumbrance": 12,
     "warmth": 15,
     "material_thickness": 6,
     "environmental_protection": 8,
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "hand_l", "hand_r" ], "encumbrance": 12 }
   },
   {
     "result": "XEAS_gloves",

--- a/data/Unleash_The_Mods/Working_mods/XEAS/Helmet.json
+++ b/data/Unleash_The_Mods/Working_mods/XEAS/Helmet.json
@@ -14,14 +14,12 @@
     "symbol": "[",
     "looks_like": "helmet_survivor",
     "color": "light_cyan",
-    "covers": [ "head" ],
-    "coverage": 100,
-    "encumbrance": 20,
     "warmth": 15,
     "material_thickness": 8,
     "environmental_protection": 8,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY", "PARTIAL_DEAF" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY", "PARTIAL_DEAF" ],
+    "armor": { "coverage": 100, "covers": [ "head" ], "encumbrance": 20 }
   },
   {
     "result": "XEAS_helmet",

--- a/data/Unleash_The_Mods/Working_mods/XEAS/Mask.json
+++ b/data/Unleash_The_Mods/Working_mods/XEAS/Mask.json
@@ -16,15 +16,13 @@
     "material": [ "acidchitin", "diamond" ],
     "symbol": "[",
     "color": "light_cyan",
-    "covers": [ "eyes", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 20,
     "warmth": 15,
     "material_thickness": 2,
     "environmental_protection": 2,
     "environmental_protection_with_filter": 17,
     "qualities": [ [ "GLARE", 3 ] ],
-    "flags": [ "VARSIZE", "STURDY", "SUN_GLASSES", "SUN_GLASSES", "WATER_FRIENDLY", "SWIM_GOGGLES", "PSYSHIELD_PARTIAL" ]
+    "flags": [ "VARSIZE", "STURDY", "SUN_GLASSES", "SUN_GLASSES", "WATER_FRIENDLY", "SWIM_GOGGLES", "PSYSHIELD_PARTIAL" ],
+    "armor": { "coverage": 100, "covers": [ "eyes", "mouth" ], "encumbrance": 20 }
   },
   {
     "result": "XEAS_mask",

--- a/data/Unleash_The_Mods/Working_mods/XEAS/Suit.json
+++ b/data/Unleash_The_Mods/Working_mods/XEAS/Suit.json
@@ -14,9 +14,6 @@
     "symbol": "[",
     "looks_like": "survivor_suit",
     "color": "light_cyan",
-    "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r" ],
-    "coverage": 100,
-    "encumbrance": 20,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "4 L", "max_contains_weight": "5 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "4 L", "max_contains_weight": "5 kg", "moves": 80 },
@@ -26,7 +23,8 @@
     "warmth": 15,
     "material_thickness": 7,
     "environmental_protection": 7,
-    "flags": [ "STURDY", "VARSIZE", "WATERPROOF", "RAINPROOF", "POCKETS", "HOOD", "COLLAR", "RAD_RESIST", "SUPER_FANCY" ]
+    "flags": [ "STURDY", "VARSIZE", "WATERPROOF", "RAINPROOF", "POCKETS", "HOOD", "COLLAR", "RAD_RESIST", "SUPER_FANCY" ],
+    "armor": { "coverage": 100, "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r" ], "encumbrance": 20 }
   },
   {
     "result": "XEAS_suit",

--- a/data/Unleash_The_Mods/Working_mods/Zets_CDDA_Mod/adv_gear_equipment.json
+++ b/data/Unleash_The_Mods/Working_mods/Zets_CDDA_Mod/adv_gear_equipment.json
@@ -7,11 +7,9 @@
     "looks_like": "slime_scrap",
     "weight": "3157 g",
     "volume": "2000 ml",
-    "covers": [ "torso" ],
     "description": "A large blob of nanites with an AI, it actively branches out pseudopods to grasp items held near it and supports them as optimally as possible, including reaching down and forming 'legs' to support itself if needed.",
     "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "mutations": [ "ZETS_CARRY_MORE" ] } ] },
     "extend": { "flags": [ "TARDIS", "BELTED" ] },
-    "coverage": 30,
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -21,7 +19,8 @@
         "max_item_volume": "32 ml",
         "max_contains_weight": "250 kg"
       }
-    ]
+    ],
+    "armor": { "coverage": 30, "covers": [ "torso" ] }
   },
   {
     "id": "nano_container",

--- a/data/Unleash_The_Mods/Working_mods/aaa_NO_blacklist/armor/armor.json
+++ b/data/Unleash_The_Mods/Working_mods/aaa_NO_blacklist/armor/armor.json
@@ -10,9 +10,6 @@
     "material": [ "cotton", "plastic" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 95,
-    "encumbrance": 15,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "800 ml", "max_contains_weight": "3 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "800 ml", "max_contains_weight": "3 kg", "moves": 80 },
@@ -23,7 +20,8 @@
     ],
     "warmth": 20,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER" ],
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 15 }
   },
   {
     "id": "acu_pants",
@@ -36,9 +34,6 @@
     "material": [ "cotton", "plastic" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 18,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "700 ml", "max_contains_weight": "2 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "700 ml", "max_contains_weight": "2 kg", "moves": 80 },
@@ -47,7 +42,8 @@
     ],
     "warmth": 20,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "POCKETS" ]
+    "flags": [ "VARSIZE", "POCKETS" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r" ], "encumbrance": 18 }
   },
   {
     "id": "pasgt_helmet",
@@ -63,13 +59,11 @@
     "material": [ "kevlar", "plastic" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "head" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "warmth": 20,
     "material_thickness": 5,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 95, "covers": [ "head" ], "encumbrance": 20 }
   },
   {
     "id": "pasgt_helmet_green",
@@ -85,13 +79,11 @@
     "material": [ "kevlar", "plastic", "cotton" ],
     "symbol": "[",
     "color": "green",
-    "covers": [ "head" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "warmth": 20,
     "material_thickness": 5,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 95, "covers": [ "head" ], "encumbrance": 20 }
   },
   {
     "id": "pasgt_helmet_patchwork",
@@ -107,13 +99,11 @@
     "material": [ "kevlar", "plastic", "cotton" ],
     "symbol": "[",
     "color": "cyan",
-    "covers": [ "head" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "warmth": 20,
     "material_thickness": 5,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 95, "covers": [ "head" ], "encumbrance": 20 }
   },
   {
     "id": "pasgt_helmet_ucp",
@@ -129,13 +119,11 @@
     "material": [ "kevlar", "plastic", "cotton" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "head" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "warmth": 20,
     "material_thickness": 5,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 95, "covers": [ "head" ], "encumbrance": 20 }
   },
   {
     "id": "pasgt_helmet_multi",
@@ -151,13 +139,11 @@
     "material": [ "kevlar", "plastic", "cotton" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "head" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "warmth": 20,
     "material_thickness": 5,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 95, "covers": [ "head" ], "encumbrance": 20 }
   },
   {
     "id": "iotvucp",
@@ -173,16 +159,14 @@
     "material": [ "kevlar" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "torso" ],
-    "coverage": 85,
-    "encumbrance": 8,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1500 g", "moves": 85 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1500 g", "moves": 85 }
     ],
     "warmth": 15,
     "material_thickness": 4,
-    "flags": [ "STURDY", "OUTER" ]
+    "flags": [ "STURDY", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": 8 }
   },
   {
     "id": "iotvkevlarucp",
@@ -198,16 +182,14 @@
     "material": [ "kevlar" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "torso" ],
-    "coverage": 85,
-    "encumbrance": 8,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1500 g", "moves": 85 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1500 g", "moves": 85 }
     ],
     "warmth": 15,
     "material_thickness": 5,
-    "flags": [ "STURDY", "OUTER" ]
+    "flags": [ "STURDY", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": 8 }
   },
   {
     "id": "iotvceramicucp",
@@ -223,16 +205,14 @@
     "material": [ "kevlar", "ceramic" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "torso" ],
-    "coverage": 85,
-    "encumbrance": 8,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1500 g", "moves": 85 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1500 g", "moves": 85 }
     ],
     "warmth": 15,
     "material_thickness": 5,
-    "flags": [ "STURDY", "OUTER" ]
+    "flags": [ "STURDY", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": 8 }
   },
   {
     "id": "iotvharducp",
@@ -248,16 +228,14 @@
     "material": [ "kevlar", "hardsteel" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "torso" ],
-    "coverage": 85,
-    "encumbrance": 8,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1500 g", "moves": 85 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1500 g", "moves": 85 }
     ],
     "warmth": 15,
     "material_thickness": 5,
-    "flags": [ "STURDY", "OUTER" ]
+    "flags": [ "STURDY", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": 8 }
   },
   {
     "id": "iotvsteelucp",
@@ -273,16 +251,14 @@
     "material": [ "kevlar", "steel" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "torso" ],
-    "coverage": 85,
-    "encumbrance": 8,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1500 g", "moves": 85 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1500 g", "moves": 85 }
     ],
     "warmth": 15,
     "material_thickness": 5,
-    "flags": [ "STURDY", "OUTER" ]
+    "flags": [ "STURDY", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": 8 }
   },
   {
     "id": "iotvsuperucp",
@@ -298,16 +274,14 @@
     "material": [ "kevlar", "superalloy" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "torso" ],
-    "coverage": 85,
-    "encumbrance": 8,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1500 g", "moves": 85 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1500 g", "moves": 85 }
     ],
     "warmth": 15,
     "material_thickness": 5,
-    "flags": [ "STURDY", "OUTER" ]
+    "flags": [ "STURDY", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": 8 }
   },
   {
     "id": "iotvucp_mk2",
@@ -323,9 +297,6 @@
     "material": [ "kevlar" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 85,
-    "encumbrance": 20,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "625 ml", "max_contains_weight": "2 kg", "moves": 90 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "625 ml", "max_contains_weight": "2 kg", "moves": 90 },
@@ -334,7 +305,8 @@
     ],
     "warmth": 15,
     "material_thickness": 10,
-    "flags": [ "STURDY", "OUTER" ]
+    "flags": [ "STURDY", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 20 }
   },
   {
     "id": "iotvkevlarucp_mk2",
@@ -350,9 +322,6 @@
     "material": [ "kevlar" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 85,
-    "encumbrance": 30,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "625 ml", "max_contains_weight": "2 kg", "moves": 90 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "625 ml", "max_contains_weight": "2 kg", "moves": 90 },
@@ -361,7 +330,8 @@
     ],
     "warmth": 15,
     "material_thickness": 10,
-    "flags": [ "STURDY", "OUTER" ]
+    "flags": [ "STURDY", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 30 }
   },
   {
     "id": "iotvceramicucp_mk2",
@@ -377,9 +347,6 @@
     "material": [ "kevlar", "ceramic" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 85,
-    "encumbrance": 25,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "625 ml", "max_contains_weight": "2 kg", "moves": 90 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "625 ml", "max_contains_weight": "2 kg", "moves": 90 },
@@ -388,7 +355,8 @@
     ],
     "warmth": 15,
     "material_thickness": 10,
-    "flags": [ "STURDY", "OUTER" ]
+    "flags": [ "STURDY", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "iotvharducp_mk2",
@@ -404,9 +372,6 @@
     "material": [ "kevlar", "hardsteel" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 85,
-    "encumbrance": 50,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "625 ml", "max_contains_weight": "2 kg", "moves": 90 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "625 ml", "max_contains_weight": "2 kg", "moves": 90 },
@@ -415,7 +380,8 @@
     ],
     "warmth": 15,
     "material_thickness": 10,
-    "flags": [ "STURDY", "OUTER" ]
+    "flags": [ "STURDY", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 50 }
   },
   {
     "id": "iotvsteelucp_mk2",
@@ -431,9 +397,6 @@
     "material": [ "kevlar", "steel" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 85,
-    "encumbrance": 27,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "625 ml", "max_contains_weight": "2 kg", "moves": 90 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "625 ml", "max_contains_weight": "2 kg", "moves": 90 },
@@ -442,7 +405,8 @@
     ],
     "warmth": 15,
     "material_thickness": 10,
-    "flags": [ "STURDY", "OUTER" ]
+    "flags": [ "STURDY", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 27 }
   },
   {
     "id": "iotvsuperucp_mk2",
@@ -458,9 +422,6 @@
     "material": [ "kevlar", "superalloy" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 85,
-    "encumbrance": 25,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "625 ml", "max_contains_weight": "2 kg", "moves": 90 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "625 ml", "max_contains_weight": "2 kg", "moves": 90 },
@@ -469,7 +430,8 @@
     ],
     "warmth": 15,
     "material_thickness": 10,
-    "flags": [ "STURDY", "OUTER" ]
+    "flags": [ "STURDY", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "plate_carrier_ucp",
@@ -485,16 +447,14 @@
     "material": [ "kevlar" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "torso" ],
-    "coverage": 85,
-    "encumbrance": 4,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "250 ml", "max_contains_weight": "1 kg", "moves": 120 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "250 ml", "max_contains_weight": "1 kg", "moves": 120 }
     ],
     "warmth": 15,
     "material_thickness": 2,
-    "flags": [ "STURDY", "OUTER" ]
+    "flags": [ "STURDY", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": 4 }
   },
   {
     "id": "plate_carrier_ucp_kevlar",
@@ -510,16 +470,14 @@
     "material": [ "kevlar" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "torso" ],
-    "coverage": 85,
-    "encumbrance": 4,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "250 ml", "max_contains_weight": "1 kg", "moves": 120 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "250 ml", "max_contains_weight": "1 kg", "moves": 120 }
     ],
     "warmth": 15,
     "material_thickness": 3,
-    "flags": [ "STURDY", "OUTER" ]
+    "flags": [ "STURDY", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": 4 }
   },
   {
     "id": "plate_carrier_ucp_ceramic",
@@ -535,16 +493,14 @@
     "material": [ "kevlar", "ceramic" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "torso" ],
-    "coverage": 85,
-    "encumbrance": 4,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1500 g", "moves": 85 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1500 g", "moves": 85 }
     ],
     "warmth": 15,
     "material_thickness": 3,
-    "flags": [ "STURDY", "OUTER" ]
+    "flags": [ "STURDY", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": 4 }
   },
   {
     "id": "plate_carrier_ucp_hard",
@@ -560,16 +516,14 @@
     "material": [ "kevlar", "hardsteel" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "torso" ],
-    "coverage": 85,
-    "encumbrance": 6,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "250 ml", "max_contains_weight": "1 kg", "moves": 120 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "250 ml", "max_contains_weight": "1 kg", "moves": 120 }
     ],
     "warmth": 15,
     "material_thickness": 3,
-    "flags": [ "STURDY", "OUTER" ]
+    "flags": [ "STURDY", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": 6 }
   },
   {
     "id": "plate_carrier_ucp_steel",
@@ -585,16 +539,14 @@
     "material": [ "kevlar", "steel" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "torso" ],
-    "coverage": 85,
-    "encumbrance": 4,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "250 ml", "max_contains_weight": "1 kg", "moves": 120 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "250 ml", "max_contains_weight": "1 kg", "moves": 120 }
     ],
     "warmth": 15,
     "material_thickness": 3,
-    "flags": [ "STURDY", "OUTER" ]
+    "flags": [ "STURDY", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": 4 }
   },
   {
     "id": "plate_carrier_ucp_super",
@@ -610,16 +562,14 @@
     "material": [ "kevlar", "superalloy" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "torso" ],
-    "coverage": 85,
-    "encumbrance": 3,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "250 ml", "max_contains_weight": "1 kg", "moves": 120 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "250 ml", "max_contains_weight": "1 kg", "moves": 120 }
     ],
     "warmth": 15,
     "material_thickness": 3,
-    "flags": [ "STURDY", "OUTER" ]
+    "flags": [ "STURDY", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": 3 }
   },
   {
     "id": "iotvmulti",
@@ -635,16 +585,14 @@
     "material": [ "kevlar" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso" ],
-    "coverage": 85,
-    "encumbrance": 8,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1500 g", "moves": 85 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1500 g", "moves": 85 }
     ],
     "warmth": 15,
     "material_thickness": 4,
-    "flags": [ "STURDY", "OUTER" ]
+    "flags": [ "STURDY", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": 8 }
   },
   {
     "id": "iotvkevlarmulti",
@@ -660,16 +608,14 @@
     "material": [ "kevlar" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso" ],
-    "coverage": 85,
-    "encumbrance": 8,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1500 g", "moves": 85 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1500 g", "moves": 85 }
     ],
     "warmth": 15,
     "material_thickness": 5,
-    "flags": [ "STURDY", "OUTER" ]
+    "flags": [ "STURDY", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": 8 }
   },
   {
     "id": "iotvceramicmulti",
@@ -685,16 +631,14 @@
     "material": [ "kevlar", "ceramic" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso" ],
-    "coverage": 85,
-    "encumbrance": 8,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1500 g", "moves": 85 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1500 g", "moves": 85 }
     ],
     "warmth": 15,
     "material_thickness": 5,
-    "flags": [ "STURDY", "OUTER" ]
+    "flags": [ "STURDY", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": 8 }
   },
   {
     "id": "iotvhardmulti",
@@ -710,16 +654,14 @@
     "material": [ "kevlar", "hardsteel" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso" ],
-    "coverage": 85,
-    "encumbrance": 8,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1500 g", "moves": 85 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1500 g", "moves": 85 }
     ],
     "warmth": 15,
     "material_thickness": 5,
-    "flags": [ "STURDY", "OUTER" ]
+    "flags": [ "STURDY", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": 8 }
   },
   {
     "id": "iotvsteelmulti",
@@ -735,16 +677,14 @@
     "material": [ "kevlar", "steel" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso" ],
-    "coverage": 85,
-    "encumbrance": 8,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1500 g", "moves": 85 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1500 g", "moves": 85 }
     ],
     "warmth": 15,
     "material_thickness": 5,
-    "flags": [ "STURDY", "OUTER" ]
+    "flags": [ "STURDY", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": 8 }
   },
   {
     "id": "iotvsupermulti",
@@ -760,16 +700,14 @@
     "material": [ "kevlar", "superalloy" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso" ],
-    "coverage": 85,
-    "encumbrance": 8,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1500 g", "moves": 85 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1500 g", "moves": 85 }
     ],
     "warmth": 15,
     "material_thickness": 5,
-    "flags": [ "STURDY", "OUTER" ]
+    "flags": [ "STURDY", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": 8 }
   },
   {
     "id": "iotvmulti_mk2",
@@ -785,9 +723,6 @@
     "material": [ "kevlar" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 85,
-    "encumbrance": 20,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "625 ml", "max_contains_weight": "2 kg", "moves": 90 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "625 ml", "max_contains_weight": "2 kg", "moves": 90 },
@@ -796,7 +731,8 @@
     ],
     "warmth": 15,
     "material_thickness": 10,
-    "flags": [ "STURDY", "OUTER" ]
+    "flags": [ "STURDY", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 20 }
   },
   {
     "id": "iotvkevlarmulti_mk2",
@@ -812,9 +748,6 @@
     "material": [ "kevlar" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 85,
-    "encumbrance": 30,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "625 ml", "max_contains_weight": "2 kg", "moves": 90 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "625 ml", "max_contains_weight": "2 kg", "moves": 90 },
@@ -823,7 +756,8 @@
     ],
     "warmth": 15,
     "material_thickness": 10,
-    "flags": [ "STURDY", "OUTER" ]
+    "flags": [ "STURDY", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 30 }
   },
   {
     "id": "iotvceramicmulti_mk2",
@@ -839,9 +773,6 @@
     "material": [ "kevlar", "ceramic" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 85,
-    "encumbrance": 25,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "625 ml", "max_contains_weight": "2 kg", "moves": 90 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "625 ml", "max_contains_weight": "2 kg", "moves": 90 },
@@ -850,7 +781,8 @@
     ],
     "warmth": 15,
     "material_thickness": 10,
-    "flags": [ "STURDY", "OUTER" ]
+    "flags": [ "STURDY", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "iotvhardmulti_mk2",
@@ -866,9 +798,6 @@
     "material": [ "kevlar", "hardsteel" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 85,
-    "encumbrance": 50,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "625 ml", "max_contains_weight": "2 kg", "moves": 90 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "625 ml", "max_contains_weight": "2 kg", "moves": 90 },
@@ -877,7 +806,8 @@
     ],
     "warmth": 15,
     "material_thickness": 10,
-    "flags": [ "STURDY", "OUTER" ]
+    "flags": [ "STURDY", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 50 }
   },
   {
     "id": "iotvsteelmulti_mk2",
@@ -893,9 +823,6 @@
     "material": [ "kevlar", "steel" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 85,
-    "encumbrance": 27,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "625 ml", "max_contains_weight": "2 kg", "moves": 90 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "625 ml", "max_contains_weight": "2 kg", "moves": 90 },
@@ -904,7 +831,8 @@
     ],
     "warmth": 15,
     "material_thickness": 10,
-    "flags": [ "STURDY", "OUTER" ]
+    "flags": [ "STURDY", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 27 }
   },
   {
     "id": "iotvsupermulti_mk2",
@@ -920,9 +848,6 @@
     "material": [ "kevlar", "superalloy" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 85,
-    "encumbrance": 25,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "625 ml", "max_contains_weight": "2 kg", "moves": 90 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "625 ml", "max_contains_weight": "2 kg", "moves": 90 },
@@ -931,7 +856,8 @@
     ],
     "warmth": 15,
     "material_thickness": 10,
-    "flags": [ "STURDY", "OUTER" ]
+    "flags": [ "STURDY", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 25 }
   },
   {
     "id": "plate_carrier_multi",
@@ -947,16 +873,14 @@
     "material": [ "kevlar" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso" ],
-    "coverage": 85,
-    "encumbrance": 4,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "250 ml", "max_contains_weight": "1 kg", "moves": 120 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "250 ml", "max_contains_weight": "1 kg", "moves": 120 }
     ],
     "warmth": 15,
     "material_thickness": 2,
-    "flags": [ "STURDY", "OUTER" ]
+    "flags": [ "STURDY", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": 4 }
   },
   {
     "id": "plate_carrier_multi_kevlar",
@@ -972,16 +896,14 @@
     "material": [ "kevlar" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso" ],
-    "coverage": 85,
-    "encumbrance": 4,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "250 ml", "max_contains_weight": "1 kg", "moves": 120 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "250 ml", "max_contains_weight": "1 kg", "moves": 120 }
     ],
     "warmth": 15,
     "material_thickness": 3,
-    "flags": [ "STURDY", "OUTER" ]
+    "flags": [ "STURDY", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": 4 }
   },
   {
     "id": "plate_carrier_multi_ceramic",
@@ -997,16 +919,14 @@
     "material": [ "kevlar", "ceramic" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso" ],
-    "coverage": 85,
-    "encumbrance": 4,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1500 g", "moves": 85 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1500 g", "moves": 85 }
     ],
     "warmth": 15,
     "material_thickness": 3,
-    "flags": [ "STURDY", "OUTER" ]
+    "flags": [ "STURDY", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": 4 }
   },
   {
     "id": "plate_carrier_multi_hard",
@@ -1022,16 +942,14 @@
     "material": [ "kevlar", "hardsteel" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso" ],
-    "coverage": 85,
-    "encumbrance": 6,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "250 ml", "max_contains_weight": "1 kg", "moves": 120 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "250 ml", "max_contains_weight": "1 kg", "moves": 120 }
     ],
     "warmth": 15,
     "material_thickness": 3,
-    "flags": [ "STURDY", "OUTER" ]
+    "flags": [ "STURDY", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": 6 }
   },
   {
     "id": "plate_carrier_multi_steel",
@@ -1047,16 +965,14 @@
     "material": [ "kevlar", "steel" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso" ],
-    "coverage": 85,
-    "encumbrance": 4,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "250 ml", "max_contains_weight": "1 kg", "moves": 120 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "250 ml", "max_contains_weight": "1 kg", "moves": 120 }
     ],
     "warmth": 15,
     "material_thickness": 3,
-    "flags": [ "STURDY", "OUTER" ]
+    "flags": [ "STURDY", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": 4 }
   },
   {
     "id": "plate_carrier_multi_super",
@@ -1072,16 +988,14 @@
     "material": [ "kevlar", "superalloy" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso" ],
-    "coverage": 85,
-    "encumbrance": 3,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "250 ml", "max_contains_weight": "1 kg", "moves": 120 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "250 ml", "max_contains_weight": "1 kg", "moves": 120 }
     ],
     "warmth": 15,
     "material_thickness": 3,
-    "flags": [ "STURDY", "OUTER" ]
+    "flags": [ "STURDY", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": 3 }
   },
   {
     "id": "acu_jacket_multi",
@@ -1094,9 +1008,6 @@
     "material": [ "cotton", "plastic" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 95,
-    "encumbrance": 15,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "800 ml", "max_contains_weight": "3 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "800 ml", "max_contains_weight": "3 kg", "moves": 80 },
@@ -1107,7 +1018,8 @@
     ],
     "warmth": 20,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER" ],
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 15 }
   },
   {
     "id": "acu_pants_multi",
@@ -1120,9 +1032,6 @@
     "material": [ "cotton", "plastic" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 18,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "700 ml", "max_contains_weight": "2 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "700 ml", "max_contains_weight": "2 kg", "moves": 80 },
@@ -1131,7 +1040,8 @@
     ],
     "warmth": 20,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "POCKETS" ]
+    "flags": [ "VARSIZE", "POCKETS" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r" ], "encumbrance": 18 }
   },
   {
     "id": "talos",
@@ -1148,9 +1058,6 @@
     "material": [ "aluminum", "superalloy" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r", "hand_l", "hand_r", "foot_l", "foot_r" ],
-    "coverage": 98,
-    "encumbrance": 20,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2900 ml", "max_contains_weight": "9 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2900 ml", "max_contains_weight": "9 kg", "moves": 80 },
@@ -1162,7 +1069,12 @@
     "warmth": 60,
     "material_thickness": 10,
     "environmental_protection": 10,
-    "flags": [ "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE" ]
+    "flags": [ "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE" ],
+    "armor": {
+      "coverage": 98,
+      "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r", "hand_l", "hand_r", "foot_l", "foot_r" ],
+      "encumbrance": 20
+    }
   },
   {
     "id": "talos_helmet",
@@ -1178,14 +1090,12 @@
     "material": [ "aluminum", "superalloy" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "head", "mouth", "eyes" ],
-    "coverage": 100,
-    "encumbrance": 10,
     "warmth": 60,
     "material_thickness": 10,
     "environmental_protection": 10,
     "qualities": [ [ "GLARE", 2 ] ],
-    "flags": [ "WATCH", "WATERPROOF", "STURDY", "PARTIAL_DEAF", "THERMOMETER", "FLASH_PROTECTION", "GAS_PROOF" ]
+    "flags": [ "WATCH", "WATERPROOF", "STURDY", "PARTIAL_DEAF", "THERMOMETER", "FLASH_PROTECTION", "GAS_PROOF" ],
+    "armor": { "coverage": 100, "covers": [ "head", "mouth", "eyes" ], "encumbrance": 10 }
   },
   {
     "id": "lv2_ policevest",
@@ -1201,16 +1111,14 @@
     "material": [ "kevlar" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "torso" ],
-    "coverage": 85,
-    "encumbrance": 4,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "250 ml", "max_contains_weight": "1 kg", "moves": 120 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "250 ml", "max_contains_weight": "1 kg", "moves": 120 }
     ],
     "warmth": 15,
     "material_thickness": 2,
-    "flags": [ "STURDY", "OUTER" ]
+    "flags": [ "STURDY", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": 4 }
   },
   {
     "id": "lv3_ policevest",
@@ -1226,15 +1134,13 @@
     "material": [ "kevlar" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "torso" ],
-    "coverage": 85,
-    "encumbrance": 4,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "250 ml", "max_contains_weight": "1 kg", "moves": 120 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "250 ml", "max_contains_weight": "1 kg", "moves": 120 }
     ],
     "warmth": 15,
     "material_thickness": 4,
-    "flags": [ "STURDY", "OUTER" ]
+    "flags": [ "STURDY", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": 4 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/aaa_NO_blacklist/armor/boots.json
+++ b/data/Unleash_The_Mods/Working_mods/aaa_NO_blacklist/armor/boots.json
@@ -13,13 +13,11 @@
     "material": [ "kevlar", "nomex" ],
     "symbol": "[",
     "color": "yellow",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 25,
     "warmth": 25,
     "material_thickness": 3,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "foot_l", "foot_r" ], "encumbrance": 25 }
   },
   {
     "id": "boots_combat_brown",
@@ -35,12 +33,10 @@
     "material": [ "kevlar", "nomex" ],
     "symbol": "[",
     "color": "yellow",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 25,
     "warmth": 25,
     "material_thickness": 3,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "foot_l", "foot_r" ], "encumbrance": 25 }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/pixels_fuckery/pix_item.json
+++ b/data/Unleash_The_Mods/Working_mods/pixels_fuckery/pix_item.json
@@ -48,14 +48,16 @@
     "material": [ "kevlar", "plastic" ],
     "symbol": "[",
     "color": "light_red",
-    "covers": [ "torso", "head", "eyes", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 50,
     "warmth": 50,
     "material_thickness": 3,
     "environmental_protection": 20,
     "looks_like": "anbc_suit",
-    "flags": [ "VARSIZE", "OVERSIZE", "WATERPROOF", "RAINPROOF", "STURDY", "RAD_PROOF", "ELECTRIC_IMMUNE", "GAS_PROOF", "OUTER" ]
+    "flags": [ "VARSIZE", "OVERSIZE", "WATERPROOF", "RAINPROOF", "STURDY", "RAD_PROOF", "ELECTRIC_IMMUNE", "GAS_PROOF", "OUTER" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "head", "eyes", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 50
+    }
   },
   {
     "id": "aluminumnailbat",

--- a/data/Unleash_The_Mods/mods/Dmbb/Modification_Files/Items/def_armors.json
+++ b/data/Unleash_The_Mods/mods/Dmbb/Modification_Files/Items/def_armors.json
@@ -7,9 +7,6 @@
     "volume": "1 ml",
     "weight": "1 g",
     "price": "0 cent",
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r", "head", "mouth", "eyes" ],
-    "coverage": 0,
-    "encumbrance": 0,
     "material_thickness": 1,
     "environmental_protection": 15,
     "to_hit": -50,
@@ -26,7 +23,12 @@
       }
     ],
     "relic_data": { "passive_effects": [ { "id": "DMBB_ORB_bu_ench" } ] },
-    "drop_action": { "target": "dmbb_death_act", "target_charges": 1, "active": true, "type": "transform" }
+    "drop_action": { "target": "dmbb_death_act", "target_charges": 1, "active": true, "type": "transform" },
+    "armor": {
+      "coverage": 0,
+      "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r", "head", "mouth", "eyes" ],
+      "encumbrance": 0
+    }
   },
   {
     "id": "dmbb_death_act",
@@ -55,7 +57,9 @@
     "symbol": "O",
     "color": "white",
     "environmental_protection": 15,
-    "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r", "mouth", "eyes" ],
-    "flags": [ "AURA", "SEMITANGIBLE", "OVERSIZE", "ONLY_ONE", "TRADER_AVOID", "NO_TAKEOFF", "NONCONDUCTIVE" ]
+    "flags": [ "AURA", "SEMITANGIBLE", "OVERSIZE", "ONLY_ONE", "TRADER_AVOID", "NO_TAKEOFF", "NONCONDUCTIVE" ],
+    "armor": {
+      "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r", "mouth", "eyes" ]
+    }
   }
 ]

--- a/data/Unleash_The_Mods/mods/Dmbb/Modification_Files/Items/def_armors_dragon.json
+++ b/data/Unleash_The_Mods/mods/Dmbb/Modification_Files/Items/def_armors_dragon.json
@@ -12,14 +12,12 @@
     "material": [ "dmbb_dragon_fire" ],
     "symbol": "[",
     "color": "light_red",
-    "covers": [ "hand_r", "hand_l" ],
-    "coverage": 100,
-    "encumbrance": 20,
     "warmth": 15,
     "material_thickness": 3,
     "environmental_protection": 3,
     "relic_data": { "passive_effects": [ { "id": "dmbb_dragon_fire_armor_ench" } ] },
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "hand_r", "hand_l" ], "encumbrance": 20 }
   },
   {
     "id": "dmbb_dragon_fire_hide_gloves",
@@ -34,14 +32,12 @@
     "material": [ "dmbb_dragon_fire" ],
     "symbol": "[",
     "color": "light_red",
-    "covers": [ "hand_r", "hand_l" ],
-    "coverage": 100,
-    "encumbrance": 10,
     "warmth": 15,
     "material_thickness": 2,
     "environmental_protection": 1,
     "relic_data": { "passive_effects": [ { "id": "dmbb_dragon_fire_armor_smol_ench" } ] },
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "hand_r", "hand_l" ], "encumbrance": 10 }
   },
   {
     "id": "dmbb_xlfire_dragon_scale_gauntlets",
@@ -51,8 +47,8 @@
     "description": "A pair of heavy-duty gauntlets made of fire dragonscale that covers your hands, or whatever you use as hands.\n\nThis item has the following abilities when worn:\n\n<color_cyan>Fire Resistance (medium)</color>:\n<color_white>Decreases fire damage dealt on you by 12. Only affects covered body part(s).</color>",
     "weight": "680 g",
     "volume": "2 L",
-    "encumbrance": 30,
-    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "encumbrance": 30 }
   },
   {
     "id": "dmbb_xlfire_dragon_hide_gloves",
@@ -62,8 +58,8 @@
     "description": "A pair of customized, Kevlar armored leather gloves, modified to be easy to wear while providing maximum protection under extreme conditions.  Sized to fit even the strangest of anatomy.\n\nThis item has the following abilities when worn:\n\n<color_cyan>Fire Resistance (low)</color>:\n<color_white>Decreases fire damage dealt on you by 6. Only affects covered body part(s).</color>",
     "weight": "430 g",
     "volume": "1500 ml",
-    "encumbrance": 20,
-    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "encumbrance": 20 }
   },
   {
     "id": "dmbb_dragon_fire_scale_boots",
@@ -79,14 +75,12 @@
     "material": [ "dmbb_dragon_fire" ],
     "symbol": "[",
     "color": "light_red",
-    "covers": [ "foot_r", "foot_l" ],
-    "coverage": 100,
-    "encumbrance": 30,
     "warmth": 20,
     "material_thickness": 3,
     "environmental_protection": 3,
     "relic_data": { "passive_effects": [ { "id": "dmbb_dragon_fire_armor_ench" } ] },
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "foot_r", "foot_l" ], "encumbrance": 30 }
   },
   {
     "id": "dmbb_dragon_fire_hide_boots",
@@ -102,14 +96,12 @@
     "material": [ "dmbb_dragon_fire" ],
     "symbol": "[",
     "color": "light_red",
-    "covers": [ "foot_r", "foot_l" ],
-    "coverage": 100,
-    "encumbrance": 20,
     "warmth": 20,
     "material_thickness": 2,
     "environmental_protection": 3,
     "relic_data": { "passive_effects": [ { "id": "dmbb_dragon_fire_armor_smol_ench" } ] },
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "foot_r", "foot_l" ], "encumbrance": 20 }
   },
   {
     "id": "dmbb_xlfire_dragon_scale_boots",
@@ -119,8 +111,8 @@
     "description": "Massive boots made of fire dragonscale, modified to fit even the strangest of bodies.  Very protective, and surprisingly light.\n\nThis item has the following abilities when worn:\n\n<color_cyan>Fire Resistance (medium)</color>:\n<color_white>Decreases fire damage dealt on you by 12. Only affects covered body part(s).</color>",
     "weight": "1545 g",
     "volume": "6250 ml",
-    "encumbrance": 40,
-    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "encumbrance": 40 }
   },
   {
     "id": "dmbb_xlfire_dragon_hide_boots",
@@ -130,8 +122,8 @@
     "description": "Massive boots made of fire dragonhide, modified to fit even the strangest of bodies.  Very protective, and surprisingly light.\n\nThis item has the following abilities when worn:\n\n<color_cyan>Fire Resistance (low)</color>:\n<color_white>Decreases fire damage dealt on you by 6. Only affects covered body part(s).</color>",
     "weight": "955 g",
     "volume": "6250 ml",
-    "encumbrance": 30,
-    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "encumbrance": 30 }
   },
   {
     "id": "dmbb_dragon_fire_scale_helmet",
@@ -147,15 +139,13 @@
     "material": [ "dmbb_dragon_fire" ],
     "symbol": "[",
     "color": "light_red",
-    "covers": [ "head", "eyes", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 30,
     "warmth": 15,
     "material_thickness": 6,
     "environmental_protection": 3,
     "relic_data": { "passive_effects": [ { "id": "dmbb_dragon_fire_armor_ench" } ] },
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "head", "eyes", "mouth" ], "encumbrance": 30 }
   },
   {
     "id": "dmbb_dragon_fire_hide_helmet",
@@ -171,15 +161,13 @@
     "material": [ "dmbb_dragon_fire" ],
     "symbol": "[",
     "color": "light_red",
-    "covers": [ "head" ],
-    "coverage": 100,
-    "encumbrance": 30,
     "warmth": 15,
     "material_thickness": 2,
     "environmental_protection": 1,
     "relic_data": { "passive_effects": [ { "id": "dmbb_dragon_fire_armor_smol_ench" } ] },
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "head" ], "encumbrance": 30 }
   },
   {
     "id": "dmbb_xlfire_dragon_scale_helmet",
@@ -189,8 +177,8 @@
     "description": "A massive helmet made from fire dragonscale, held together with fire dragonhide.  It comes equipped with a full face visor and is large enough to fit even the strangest of heads.\n\nThis item has the following abilities when worn:\n\n<color_cyan>Fire Resistance (medium)</color>:\n<color_white>Decreases fire damage dealt on you by 12. Only affects covered body part(s).</color>",
     "weight": "1256 g",
     "volume": "4500 ml",
-    "encumbrance": 40,
-    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "encumbrance": 40 }
   },
   {
     "id": "dmbb_xlfire_dragon_hide_helmet",
@@ -200,8 +188,8 @@
     "description": "A massive helmet made from fire dragonhide.  It protects your head well, and doesn't cover your face, but is large enough to fit even the strangest of heads.\n\nThis item has the following abilities when worn:\n\n<color_cyan>Fire Resistance (low)</color>:\n<color_white>Decreases fire damage dealt on you by 6. Only affects covered body part(s).</color>",
     "weight": "815 g",
     "volume": "4500 ml",
-    "encumbrance": 40,
-    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "encumbrance": 40 }
   },
   {
     "id": "dmbb_dragon_fire_scale_suit",
@@ -217,14 +205,12 @@
     "material": [ "dmbb_dragon_fire" ],
     "symbol": "[",
     "color": "light_red",
-    "covers": [ "leg_r", "leg_l", "torso", "arm_r", "arm_l" ],
-    "coverage": 100,
-    "encumbrance": 25,
     "warmth": 15,
     "material_thickness": 6,
     "environmental_protection": 2,
     "relic_data": { "passive_effects": [ { "id": "dmbb_dragon_fire_armor_ench" } ] },
-    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "leg_r", "leg_l", "torso", "arm_r", "arm_l" ], "encumbrance": 25 }
   },
   {
     "id": "dmbb_dragon_fire_hide_suit",
@@ -240,14 +226,12 @@
     "material": [ "dmbb_dragon_fire" ],
     "symbol": "[",
     "color": "light_red",
-    "covers": [ "leg_r", "leg_l", "torso", "arm_r", "arm_l" ],
-    "coverage": 100,
-    "encumbrance": 20,
     "warmth": 15,
     "material_thickness": 2,
     "environmental_protection": 1,
     "relic_data": { "passive_effects": [ { "id": "dmbb_dragon_fire_armor_ench" } ] },
-    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "leg_r", "leg_l", "torso", "arm_r", "arm_l" ], "encumbrance": 20 }
   },
   {
     "id": "dmbb_xlfire_dragon_scale_suit",
@@ -257,8 +241,8 @@
     "description": "A massive full suit of fire dragon scale mail.  It comes with all the accoutrements that cover your torso, legs, and arms; sized to fit even the strangest of bodies.\n\nThis item has the following abilities when worn:\n\n<color_cyan>Fire Resistance (medium)</color>:\n<color_white>Decreases fire damage dealt on you by 12. Only affects covered body part(s).</color>",
     "weight": "6250 g",
     "volume": "18 L",
-    "encumbrance": 35,
-    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "RAINPROOF", "STURDY" ]
+    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "RAINPROOF", "STURDY" ],
+    "armor": { "encumbrance": 35 }
   },
   {
     "id": "dmbb_xlfire_dragon_hide_suit",
@@ -268,8 +252,8 @@
     "description": "A massive full suit of fire dragonhide armor.  It comes with all the accoutrements that cover your torso, legs, and arms; sized to fit even the strangest of bodies.\n\nThis item has the following abilities when worn:\n\n<color_cyan>Fire Resistance (low)</color>:\n<color_white>Decreases fire damage dealt on you by 6. Only affects covered body part(s).</color>",
     "weight": "5500 g",
     "volume": "18 L",
-    "encumbrance": 30,
-    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "RAINPROOF", "STURDY" ]
+    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "RAINPROOF", "STURDY" ],
+    "armor": { "encumbrance": 30 }
   },
   {
     "id": "dmbb_dragon_ice_scale_gauntlets",
@@ -284,14 +268,12 @@
     "material": [ "dmbb_dragon_ice" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "hand_r", "hand_l" ],
-    "coverage": 100,
-    "encumbrance": 20,
     "warmth": 20,
     "material_thickness": 3,
     "environmental_protection": 3,
     "relic_data": { "passive_effects": [ { "id": "dmbb_dragon_ice_armor_ench" } ] },
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "hand_r", "hand_l" ], "encumbrance": 20 }
   },
   {
     "id": "dmbb_dragon_ice_hide_gloves",
@@ -306,14 +288,12 @@
     "material": [ "dmbb_dragon_ice" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "hand_r", "hand_l" ],
-    "coverage": 100,
-    "encumbrance": 10,
     "warmth": 20,
     "material_thickness": 2,
     "environmental_protection": 1,
     "relic_data": { "passive_effects": [ { "id": "dmbb_dragon_ice_armor_smol_ench" } ] },
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "hand_r", "hand_l" ], "encumbrance": 10 }
   },
   {
     "id": "dmbb_xlice_dragon_scale_gauntlets",
@@ -323,8 +303,8 @@
     "description": "A pair of heavy-duty gauntlets made of ice dragonscale that covers your hands, or whatever you use as hands.\n\nThis item has the following abilities when worn:\n\n<color_cyan>Ice Resistance (medium)</color>:\n<color_white>Decreases cold damage dealt on you by 12. Only affects covered body part(s).</color>",
     "weight": "680 g",
     "volume": "2 L",
-    "encumbrance": 30,
-    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "encumbrance": 30 }
   },
   {
     "id": "dmbb_xlice_dragon_hide_gloves",
@@ -334,8 +314,8 @@
     "description": "A pair of customized, Kevlar armored leather gloves, modified to be easy to wear while providing maximum protection under extreme conditions.  Sized to fit even the strangest of anatomy.\n\nThis item has the following abilities when worn:\n\n<color_cyan>Ice Resistance (low)</color>:\n<color_white>Decreases cold damage dealt on you by 6. Only affects covered body part(s).</color>",
     "weight": "430 g",
     "volume": "1500 ml",
-    "encumbrance": 20,
-    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "encumbrance": 20 }
   },
   {
     "id": "dmbb_dragon_ice_scale_boots",
@@ -351,14 +331,12 @@
     "material": [ "dmbb_dragon_ice" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "foot_r", "foot_l" ],
-    "coverage": 100,
-    "encumbrance": 30,
     "warmth": 20,
     "material_thickness": 3,
     "environmental_protection": 3,
     "relic_data": { "passive_effects": [ { "id": "dmbb_dragon_ice_armor_ench" } ] },
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "foot_r", "foot_l" ], "encumbrance": 30 }
   },
   {
     "id": "dmbb_dragon_ice_hide_boots",
@@ -374,14 +352,12 @@
     "material": [ "dmbb_dragon_ice" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "foot_r", "foot_l" ],
-    "coverage": 100,
-    "encumbrance": 20,
     "warmth": 20,
     "material_thickness": 2,
     "environmental_protection": 3,
     "relic_data": { "passive_effects": [ { "id": "dmbb_dragon_ice_armor_smol_ench" } ] },
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "foot_r", "foot_l" ], "encumbrance": 20 }
   },
   {
     "id": "dmbb_xlice_dragon_scale_boots",
@@ -391,8 +367,8 @@
     "description": "Massive boots made of ice dragonscale, modified to fit even the strangest of bodies.  Very protective, and surprisingly light.\n\nThis item has the following abilities when worn:\n\n<color_cyan>Ice Resistance (medium)</color>:\n<color_white>Decreases cold damage dealt on you by 12. Only affects covered body part(s).</color>",
     "weight": "1545 g",
     "volume": "6250 ml",
-    "encumbrance": 40,
-    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "encumbrance": 40 }
   },
   {
     "id": "dmbb_xlice_dragon_hide_boots",
@@ -402,8 +378,8 @@
     "description": "Massive boots made of ice dragonhide, modified to fit even the strangest of bodies.  Very protective, and surprisingly light.\n\nThis item has the following abilities when worn:\n\n<color_cyan>Ice Resistance (low)</color>:\n<color_white>Decreases cold damage dealt on you by 6. Only affects covered body part(s).</color>",
     "weight": "955 g",
     "volume": "6250 ml",
-    "encumbrance": 30,
-    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "encumbrance": 30 }
   },
   {
     "id": "dmbb_dragon_ice_scale_helmet",
@@ -419,15 +395,13 @@
     "material": [ "dmbb_dragon_ice" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "head", "eyes", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 30,
     "warmth": 20,
     "material_thickness": 6,
     "environmental_protection": 3,
     "relic_data": { "passive_effects": [ { "id": "dmbb_dragon_ice_armor_ench" } ] },
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "head", "eyes", "mouth" ], "encumbrance": 30 }
   },
   {
     "id": "dmbb_dragon_ice_hide_helmet",
@@ -443,15 +417,13 @@
     "material": [ "dmbb_dragon_ice" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "head" ],
-    "coverage": 100,
-    "encumbrance": 30,
     "warmth": 20,
     "material_thickness": 2,
     "environmental_protection": 1,
     "relic_data": { "passive_effects": [ { "id": "dmbb_dragon_ice_armor_smol_ench" } ] },
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "head" ], "encumbrance": 30 }
   },
   {
     "id": "dmbb_xlice_dragon_scale_helmet",
@@ -461,8 +433,8 @@
     "description": "A massive helmet made from ice dragonscale, held together with ice dragonhide.  It comes equipped with a full face visor and is large enough to fit even the strangest of heads.\n\nThis item has the following abilities when worn:\n\n<color_cyan>Ice Resistance (medium)</color>:\n<color_white>Decreases cold damage dealt on you by 12. Only affects covered body part(s).</color>",
     "weight": "1256 g",
     "volume": "4500 ml",
-    "encumbrance": 40,
-    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "encumbrance": 40 }
   },
   {
     "id": "dmbb_xlice_dragon_hide_helmet",
@@ -472,8 +444,8 @@
     "description": "A massive helmet made from ice dragonhide.  It protects your head well, and doesn't cover your face, but is large enough to fit even the strangest of heads.\n\nThis item has the following abilities when worn:\n\n<color_cyan>Ice Resistance (low)</color>:\n<color_white>Decreases cold damage dealt on you by 6. Only affects covered body part(s).</color>",
     "weight": "815 g",
     "volume": "4500 ml",
-    "encumbrance": 40,
-    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "encumbrance": 40 }
   },
   {
     "id": "dmbb_dragon_ice_scale_suit",
@@ -489,14 +461,12 @@
     "material": [ "dmbb_dragon_ice" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "leg_r", "leg_l", "torso", "arm_r", "arm_l" ],
-    "coverage": 100,
-    "encumbrance": 25,
     "warmth": 20,
     "material_thickness": 6,
     "environmental_protection": 2,
     "relic_data": { "passive_effects": [ { "id": "dmbb_dragon_ice_armor_ench" } ] },
-    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "leg_r", "leg_l", "torso", "arm_r", "arm_l" ], "encumbrance": 25 }
   },
   {
     "id": "dmbb_dragon_ice_hide_suit",
@@ -512,14 +482,12 @@
     "material": [ "dmbb_dragon_ice" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "leg_r", "leg_l", "torso", "arm_r", "arm_l" ],
-    "coverage": 100,
-    "encumbrance": 20,
     "warmth": 20,
     "material_thickness": 2,
     "environmental_protection": 1,
     "relic_data": { "passive_effects": [ { "id": "dmbb_dragon_ice_armor_ench" } ] },
-    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "leg_r", "leg_l", "torso", "arm_r", "arm_l" ], "encumbrance": 20 }
   },
   {
     "id": "dmbb_xlice_dragon_scale_suit",
@@ -529,8 +497,8 @@
     "description": "A massive full suit of ice dragon scale mail.  It comes with all the accoutrements that cover your torso, legs, and arms; sized to fit even the strangest of bodies.\n\nThis item has the following abilities when worn:\n\n<color_cyan>Ice Resistance (medium)</color>:\n<color_white>Decreases cold damage dealt on you by 12. Only affects covered body part(s).</color>",
     "weight": "6250 g",
     "volume": "18 L",
-    "encumbrance": 35,
-    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "RAINPROOF", "STURDY" ]
+    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "RAINPROOF", "STURDY" ],
+    "armor": { "encumbrance": 35 }
   },
   {
     "id": "dmbb_xlice_dragon_hide_suit",
@@ -540,8 +508,8 @@
     "description": "A massive full suit of ice dragonhide armor.  It comes with all the accoutrements that cover your torso, legs, and arms; sized to fit even the strangest of bodies.\n\nThis item has the following abilities when worn:\n\n<color_cyan>Ice Resistance (low)</color>:\n<color_white>Decreases cold damage dealt on you by 6. Only affects covered body part(s).</color>",
     "weight": "5500 g",
     "volume": "18 L",
-    "encumbrance": 30,
-    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "RAINPROOF", "STURDY" ]
+    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "RAINPROOF", "STURDY" ],
+    "armor": { "encumbrance": 30 }
   },
   {
     "id": "dmbb_dragon_storm_scale_gauntlets",
@@ -556,14 +524,12 @@
     "material": [ "dmbb_dragon_storm" ],
     "symbol": "[",
     "color": "light_blue",
-    "covers": [ "hand_r", "hand_l" ],
-    "coverage": 100,
-    "encumbrance": 20,
     "warmth": 20,
     "material_thickness": 3,
     "environmental_protection": 3,
     "relic_data": { "passive_effects": [ { "id": "dmbb_dragon_storm_armor_ench" } ] },
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "hand_r", "hand_l" ], "encumbrance": 20 }
   },
   {
     "id": "dmbb_dragon_storm_hide_gloves",
@@ -578,14 +544,12 @@
     "material": [ "dmbb_dragon_storm" ],
     "symbol": "[",
     "color": "light_blue",
-    "covers": [ "hand_r", "hand_l" ],
-    "coverage": 100,
-    "encumbrance": 10,
     "warmth": 20,
     "material_thickness": 2,
     "environmental_protection": 1,
     "relic_data": { "passive_effects": [ { "id": "dmbb_dragon_storm_armor_smol_ench" } ] },
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "hand_r", "hand_l" ], "encumbrance": 10 }
   },
   {
     "id": "dmbb_xlstorm_dragon_scale_gauntlets",
@@ -595,8 +559,8 @@
     "description": "A pair of heavy-duty gauntlets made of electric dragonscale that covers your hands, or whatever you use as hands.\n\nThis item has the following abilities when worn:\n\n<color_cyan>Electric Resistance (medium)</color>:\n<color_white>Decreases electric damage dealt on you by 12. Only affects covered body part(s).</color>",
     "weight": "680 g",
     "volume": "2 L",
-    "encumbrance": 30,
-    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "encumbrance": 30 }
   },
   {
     "id": "dmbb_xlstorm_dragon_hide_gloves",
@@ -606,8 +570,8 @@
     "description": "A pair of customized, Kevlar armored leather gloves, modified to be easy to wear while providing maximum protection under extreme conditions.  Sized to fit even the strangest of anatomy.\n\nThis item has the following abilities when worn:\n\n<color_cyan>Electric Resistance (low)</color>:\n<color_white>Decreases electric damage dealt on you by 6. Only affects covered body part(s).</color>",
     "weight": "430 g",
     "volume": "1500 ml",
-    "encumbrance": 20,
-    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "encumbrance": 20 }
   },
   {
     "id": "dmbb_dragon_storm_scale_boots",
@@ -623,14 +587,12 @@
     "material": [ "dmbb_dragon_storm" ],
     "symbol": "[",
     "color": "light_blue",
-    "covers": [ "foot_r", "foot_l" ],
-    "coverage": 100,
-    "encumbrance": 30,
     "warmth": 20,
     "material_thickness": 3,
     "environmental_protection": 3,
     "relic_data": { "passive_effects": [ { "id": "dmbb_dragon_storm_armor_ench" } ] },
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "foot_r", "foot_l" ], "encumbrance": 30 }
   },
   {
     "id": "dmbb_dragon_storm_hide_boots",
@@ -646,14 +608,12 @@
     "material": [ "dmbb_dragon_storm" ],
     "symbol": "[",
     "color": "light_blue",
-    "covers": [ "foot_r", "foot_l" ],
-    "coverage": 100,
-    "encumbrance": 20,
     "warmth": 20,
     "material_thickness": 2,
     "environmental_protection": 3,
     "relic_data": { "passive_effects": [ { "id": "dmbb_dragon_storm_armor_smol_ench" } ] },
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "foot_r", "foot_l" ], "encumbrance": 20 }
   },
   {
     "id": "dmbb_xlstorm_dragon_scale_boots",
@@ -663,8 +623,8 @@
     "description": "Massive boots made of electric dragonscale, modified to fit even the strangest of bodies.  Very protective, and surprisingly light.\n\nThis item has the following abilities when worn:\n\n<color_cyan>Electric Resistance (medium)</color>:\n<color_white>Decreases electric damage dealt on you by 12. Only affects covered body part(s).</color>",
     "weight": "1545 g",
     "volume": "6250 ml",
-    "encumbrance": 40,
-    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "encumbrance": 40 }
   },
   {
     "id": "dmbb_xlstorm_dragon_hide_boots",
@@ -674,8 +634,8 @@
     "description": "Massive boots made of electric dragonhide, modified to fit even the strangest of bodies.  Very protective, and surprisingly light.\n\nThis item has the following abilities when worn:\n\n<color_cyan>Electric Resistance (low)</color>:\n<color_white>Decreases electric damage dealt on you by 6. Only affects covered body part(s).</color>",
     "weight": "955 g",
     "volume": "6250 ml",
-    "encumbrance": 30,
-    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "encumbrance": 30 }
   },
   {
     "id": "dmbb_dragon_storm_scale_helmet",
@@ -691,15 +651,13 @@
     "material": [ "dmbb_dragon_storm" ],
     "symbol": "[",
     "color": "light_blue",
-    "covers": [ "head", "eyes", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 30,
     "warmth": 20,
     "material_thickness": 6,
     "environmental_protection": 3,
     "relic_data": { "passive_effects": [ { "id": "dmbb_dragon_storm_armor_ench" } ] },
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "head", "eyes", "mouth" ], "encumbrance": 30 }
   },
   {
     "id": "dmbb_dragon_storm_hide_helmet",
@@ -715,15 +673,13 @@
     "material": [ "dmbb_dragon_storm" ],
     "symbol": "[",
     "color": "light_blue",
-    "covers": [ "head" ],
-    "coverage": 100,
-    "encumbrance": 30,
     "warmth": 20,
     "material_thickness": 2,
     "environmental_protection": 1,
     "relic_data": { "passive_effects": [ { "id": "dmbb_dragon_storm_armor_smol_ench" } ] },
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "head" ], "encumbrance": 30 }
   },
   {
     "id": "dmbb_xlstorm_dragon_scale_helmet",
@@ -733,8 +689,8 @@
     "description": "A massive helmet made from electric dragonscale, held together with electric dragonhide.  It comes equipped with a full face visor and is large enough to fit even the strangest of heads.\n\nThis item has the following abilities when worn:\n\n<color_cyan>Electric Resistance (medium)</color>:\n<color_white>Decreases electric damage dealt on you by 12. Only affects covered body part(s).</color>",
     "weight": "1256 g",
     "volume": "4500 ml",
-    "encumbrance": 40,
-    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "encumbrance": 40 }
   },
   {
     "id": "dmbb_xlstorm_dragon_hide_helmet",
@@ -744,8 +700,8 @@
     "description": "A massive helmet made from electric dragonhide.  It protects your head well, and doesn't cover your face, but is large enough to fit even the strangest of heads.\n\nThis item has the following abilities when worn:\n\n<color_cyan>Electric Resistance (low)</color>:\n<color_white>Decreases electric damage dealt on you by 6. Only affects covered body part(s).</color>",
     "weight": "815 g",
     "volume": "4500 ml",
-    "encumbrance": 40,
-    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "encumbrance": 40 }
   },
   {
     "id": "dmbb_dragon_storm_scale_suit",
@@ -761,14 +717,12 @@
     "material": [ "dmbb_dragon_storm" ],
     "symbol": "[",
     "color": "light_blue",
-    "covers": [ "leg_r", "leg_l", "torso", "arm_r", "arm_l" ],
-    "coverage": 100,
-    "encumbrance": 25,
     "warmth": 20,
     "material_thickness": 6,
     "environmental_protection": 2,
     "relic_data": { "passive_effects": [ { "id": "dmbb_dragon_storm_armor_ench" } ] },
-    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "leg_r", "leg_l", "torso", "arm_r", "arm_l" ], "encumbrance": 25 }
   },
   {
     "id": "dmbb_dragon_storm_hide_suit",
@@ -784,14 +738,12 @@
     "material": [ "dmbb_dragon_storm" ],
     "symbol": "[",
     "color": "light_blue",
-    "covers": [ "leg_r", "leg_l", "torso", "arm_r", "arm_l" ],
-    "coverage": 100,
-    "encumbrance": 20,
     "warmth": 20,
     "material_thickness": 2,
     "environmental_protection": 1,
     "relic_data": { "passive_effects": [ { "id": "dmbb_dragon_storm_armor_ench" } ] },
-    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "leg_r", "leg_l", "torso", "arm_r", "arm_l" ], "encumbrance": 20 }
   },
   {
     "id": "dmbb_xlstorm_dragon_scale_suit",
@@ -801,8 +753,8 @@
     "description": "A massive full suit of electric dragon scale mail.  It comes with all the accoutrements that cover your torso, legs, and arms; sized to fit even the strangest of bodies.\n\nThis item has the following abilities when worn:\n\n<color_cyan>Electric Resistance (medium)</color>:\n<color_white>Decreases electric damage dealt on you by 12. Only affects covered body part(s).</color>",
     "weight": "6250 g",
     "volume": "18 L",
-    "encumbrance": 35,
-    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "RAINPROOF", "STURDY" ]
+    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "RAINPROOF", "STURDY" ],
+    "armor": { "encumbrance": 35 }
   },
   {
     "id": "dmbb_xlstorm_dragon_hide_suit",
@@ -812,7 +764,7 @@
     "description": "A massive full suit of electric dragonhide armor.  It comes with all the accoutrements that cover your torso, legs, and arms; sized to fit even the strangest of bodies.\n\nThis item has the following abilities when worn:\n\n<color_cyan>Electric Resistance (low)</color>:\n<color_white>Decreases electric damage dealt on you by 6. Only affects covered body part(s).</color>",
     "weight": "5500 g",
     "volume": "18 L",
-    "encumbrance": 30,
-    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "RAINPROOF", "STURDY" ]
+    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "RAINPROOF", "STURDY" ],
+    "armor": { "encumbrance": 30 }
   }
 ]

--- a/data/Unleash_The_Mods/mods/Fallout/Gunsmiths_Guru/items/clothing/armor.json
+++ b/data/Unleash_The_Mods/mods/Fallout/Gunsmiths_Guru/items/clothing/armor.json
@@ -12,9 +12,6 @@
     "material": [ "leather", "plastic" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 1,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "3 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "3 kg", "moves": 80 },
@@ -23,7 +20,8 @@
     ],
     "warmth": 15,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "POCKETS" ]
+    "flags": [ "VARSIZE", "POCKETS" ],
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 1 }
   },
   {
     "id": "jumpsuit_vault_13",
@@ -38,9 +36,6 @@
     "material": [ "leather", "plastic" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 0,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "3 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "3 kg", "moves": 80 },
@@ -49,7 +44,8 @@
     ],
     "warmth": 30,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "POCKETS" ]
+    "flags": [ "VARSIZE", "POCKETS" ],
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 0 }
   },
   {
     "id": "jumpsuit_vault_13_utility",
@@ -64,9 +60,6 @@
     "material": [ "leather", "plastic" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 0,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "3 L", "max_contains_weight": "5 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "3 L", "max_contains_weight": "5 kg", "moves": 80 },
@@ -75,7 +68,8 @@
     ],
     "warmth": 30,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "POCKETS" ]
+    "flags": [ "VARSIZE", "POCKETS" ],
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 0 }
   },
   {
     "id": "jumpsuit_vault_13_armored",
@@ -89,9 +83,6 @@
     "material": [ "leather", "plastic" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 2,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "3 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "3 kg", "moves": 80 },
@@ -100,7 +91,8 @@
     ],
     "warmth": 15,
     "material_thickness": 3,
-    "flags": [ "VARSIZE", "POCKETS" ]
+    "flags": [ "VARSIZE", "POCKETS" ],
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 2 }
   },
   {
     "id": "jumpsuit_xl_vault",
@@ -115,9 +107,6 @@
     "material": [ "leather", "plastic" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 2,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "3 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "3 kg", "moves": 80 },
@@ -126,7 +115,8 @@
     ],
     "warmth": 15,
     "material_thickness": 1,
-    "flags": [ "POCKETS", "OVERSIZE" ]
+    "flags": [ "POCKETS", "OVERSIZE" ],
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 2 }
   },
   {
     "id": "armor_wasteplate",
@@ -142,12 +132,10 @@
     "material": [ "steel", "leather" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 95,
-    "encumbrance": 15,
     "warmth": 20,
     "material_thickness": 4,
-    "flags": [ "VARSIZE", "OUTER", "STURDY", "STAB" ]
+    "flags": [ "VARSIZE", "OUTER", "STURDY", "STAB" ],
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 15 }
   },
   {
     "id": "helm_nullifier",
@@ -162,11 +150,9 @@
     "material": [ "iron" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "head" ],
-    "coverage": 5,
-    "encumbrance": 0,
     "material_thickness": 4,
-    "flags": [ "VARSIZE", "STURDY", "HELMET_COMPAT", "PSYSHIELD_PARTIAL" ]
+    "flags": [ "VARSIZE", "STURDY", "HELMET_COMPAT", "PSYSHIELD_PARTIAL" ],
+    "armor": { "coverage": 5, "covers": [ "head" ], "encumbrance": 0 }
   },
   {
     "id": "jacket_leather_tunnel",
@@ -181,9 +167,6 @@
     "symbol": "[",
     "looks_like": "jacket_windbreaker",
     "color": "dark_gray",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 90,
-    "encumbrance": 15,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1 kg", "moves": 60 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1 kg", "moves": 60 }
@@ -192,7 +175,8 @@
     "material_thickness": 5,
     "environmental_protection": 2,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "VARSIZE", "POCKETS", "OUTER" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 15 }
   },
   {
     "id": "jacket_leather_king",
@@ -207,9 +191,6 @@
     "symbol": "[",
     "looks_like": "jacket_windbreaker",
     "color": "dark_gray",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 90,
-    "encumbrance": 5,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1 kg", "moves": 60 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1 kg", "moves": 60 }
@@ -218,7 +199,8 @@
     "material_thickness": 3,
     "environmental_protection": 1,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "FANCY" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "FANCY" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 5 }
   },
   {
     "id": "jacket_leather_khan",
@@ -233,9 +215,6 @@
     "material": [ "leather" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "torso" ],
-    "coverage": 90,
-    "encumbrance": 10,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1 kg", "moves": 60 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1 kg", "moves": 60 }
@@ -244,7 +223,8 @@
     "material_thickness": 4,
     "environmental_protection": 1,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "VARSIZE", "POCKETS", "OUTER" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER" ],
+    "armor": { "coverage": 90, "covers": [ "torso" ], "encumbrance": 10 }
   },
   {
     "id": "jacket_leather_atomcat",
@@ -259,9 +239,6 @@
     "material": [ "leather" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 90,
-    "encumbrance": 20,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "3 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "3 kg", "moves": 80 }
@@ -270,7 +247,8 @@
     "material_thickness": 2,
     "environmental_protection": 1,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "FANCY" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "FANCY" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 20 }
   },
   {
     "id": "nightpants_naughty",
@@ -284,12 +262,10 @@
     "symbol": "[",
     "looks_like": "leggings",
     "color": "yellow",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 3,
     "warmth": 30,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r" ], "encumbrance": 3 }
   },
   {
     "id": "nightshirt_naughty",
@@ -303,12 +279,10 @@
     "symbol": "[",
     "looks_like": "longshirt",
     "color": "yellow",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 95,
-    "encumbrance": 3,
     "warmth": 30,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 3 }
   },
   {
     "id": "jumpsuit_china",
@@ -323,9 +297,6 @@
     "symbol": "[",
     "looks_like": "touring_suit",
     "color": "green",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 2,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "3 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "3 kg", "moves": 80 },
@@ -334,7 +305,8 @@
     ],
     "warmth": 15,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "POCKETS" ]
+    "flags": [ "VARSIZE", "POCKETS" ],
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 2 }
   },
   {
     "id": "jumpsuit_racer",
@@ -348,9 +320,6 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "red",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 2,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "3 L", "max_contains_weight": "4 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "3 L", "max_contains_weight": "4 kg", "moves": 80 },
@@ -359,7 +328,8 @@
     ],
     "warmth": 15,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "POCKETS" ]
+    "flags": [ "VARSIZE", "POCKETS" ],
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 2 }
   },
   {
     "id": "jumpsuit_enclave",
@@ -374,9 +344,6 @@
     "symbol": "[",
     "looks_like": "touring_suit",
     "color": "yellow",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 2,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "3 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "3 kg", "moves": 80 },
@@ -386,7 +353,8 @@
     "warmth": 5,
     "material_thickness": 2,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "VARSIZE", "POCKETS" ]
+    "flags": [ "VARSIZE", "POCKETS" ],
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 2 }
   },
   {
     "id": "winter_jacket_enclave",
@@ -400,9 +368,6 @@
     "symbol": "[",
     "looks_like": "coat_winter",
     "color": "brown",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 95,
-    "encumbrance": 10,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1750 ml", "max_contains_weight": "3 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1750 ml", "max_contains_weight": "3 kg", "moves": 80 }
@@ -410,7 +375,8 @@
     "warmth": 50,
     "material_thickness": 5,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "VARSIZE", "POCKETS", "HOOD", "OUTER", "WATERPROOF" ]
+    "flags": [ "VARSIZE", "POCKETS", "HOOD", "OUTER", "WATERPROOF" ],
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 10 }
   },
   {
     "id": "winter_pants_enclave",
@@ -424,9 +390,6 @@
     "symbol": "[",
     "looks_like": "pants_army",
     "color": "brown",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 11,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "2 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "2 kg", "moves": 80 }
@@ -434,7 +397,8 @@
     "warmth": 50,
     "material_thickness": 5,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "VARSIZE", "POCKETS", "WATERPROOF", "OUTER" ]
+    "flags": [ "VARSIZE", "POCKETS", "WATERPROOF", "OUTER" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r" ], "encumbrance": 11 }
   },
   {
     "id": "hat_enclave",
@@ -448,13 +412,11 @@
     "symbol": "[",
     "looks_like": "hat_cotton",
     "color": "black",
-    "covers": [ "head" ],
-    "coverage": 50,
-    "encumbrance": 10,
     "warmth": 5,
     "material_thickness": 1,
     "environmental_protection": 2,
-    "flags": [ "SUN_GLASSES" ]
+    "flags": [ "SUN_GLASSES" ],
+    "armor": { "coverage": 50, "covers": [ "head" ], "encumbrance": 10 }
   },
   {
     "id": "duster_minutemen",
@@ -469,9 +431,6 @@
     "material": [ "leather" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 90,
-    "encumbrance": 17,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "3 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "3 kg", "moves": 80 },
@@ -482,7 +441,8 @@
     "material_thickness": 4,
     "environmental_protection": 2,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "WATERPROOF", "RAINPROOF" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "WATERPROOF", "RAINPROOF" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 17 }
   },
   {
     "id": "duster_minutemen_general",
@@ -497,9 +457,6 @@
     "material": [ "leather", "kevlar" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 12,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "4 L", "max_contains_weight": "5 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "4 L", "max_contains_weight": "5 kg", "moves": 80 },
@@ -510,7 +467,8 @@
     "material_thickness": 12,
     "environmental_protection": 4,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "WATERPROOF", "RAINPROOF", "FANCY" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "WATERPROOF", "RAINPROOF", "FANCY" ],
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 12 }
   },
   {
     "id": "coat_frock_red",
@@ -525,9 +483,6 @@
     "material": [ "leather" ],
     "symbol": "[",
     "color": "red",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 90,
-    "encumbrance": 17,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "5 L", "max_contains_weight": "7 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "5 L", "max_contains_weight": "7 kg", "moves": 80 },
@@ -538,7 +493,8 @@
     "material_thickness": 3,
     "environmental_protection": 1,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "WATERPROOF", "RAINPROOF", "FANCY" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "WATERPROOF", "RAINPROOF", "FANCY" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 17 }
   },
   {
     "id": "trenchcoat_general_green",
@@ -553,9 +509,6 @@
     "material": [ "leather" ],
     "symbol": "[",
     "color": "green",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 90,
-    "encumbrance": 17,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "3500 g", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "3500 g", "moves": 80 },
@@ -566,7 +519,8 @@
     "material_thickness": 3,
     "environmental_protection": 1,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "FANCY" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "FANCY" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 17 }
   },
   {
     "id": "trenchcoat_general_white",
@@ -581,9 +535,6 @@
     "material": [ "leather" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 90,
-    "encumbrance": 17,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "3500 g", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "3500 g", "moves": 80 },
@@ -594,7 +545,8 @@
     "material_thickness": 3,
     "environmental_protection": 1,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "FANCY" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "FANCY" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 17 }
   },
   {
     "id": "trenchcoat_general_black",
@@ -609,9 +561,6 @@
     "material": [ "leather" ],
     "symbol": "[",
     "color": "black",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 90,
-    "encumbrance": 17,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "3500 g", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "3500 g", "moves": 80 },
@@ -622,7 +571,8 @@
     "material_thickness": 5,
     "environmental_protection": 3,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "FANCY" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "FANCY" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 17 }
   },
   {
     "id": "cathedralrobe",
@@ -637,13 +587,15 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "torso", "head", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r" ],
-    "coverage": 65,
-    "encumbrance": 3,
     "warmth": 25,
     "material_thickness": 7,
     "environmental_protection": 5,
-    "flags": [ "OVERSIZE", "OUTER", "HELMET_COMPAT", "FANCY" ]
+    "flags": [ "OVERSIZE", "OUTER", "HELMET_COMPAT", "FANCY" ],
+    "armor": {
+      "coverage": 65,
+      "covers": [ "torso", "head", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r" ],
+      "encumbrance": 3
+    }
   },
   {
     "id": "hat_general_green",
@@ -657,13 +609,11 @@
     "symbol": "[",
     "looks_like": "hat_cotton",
     "color": "green",
-    "covers": [ "head" ],
-    "coverage": 50,
-    "encumbrance": 10,
     "warmth": 5,
     "material_thickness": 1,
     "environmental_protection": 2,
-    "flags": [ "SUN_GLASSES", "FANCY" ]
+    "flags": [ "SUN_GLASSES", "FANCY" ],
+    "armor": { "coverage": 50, "covers": [ "head" ], "encumbrance": 10 }
   },
   {
     "id": "hat_general_white",
@@ -677,13 +627,11 @@
     "symbol": "[",
     "looks_like": "hat_cotton",
     "color": "white",
-    "covers": [ "head" ],
-    "coverage": 50,
-    "encumbrance": 10,
     "warmth": 15,
     "material_thickness": 1,
     "environmental_protection": 2,
-    "flags": [ "SUN_GLASSES", "FANCY" ]
+    "flags": [ "SUN_GLASSES", "FANCY" ],
+    "armor": { "coverage": 50, "covers": [ "head" ], "encumbrance": 10 }
   },
   {
     "id": "hat_general_black",
@@ -697,13 +645,11 @@
     "symbol": "[",
     "looks_like": "hat_cotton",
     "color": "green",
-    "covers": [ "head" ],
-    "coverage": 50,
-    "encumbrance": 10,
     "warmth": 5,
     "material_thickness": 1,
     "environmental_protection": 2,
-    "flags": [ "SUN_GLASSES", "FANCY" ]
+    "flags": [ "SUN_GLASSES", "FANCY" ],
+    "armor": { "coverage": 50, "covers": [ "head" ], "encumbrance": 10 }
   },
   {
     "id": "wastehound_mask",
@@ -718,14 +664,12 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "head", "eyes", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 30,
     "warmth": 30,
     "material_thickness": 5,
     "environmental_protection": 3,
     "qualities": [ [ "GLARE", 1 ] ],
-    "flags": [ "VARSIZE", "SKINTIGHT", "SUN_GLASSES" ]
+    "flags": [ "VARSIZE", "SKINTIGHT", "SUN_GLASSES" ],
+    "armor": { "coverage": 100, "covers": [ "head", "eyes", "mouth" ], "encumbrance": 30 }
   },
   {
     "id": "helmet_biker_retro",
@@ -742,13 +686,11 @@
     "symbol": "[",
     "looks_like": "hat_hard",
     "color": "green",
-    "covers": [ "head" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "warmth": 20,
     "material_thickness": 5,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 95, "covers": [ "head" ], "encumbrance": 20 }
   },
   {
     "id": "hat_peoples",
@@ -762,11 +704,9 @@
     "symbol": "[",
     "looks_like": "hat_knit",
     "color": "brown",
-    "covers": [ "head" ],
-    "coverage": 95,
-    "encumbrance": 10,
     "warmth": 70,
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 95, "covers": [ "head" ], "encumbrance": 10 }
   },
   {
     "id": "mask_pint",
@@ -783,13 +723,11 @@
     "symbol": "[",
     "looks_like": "glasses_safety",
     "color": "white",
-    "covers": [ "mouth", "eyes" ],
-    "coverage": 100,
-    "encumbrance": 30,
     "warmth": 5,
     "material_thickness": 1,
     "environmental_protection": 1,
-    "flags": [ "STURDY" ]
+    "flags": [ "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "mouth", "eyes" ], "encumbrance": 30 }
   },
   {
     "id": "mask_pint_magic",
@@ -806,13 +744,11 @@
     "material": [ "paper" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "mouth", "eyes" ],
-    "coverage": 100,
-    "encumbrance": 5,
     "warmth": 5,
     "material_thickness": 20,
     "environmental_protection": 5,
-    "flags": [ "WATER_FRIENDLY", "STURDY" ]
+    "flags": [ "WATER_FRIENDLY", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "mouth", "eyes" ], "encumbrance": 5 }
   },
   {
     "id": "suit_benny",
@@ -827,16 +763,14 @@
     "symbol": "[",
     "looks_like": "jumpsuit",
     "color": "light_gray",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 15,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1 L", "max_contains_weight": "2 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1 L", "max_contains_weight": "2 kg", "moves": 80 }
     ],
     "warmth": 25,
     "material_thickness": 4,
-    "flags": [ "VARSIZE", "FANCY", "POCKETS" ]
+    "flags": [ "VARSIZE", "FANCY", "POCKETS" ],
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 15 }
   },
   {
     "id": "jacket_boomer",
@@ -851,9 +785,6 @@
     "material": [ "leather" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 90,
-    "encumbrance": 15,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1 kg", "moves": 80 }
@@ -862,7 +793,8 @@
     "material_thickness": 3,
     "environmental_protection": 1,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "FANCY" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "FANCY" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 15 }
   },
   {
     "id": "scrubs_bigmt",
@@ -875,13 +807,11 @@
     "material": [ "plastic" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 100,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 1,
     "environmental_protection": 10,
-    "flags": [ "VARSIZE", "WATERPROOF", "HOOD", "RAINPROOF", "RAD_RESIST", "OUTER" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "HOOD", "RAINPROOF", "RAD_RESIST", "OUTER" ],
+    "armor": { "coverage": 100, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 25 }
   },
   {
     "id": "dress_shirt_NCR",
@@ -895,13 +825,11 @@
     "symbol": "[",
     "looks_like": "longshirt",
     "color": "brown",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 90,
-    "encumbrance": 5,
     "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "250 ml", "max_contains_weight": "500 g", "moves": 80 } ],
     "warmth": 10,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 5 }
   },
   {
     "id": "jeans_ncr",
@@ -916,16 +844,14 @@
     "symbol": "[",
     "looks_like": "pants",
     "color": "brown",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 16,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1 kg", "moves": 80 }
     ],
     "warmth": 10,
     "material_thickness": 3,
-    "flags": [ "VARSIZE", "POCKETS" ]
+    "flags": [ "VARSIZE", "POCKETS" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r" ], "encumbrance": 16 }
   },
   {
     "id": "ncr_armor",
@@ -940,9 +866,6 @@
     "symbol": "[",
     "looks_like": "jacket_leather",
     "color": "dark_gray",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 30,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "250 ml", "max_contains_weight": "750 g", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "250 ml", "max_contains_weight": "750 g", "moves": 80 }
@@ -950,7 +873,8 @@
     "warmth": 35,
     "material_thickness": 4,
     "environmental_protection": 5,
-    "flags": [ "VARSIZE", "RAINPROOF" ]
+    "flags": [ "VARSIZE", "RAINPROOF" ],
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 30 }
   },
   {
     "id": "armor_legate",
@@ -967,12 +891,10 @@
     "symbol": "[",
     "looks_like": "armor_larmor",
     "color": "brown",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "warmth": 20,
     "material_thickness": 4,
-    "flags": [ "VARSIZE", "OUTER", "STURDY", "FANCY" ]
+    "flags": [ "VARSIZE", "OUTER", "STURDY", "FANCY" ],
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 20 }
   },
   {
     "id": "helmet_legate",
@@ -988,14 +910,12 @@
     "symbol": "[",
     "looks_like": "helmet_barbute",
     "color": "brown",
-    "covers": [ "head", "eyes", "mouth" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "warmth": 25,
     "material_thickness": 4,
     "environmental_protection": 1,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "STURDY", "FANCY" ]
+    "flags": [ "STURDY", "FANCY" ],
+    "armor": { "coverage": 95, "covers": [ "head", "eyes", "mouth" ], "encumbrance": 20 }
   },
   {
     "id": "hazmat_suit_ghost",
@@ -1009,13 +929,15 @@
     "symbol": "[",
     "looks_like": "beekeeping_suit",
     "color": "brown",
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 50,
     "warmth": 40,
     "material_thickness": 8,
     "environmental_protection": 20,
-    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "GAS_PROOF", "RAD_PROOF", "ELECTRIC_IMMUNE", "OUTER" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "GAS_PROOF", "RAD_PROOF", "ELECTRIC_IMMUNE", "OUTER" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 50
+    }
   },
   {
     "id": "beret_recon",
@@ -1029,11 +951,10 @@
     "symbol": "[",
     "looks_like": "hat_cotton",
     "color": "red",
-    "covers": [ "head" ],
-    "coverage": 40,
     "warmth": 10,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "WATER_FRIENDLY", "FANCY" ]
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "FANCY" ],
+    "armor": { "coverage": 40, "covers": [ "head" ] }
   },
   {
     "id": "helmet_fiend",
@@ -1049,12 +970,10 @@
     "symbol": "[",
     "looks_like": "helmet_bike",
     "color": "white",
-    "covers": [ "head" ],
-    "coverage": 65,
-    "encumbrance": 20,
     "warmth": 10,
     "material_thickness": 4,
-    "techniques": [ "WBLOCK_1" ]
+    "techniques": [ "WBLOCK_1" ],
+    "armor": { "coverage": 65, "covers": [ "head" ], "encumbrance": 20 }
   },
   {
     "id": "jacket_db_varsity",
@@ -1068,16 +987,14 @@
     "symbol": "[",
     "looks_like": "jacket_windbreaker",
     "color": "green",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 90,
-    "encumbrance": 8,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1 kg", "moves": 80 }
     ],
     "warmth": 15,
     "material_thickness": 3,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "FANCY" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "FANCY" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 8 }
   },
   {
     "id": "armor_combat_light",
@@ -1095,9 +1012,6 @@
     "symbol": "[",
     "looks_like": "kevlar",
     "color": "green",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 85,
-    "encumbrance": 15,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "4 L", "max_contains_weight": "6 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "4 L", "max_contains_weight": "6 kg", "moves": 80 },
@@ -1106,7 +1020,8 @@
     ],
     "warmth": 10,
     "material_thickness": 6,
-    "flags": [ "STURDY", "WATERPROOF", "RAINPROOF", "POCKETS", "OUTER" ]
+    "flags": [ "STURDY", "WATERPROOF", "RAINPROOF", "POCKETS", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 15 }
   },
   {
     "id": "armor_combat_light_winter",
@@ -1124,9 +1039,6 @@
     "symbol": "[",
     "looks_like": "kevlar",
     "color": "green",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 85,
-    "encumbrance": 25,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "4 L", "max_contains_weight": "6 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "4 L", "max_contains_weight": "6 kg", "moves": 80 },
@@ -1135,7 +1047,8 @@
     ],
     "warmth": 30,
     "material_thickness": 6,
-    "flags": [ "STURDY", "WATERPROOF", "RAINPROOF", "POCKETS", "OUTER" ]
+    "flags": [ "STURDY", "WATERPROOF", "RAINPROOF", "POCKETS", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 25 }
   },
   {
     "id": "armor_combat_light_winter_medic",
@@ -1153,9 +1066,6 @@
     "material": [ "plastic", "cotton", "kevlar" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 85,
-    "encumbrance": 20,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "4 L", "max_contains_weight": "6 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "4 L", "max_contains_weight": "6 kg", "moves": 80 },
@@ -1164,7 +1074,8 @@
     ],
     "warmth": 30,
     "material_thickness": 5,
-    "flags": [ "STURDY", "WATERPROOF", "RAINPROOF", "POCKETS", "OUTER" ]
+    "flags": [ "STURDY", "WATERPROOF", "RAINPROOF", "POCKETS", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 20 }
   },
   {
     "id": "helmet_combat_light",
@@ -1182,13 +1093,11 @@
     "symbol": "[",
     "looks_like": "hat_hard",
     "color": "green",
-    "covers": [ "head" ],
-    "coverage": 85,
-    "encumbrance": 25,
     "warmth": 20,
     "material_thickness": 10,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 85, "covers": [ "head" ], "encumbrance": 25 }
   },
   {
     "id": "helmet_combat_light_winter",
@@ -1206,13 +1115,11 @@
     "symbol": "[",
     "looks_like": "hat_hard",
     "color": "white",
-    "covers": [ "head" ],
-    "coverage": 85,
-    "encumbrance": 25,
     "warmth": 25,
     "material_thickness": 10,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 85, "covers": [ "head" ], "encumbrance": 25 }
   },
   {
     "id": "balclava_winter",
@@ -1226,11 +1133,9 @@
     "symbol": "[",
     "looks_like": "balaclava",
     "color": "white",
-    "covers": [ "head", "mouth" ],
-    "coverage": 95,
-    "encumbrance": 10,
     "warmth": 30,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "SKINTIGHT" ]
+    "flags": [ "VARSIZE", "SKINTIGHT" ],
+    "armor": { "coverage": 95, "covers": [ "head", "mouth" ], "encumbrance": 10 }
   }
 ]

--- a/data/Unleash_The_Mods/mods/Fallout/Gunsmiths_Guru/items/clothing/armor_gecko.json
+++ b/data/Unleash_The_Mods/mods/Fallout/Gunsmiths_Guru/items/clothing/armor_gecko.json
@@ -14,13 +14,11 @@
     "symbol": "[",
     "looks_like": "dress_shoes",
     "color": "dark_gray",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 5,
     "warmth": 20,
     "material_thickness": 3,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "WATERPROOF" ]
+    "flags": [ "VARSIZE", "WATERPROOF" ],
+    "armor": { "coverage": 100, "covers": [ "foot_l", "foot_r" ], "encumbrance": 5 }
   },
   {
     "id": "boots_gecko_gold",
@@ -37,13 +35,11 @@
     "symbol": "[",
     "looks_like": "dress_shoes",
     "color": "dark_gray",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 5,
     "warmth": 20,
     "material_thickness": 3,
     "environmental_protection": 3,
-    "flags": [ "VARSIZE", "WATERPROOF", "FANCY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "FANCY" ],
+    "armor": { "coverage": 100, "covers": [ "foot_l", "foot_r" ], "encumbrance": 5 }
   },
   {
     "id": "gloves_leather_gecko",
@@ -58,13 +54,11 @@
     "symbol": "[",
     "looks_like": "gloves_light",
     "color": "light_gray",
-    "covers": [ "hand_l", "hand_r" ],
-    "coverage": 100,
-    "encumbrance": 5,
     "warmth": 25,
     "material_thickness": 1,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "VARSIZE", "WATERPROOF" ]
+    "flags": [ "VARSIZE", "WATERPROOF" ],
+    "armor": { "coverage": 100, "covers": [ "hand_l", "hand_r" ], "encumbrance": 5 }
   },
   {
     "id": "gloves_leather_gecko_gold",
@@ -79,13 +73,11 @@
     "symbol": "[",
     "looks_like": "gloves_light",
     "color": "yellow",
-    "covers": [ "hand_l", "hand_r" ],
-    "coverage": 100,
-    "encumbrance": 5,
     "warmth": 25,
     "material_thickness": 1,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "VARSIZE", "WATERPROOF", "FANCY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "FANCY" ],
+    "armor": { "coverage": 100, "covers": [ "hand_l", "hand_r" ], "encumbrance": 5 }
   },
   {
     "id": "backpack_leather_gecko",
@@ -101,10 +93,6 @@
     "symbol": "[",
     "looks_like": "backpack",
     "color": "light_gray",
-    "covers": [ "torso" ],
-    "coverage": 30,
-    "encumbrance": 2,
-    "max_encumbrance": 10,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "8 L", "max_contains_weight": "12 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "8 L", "max_contains_weight": "12 kg", "moves": 80 },
@@ -115,7 +103,8 @@
     ],
     "warmth": 9,
     "material_thickness": 3,
-    "flags": [ "BELTED", "WATER_FRIENDLY" ]
+    "flags": [ "BELTED", "WATER_FRIENDLY" ],
+    "armor": { "coverage": 30, "covers": [ "torso" ], "encumbrance": [ 2, 10 ] }
   },
   {
     "id": "backpack_leather_gecko_gold",
@@ -131,10 +120,6 @@
     "symbol": "[",
     "looks_like": "backpack",
     "color": "yellow",
-    "covers": [ "torso" ],
-    "coverage": 30,
-    "encumbrance": 2,
-    "max_encumbrance": 10,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "10 L", "max_contains_weight": "15 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "10 L", "max_contains_weight": "15 kg", "moves": 80 },
@@ -145,7 +130,8 @@
     ],
     "warmth": 9,
     "material_thickness": 3,
-    "flags": [ "BELTED", "WATER_FRIENDLY", "FANCY" ]
+    "flags": [ "BELTED", "WATER_FRIENDLY", "FANCY" ],
+    "armor": { "coverage": 30, "covers": [ "torso" ], "encumbrance": [ 2, 10 ] }
   },
   {
     "id": "armguard_leather_gecko",
@@ -161,13 +147,11 @@
     "symbol": "[",
     "looks_like": "arm_warmers",
     "color": "light_gray",
-    "covers": [ "arm_l", "arm_r" ],
-    "coverage": 90,
-    "encumbrance": 5,
     "warmth": 25,
     "material_thickness": 4,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "STURDY", "BELTED", "BLOCK_WHILE_WORN", "WATER_FRIENDLY" ]
+    "flags": [ "STURDY", "BELTED", "BLOCK_WHILE_WORN", "WATER_FRIENDLY" ],
+    "armor": { "coverage": 90, "covers": [ "arm_l", "arm_r" ], "encumbrance": 5 }
   },
   {
     "id": "armguard_leather_gecko_gold",
@@ -183,13 +167,11 @@
     "symbol": "[",
     "looks_like": "arm_warmers",
     "color": "yellow",
-    "covers": [ "arm_l", "arm_r" ],
-    "coverage": 10,
-    "encumbrance": 5,
     "warmth": 25,
     "material_thickness": 4,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "STURDY", "BELTED", "BLOCK_WHILE_WORN", "WATER_FRIENDLY", "FANCY" ]
+    "flags": [ "STURDY", "BELTED", "BLOCK_WHILE_WORN", "WATER_FRIENDLY", "FANCY" ],
+    "armor": { "coverage": 10, "covers": [ "arm_l", "arm_r" ], "encumbrance": 5 }
   },
   {
     "id": "armor_leather_gecko",
@@ -206,9 +188,6 @@
     "symbol": "[",
     "looks_like": "armor_larmor",
     "color": "light_gray",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 90,
-    "encumbrance": 22,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "3 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "3 kg", "moves": 80 },
@@ -218,7 +197,8 @@
     "warmth": 20,
     "material_thickness": 5,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "VARSIZE", "POCKETS", "STURDY" ]
+    "flags": [ "VARSIZE", "POCKETS", "STURDY" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 22 }
   },
   {
     "id": "armor_leather_gecko_gold",
@@ -235,9 +215,6 @@
     "symbol": "[",
     "looks_like": "armor_larmor",
     "color": "light_gray",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 100,
-    "encumbrance": 22,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "3 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "3 kg", "moves": 80 },
@@ -247,7 +224,8 @@
     "warmth": 20,
     "material_thickness": 5,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "VARSIZE", "POCKETS", "STURDY", "FANCY" ]
+    "flags": [ "VARSIZE", "POCKETS", "STURDY", "FANCY" ],
+    "armor": { "coverage": 100, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 22 }
   },
   {
     "id": "mask_gecko",
@@ -262,9 +240,6 @@
     "material": [ "leather_gecko" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "mouth", "eyes", "head" ],
-    "coverage": 100,
-    "encumbrance": 100,
     "warmth": 20,
     "material_thickness": 2,
     "environmental_protection": 1,
@@ -274,7 +249,8 @@
     "ammo": [ "gasfilter_m" ],
     "use_action": "GASMASK",
     "qualities": [ [ "GLARE", 2 ] ],
-    "flags": [ "SUN_GLASSES", "STURDY" ]
+    "flags": [ "SUN_GLASSES", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "mouth", "eyes", "head" ], "encumbrance": 100 }
   },
   {
     "id": "mask_gecko_gold",
@@ -289,9 +265,6 @@
     "material": [ "leather_gecko" ],
     "symbol": "[",
     "color": "yellow",
-    "covers": [ "mouth", "eyes", "head" ],
-    "coverage": 100,
-    "encumbrance": 100,
     "warmth": 20,
     "material_thickness": 2,
     "environmental_protection": 1,
@@ -301,7 +274,8 @@
     "ammo": [ "gasfilter_m" ],
     "use_action": "GASMASK",
     "qualities": [ [ "GLARE", 2 ] ],
-    "flags": [ "SUN_GLASSES", "STURDY", "FANCY" ]
+    "flags": [ "SUN_GLASSES", "STURDY", "FANCY" ],
+    "armor": { "coverage": 100, "covers": [ "mouth", "eyes", "head" ], "encumbrance": 100 }
   },
   {
     "id": "duster_leather_gecko",
@@ -316,9 +290,6 @@
     "symbol": "[",
     "looks_like": "duster",
     "color": "light_gray",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 90,
-    "encumbrance": 17,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "3 L", "max_contains_weight": "5 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "3 L", "max_contains_weight": "5 kg", "moves": 80 },
@@ -329,7 +300,8 @@
     "material_thickness": 3,
     "environmental_protection": 1,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "WATERPROOF", "RAINPROOF" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "WATERPROOF", "RAINPROOF" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 17 }
   },
   {
     "id": "duster_leather_gecko_gold",
@@ -344,9 +316,6 @@
     "symbol": "[",
     "looks_like": "duster",
     "color": "yellow",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 90,
-    "encumbrance": 17,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "3 L", "max_contains_weight": "5 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "3 L", "max_contains_weight": "5 kg", "moves": 80 },
@@ -357,6 +326,7 @@
     "material_thickness": 3,
     "environmental_protection": 1,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "WATERPROOF", "RAINPROOF", "FANCY" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "WATERPROOF", "RAINPROOF", "FANCY" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 17 }
   }
 ]

--- a/data/Unleash_The_Mods/mods/Fallout/Gunsmiths_Guru/items/clothing/armor_legion.json
+++ b/data/Unleash_The_Mods/mods/Fallout/Gunsmiths_Guru/items/clothing/armor_legion.json
@@ -13,16 +13,14 @@
     "symbol": "[",
     "looks_like": "chestguard_hard",
     "color": "red",
-    "covers": [ "torso", "leg_l", "leg_r" ],
-    "coverage": 45,
-    "encumbrance": 25,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "750 ml", "max_contains_weight": "1500 g", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "750 ml", "max_contains_weight": "1500 g", "moves": 80 }
     ],
     "warmth": 10,
     "material_thickness": 6,
-    "flags": [ "VARSIZE", "STURDY" ]
+    "flags": [ "VARSIZE", "STURDY" ],
+    "armor": { "coverage": 45, "covers": [ "torso", "leg_l", "leg_r" ], "encumbrance": 25 }
   },
   {
     "id": "helmet_legion_recruit",
@@ -40,14 +38,12 @@
     "symbol": "[",
     "looks_like": "hat_hard",
     "color": "blue",
-    "covers": [ "head" ],
-    "coverage": 95,
-    "encumbrance": 10,
     "warmth": 15,
     "material_thickness": 3,
     "environmental_protection": 1,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "STURDY" ]
+    "flags": [ "STURDY" ],
+    "armor": { "coverage": 95, "covers": [ "head" ], "encumbrance": 10 }
   },
   {
     "id": "armor_legion_prime",
@@ -63,16 +59,14 @@
     "symbol": "[",
     "looks_like": "chestguard_hard",
     "color": "red",
-    "covers": [ "torso", "leg_l", "leg_r" ],
-    "coverage": 45,
-    "encumbrance": 30,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1 L", "max_contains_weight": "2 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1 L", "max_contains_weight": "2 kg", "moves": 80 }
     ],
     "warmth": 10,
     "material_thickness": 7,
-    "flags": [ "VARSIZE", "STURDY" ]
+    "flags": [ "VARSIZE", "STURDY" ],
+    "armor": { "coverage": 45, "covers": [ "torso", "leg_l", "leg_r" ], "encumbrance": 30 }
   },
   {
     "id": "helmet_legion_prime",
@@ -90,14 +84,12 @@
     "symbol": "[",
     "looks_like": "hat_hard",
     "color": "blue",
-    "covers": [ "head" ],
-    "coverage": 95,
-    "encumbrance": 10,
     "warmth": 15,
     "material_thickness": 4,
     "environmental_protection": 1,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "STURDY" ]
+    "flags": [ "STURDY" ],
+    "armor": { "coverage": 95, "covers": [ "head" ], "encumbrance": 10 }
   },
   {
     "id": "armor_legion_veteran",
@@ -113,16 +105,14 @@
     "symbol": "[",
     "looks_like": "chestguard_hard",
     "color": "red",
-    "covers": [ "torso", "leg_l", "leg_r" ],
-    "coverage": 45,
-    "encumbrance": 35,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "2 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "2 kg", "moves": 80 }
     ],
     "warmth": 10,
     "material_thickness": 8,
-    "flags": [ "VARSIZE", "STURDY" ]
+    "flags": [ "VARSIZE", "STURDY" ],
+    "armor": { "coverage": 45, "covers": [ "torso", "leg_l", "leg_r" ], "encumbrance": 35 }
   },
   {
     "id": "helmet_legion_veteran",
@@ -140,13 +130,11 @@
     "symbol": "[",
     "looks_like": "hat_hard",
     "color": "white",
-    "covers": [ "head" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "warmth": 15,
     "material_thickness": 5,
     "environmental_protection": 1,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "STURDY" ]
+    "flags": [ "STURDY" ],
+    "armor": { "coverage": 95, "covers": [ "head" ], "encumbrance": 20 }
   }
 ]

--- a/data/Unleash_The_Mods/mods/Fallout/Gunsmiths_Guru/items/clothing/armor_power.json
+++ b/data/Unleash_The_Mods/mods/Fallout/Gunsmiths_Guru/items/clothing/armor_power.json
@@ -13,9 +13,6 @@
     "material": [ "steel" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 30,
     "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "5 kg", "moves": 80 } ],
     "warmth": 90,
     "power_armor": true,
@@ -23,7 +20,12 @@
     "environmental_protection": 15,
     "ammo": [ "battery" ],
     "use_action": { "type": "transform", "msg": "The %s engages.", "target": "power_armor_t51_on", "active": true },
-    "flags": [ "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE" ]
+    "flags": [ "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 30
+    }
   },
   {
     "id": "power_armor_t51_on",
@@ -37,7 +39,7 @@
     "power_draw": 4000000,
     "revert_to": "power_armor_t51",
     "use_action": { "type": "transform", "menu_text": "Turn off", "msg": "The %s armor disengages.", "target": "power_armor_t51" },
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
+    "armor": { "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ] }
   },
   {
     "id": "power_armor_helmet_t51",
@@ -53,15 +55,13 @@
     "material": [ "steel" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "head", "eyes", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 30,
     "warmth": 90,
     "power_armor": true,
     "material_thickness": 15,
     "environmental_protection": 15,
     "qualities": [ [ "GLARE", 2 ] ],
-    "flags": [ "WATCH", "WATERPROOF", "STURDY", "PARTIAL_DEAF", "THERMOMETER", "SUN_GLASSES" ]
+    "flags": [ "WATCH", "WATERPROOF", "STURDY", "PARTIAL_DEAF", "THERMOMETER", "SUN_GLASSES" ],
+    "armor": { "coverage": 100, "covers": [ "head", "eyes", "mouth" ], "encumbrance": 30 }
   },
   {
     "id": "power_armor_t45",
@@ -77,16 +77,18 @@
     "material": [ "hardsteel", "steel" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 80,
     "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "4 L", "max_contains_weight": "5 kg", "moves": 80 } ],
     "warmth": 60,
     "power_armor": true,
     "material_thickness": 10,
     "environmental_protection": 16,
     "use_action": { "type": "transform", "msg": "The %s engages.", "target": "power_armor_t45_on", "active": true },
-    "flags": [ "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE" ]
+    "flags": [ "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 80
+    }
   },
   {
     "id": "power_armor_t45_on",
@@ -100,7 +102,7 @@
     "power_draw": 4000000,
     "revert_to": "power_armor_t45",
     "use_action": { "type": "transform", "menu_text": "Turn off", "msg": "The %s armor disengages.", "target": "power_armor_t45" },
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
+    "armor": { "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ] }
   },
   {
     "id": "power_armor_helmet_t45",
@@ -116,15 +118,13 @@
     "material": [ "hardsteel", "steel" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "head", "eyes", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 80,
     "warmth": 60,
     "power_armor": true,
     "material_thickness": 10,
     "environmental_protection": 16,
     "qualities": [ [ "GLARE", 2 ] ],
-    "flags": [ "WATCH", "WATERPROOF", "STURDY", "PARTIAL_DEAF", "THERMOMETER", "SUN_GLASSES" ]
+    "flags": [ "WATCH", "WATERPROOF", "STURDY", "PARTIAL_DEAF", "THERMOMETER", "SUN_GLASSES" ],
+    "armor": { "coverage": 100, "covers": [ "head", "eyes", "mouth" ], "encumbrance": 80 }
   },
   {
     "id": "power_armor_x01",
@@ -140,16 +140,18 @@
     "material": [ "ceramic", "superalloy" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 30,
     "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "4 kg", "moves": 80 } ],
     "warmth": 90,
     "power_armor": true,
     "material_thickness": 15,
     "environmental_protection": 35,
     "use_action": { "type": "transform", "msg": "The %s engages.", "target": "power_armor_x01_on", "active": true },
-    "flags": [ "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE" ]
+    "flags": [ "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 30
+    }
   },
   {
     "id": "power_armor_x01_on",
@@ -163,7 +165,7 @@
     "power_draw": 4000000,
     "revert_to": "power_armor_x01",
     "use_action": { "type": "transform", "menu_text": "Turn off", "msg": "The %s armor disengages.", "target": "power_armor_x01" },
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
+    "armor": { "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ] }
   },
   {
     "id": "power_armor_helmet_x01",
@@ -179,9 +181,6 @@
     "material": [ "ceramic", "superalloy" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "head", "eyes", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 30,
     "warmth": 90,
     "power_armor": true,
     "material_thickness": 15,
@@ -207,7 +206,8 @@
         "item_restriction": [ "heavy_battery_cell", "heavy_plus_battery_cell", "heavy_atomic_battery_cell", "heavy_disposable_cell" ]
       }
     ],
-    "flags": [ "WATCH", "WATERPROOF", "STURDY", "PARTIAL_DEAF", "THERMOMETER", "SUN_GLASSES" ]
+    "flags": [ "WATCH", "WATERPROOF", "STURDY", "PARTIAL_DEAF", "THERMOMETER", "SUN_GLASSES" ],
+    "armor": { "coverage": 100, "covers": [ "head", "eyes", "mouth" ], "encumbrance": 30 }
   },
   {
     "id": "power_armor_helmet_x01_on",
@@ -231,8 +231,8 @@
     "power_draw": 15000,
     "revert_to": "power_armor_helmet_x01",
     "use_action": { "menu_text": "Turn off", "type": "transform", "msg": "The %s flicks off.", "target": "power_armor_helmet_x01" },
-    "covers": [ "head" ],
     "techniques": [ "WBLOCK_1" ],
-    "magazine_well": 1
+    "magazine_well": 1,
+    "armor": { "covers": [ "head" ] }
   }
 ]

--- a/data/Unleash_The_Mods/mods/Fallout/Gunsmiths_Guru/items/generic/clutter.json
+++ b/data/Unleash_The_Mods/mods/Fallout/Gunsmiths_Guru/items/generic/clutter.json
@@ -147,11 +147,9 @@
     "weight": "500 g",
     "to_hit": -1,
     "color": "light_gray",
-    "covers": [ "hand_l", "hand_r" ],
     "price": "60 USD",
     "material": [ "plastic" ],
     "flags": [ "WATCH", "WATER_FRIENDLY", "BELTED", "FRAGILE", "ALLOWS_NATURAL_ATTACKS", "OVERSIZE" ],
-    "coverage": 15,
     "symbol": "[",
     "ammo": [ "battery" ],
     "pocket_data": [
@@ -172,7 +170,8 @@
         ]
       }
     ],
-    "use_action": "PORTABLE_GAME"
+    "use_action": "PORTABLE_GAME",
+    "armor": { "coverage": 15, "covers": [ "hand_l", "hand_r" ] }
   },
   {
     "id": "doll_nixon",

--- a/data/Unleash_The_Mods/mods/Fallout/Items/clothing/armor.json
+++ b/data/Unleash_The_Mods/mods/Fallout/Items/clothing/armor.json
@@ -12,9 +12,6 @@
     "material": [ "leather", "plastic" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 1,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "3 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "3 kg", "moves": 80 },
@@ -23,7 +20,8 @@
     ],
     "warmth": 15,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "POCKETS" ]
+    "flags": [ "VARSIZE", "POCKETS" ],
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 1 }
   },
   {
     "id": "jumpsuit_vault_13",
@@ -38,9 +36,6 @@
     "material": [ "leather", "plastic" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 0,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "3 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "3 kg", "moves": 80 },
@@ -49,7 +44,8 @@
     ],
     "warmth": 30,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "POCKETS" ]
+    "flags": [ "VARSIZE", "POCKETS" ],
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 0 }
   },
   {
     "id": "jumpsuit_vault_13_utility",
@@ -64,9 +60,6 @@
     "material": [ "leather", "plastic" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 0,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "3 L", "max_contains_weight": "5 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "3 L", "max_contains_weight": "5 kg", "moves": 80 },
@@ -75,7 +68,8 @@
     ],
     "warmth": 30,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "POCKETS" ]
+    "flags": [ "VARSIZE", "POCKETS" ],
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 0 }
   },
   {
     "id": "jumpsuit_vault_13_armored",
@@ -89,9 +83,6 @@
     "material": [ "leather", "plastic" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 2,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "3 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "3 kg", "moves": 80 },
@@ -100,7 +91,8 @@
     ],
     "warmth": 15,
     "material_thickness": 3,
-    "flags": [ "VARSIZE", "POCKETS" ]
+    "flags": [ "VARSIZE", "POCKETS" ],
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 2 }
   },
   {
     "id": "jumpsuit_xl_vault",
@@ -115,9 +107,6 @@
     "material": [ "leather", "plastic" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 2,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "3 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "3 kg", "moves": 80 },
@@ -126,7 +115,8 @@
     ],
     "warmth": 15,
     "material_thickness": 1,
-    "flags": [ "POCKETS", "OVERSIZE" ]
+    "flags": [ "POCKETS", "OVERSIZE" ],
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 2 }
   },
   {
     "id": "armor_wasteplate",
@@ -142,12 +132,10 @@
     "material": [ "steel", "leather" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 95,
-    "encumbrance": 15,
     "warmth": 20,
     "material_thickness": 4,
-    "flags": [ "VARSIZE", "OUTER", "STURDY", "STAB" ]
+    "flags": [ "VARSIZE", "OUTER", "STURDY", "STAB" ],
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 15 }
   },
   {
     "id": "helm_nullifier",
@@ -162,11 +150,9 @@
     "material": [ "iron" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "head" ],
-    "coverage": 5,
-    "encumbrance": 0,
     "material_thickness": 4,
-    "flags": [ "VARSIZE", "STURDY", "HELMET_COMPAT", "PSYSHIELD_PARTIAL" ]
+    "flags": [ "VARSIZE", "STURDY", "HELMET_COMPAT", "PSYSHIELD_PARTIAL" ],
+    "armor": { "coverage": 5, "covers": [ "head" ], "encumbrance": 0 }
   },
   {
     "id": "jacket_leather_tunnel",
@@ -181,9 +167,6 @@
     "symbol": "[",
     "looks_like": "jacket_windbreaker",
     "color": "dark_gray",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 90,
-    "encumbrance": 15,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1 kg", "moves": 60 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1 kg", "moves": 60 }
@@ -192,7 +175,8 @@
     "material_thickness": 5,
     "environmental_protection": 2,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "VARSIZE", "POCKETS", "OUTER" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 15 }
   },
   {
     "id": "jacket_leather_king",
@@ -207,9 +191,6 @@
     "symbol": "[",
     "looks_like": "jacket_windbreaker",
     "color": "dark_gray",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 90,
-    "encumbrance": 5,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1 kg", "moves": 60 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1 kg", "moves": 60 }
@@ -218,7 +199,8 @@
     "material_thickness": 3,
     "environmental_protection": 1,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "FANCY" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "FANCY" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 5 }
   },
   {
     "id": "jacket_leather_khan",
@@ -233,9 +215,6 @@
     "material": [ "leather" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "torso" ],
-    "coverage": 90,
-    "encumbrance": 10,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1 kg", "moves": 60 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1 kg", "moves": 60 }
@@ -244,7 +223,8 @@
     "material_thickness": 4,
     "environmental_protection": 1,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "VARSIZE", "POCKETS", "OUTER" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER" ],
+    "armor": { "coverage": 90, "covers": [ "torso" ], "encumbrance": 10 }
   },
   {
     "id": "jacket_leather_atomcat",
@@ -259,9 +239,6 @@
     "material": [ "leather" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 90,
-    "encumbrance": 20,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "3 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "3 kg", "moves": 80 }
@@ -270,7 +247,8 @@
     "material_thickness": 2,
     "environmental_protection": 1,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "FANCY" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "FANCY" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 20 }
   },
   {
     "id": "nightpants_naughty",
@@ -284,12 +262,10 @@
     "symbol": "[",
     "looks_like": "leggings",
     "color": "yellow",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 3,
     "warmth": 30,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r" ], "encumbrance": 3 }
   },
   {
     "id": "nightshirt_naughty",
@@ -303,12 +279,10 @@
     "symbol": "[",
     "looks_like": "longshirt",
     "color": "yellow",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 95,
-    "encumbrance": 3,
     "warmth": 30,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 3 }
   },
   {
     "id": "jumpsuit_china",
@@ -323,9 +297,6 @@
     "symbol": "[",
     "looks_like": "touring_suit",
     "color": "green",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 2,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "3 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "3 kg", "moves": 80 },
@@ -334,7 +305,8 @@
     ],
     "warmth": 15,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "POCKETS" ]
+    "flags": [ "VARSIZE", "POCKETS" ],
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 2 }
   },
   {
     "id": "jumpsuit_racer",
@@ -348,9 +320,6 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "red",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 2,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "3 L", "max_contains_weight": "4 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "3 L", "max_contains_weight": "4 kg", "moves": 80 },
@@ -359,7 +328,8 @@
     ],
     "warmth": 15,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "POCKETS" ]
+    "flags": [ "VARSIZE", "POCKETS" ],
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 2 }
   },
   {
     "id": "jumpsuit_enclave",
@@ -374,9 +344,6 @@
     "symbol": "[",
     "looks_like": "touring_suit",
     "color": "yellow",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 2,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "3 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "3 kg", "moves": 80 },
@@ -386,7 +353,8 @@
     "warmth": 5,
     "material_thickness": 2,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "VARSIZE", "POCKETS" ]
+    "flags": [ "VARSIZE", "POCKETS" ],
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 2 }
   },
   {
     "id": "winter_jacket_enclave",
@@ -400,9 +368,6 @@
     "symbol": "[",
     "looks_like": "coat_winter",
     "color": "brown",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 95,
-    "encumbrance": 10,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1750 ml", "max_contains_weight": "3 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1750 ml", "max_contains_weight": "3 kg", "moves": 80 }
@@ -410,7 +375,8 @@
     "warmth": 50,
     "material_thickness": 5,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "VARSIZE", "POCKETS", "HOOD", "OUTER", "WATERPROOF" ]
+    "flags": [ "VARSIZE", "POCKETS", "HOOD", "OUTER", "WATERPROOF" ],
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 10 }
   },
   {
     "id": "winter_pants_enclave",
@@ -424,9 +390,6 @@
     "symbol": "[",
     "looks_like": "pants_army",
     "color": "brown",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 11,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "2 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "2 kg", "moves": 80 }
@@ -434,7 +397,8 @@
     "warmth": 50,
     "material_thickness": 5,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "VARSIZE", "POCKETS", "WATERPROOF", "OUTER" ]
+    "flags": [ "VARSIZE", "POCKETS", "WATERPROOF", "OUTER" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r" ], "encumbrance": 11 }
   },
   {
     "id": "hat_enclave",
@@ -448,13 +412,11 @@
     "symbol": "[",
     "looks_like": "hat_cotton",
     "color": "black",
-    "covers": [ "head" ],
-    "coverage": 50,
-    "encumbrance": 10,
     "warmth": 5,
     "material_thickness": 1,
     "environmental_protection": 2,
-    "flags": [ "SUN_GLASSES" ]
+    "flags": [ "SUN_GLASSES" ],
+    "armor": { "coverage": 50, "covers": [ "head" ], "encumbrance": 10 }
   },
   {
     "id": "duster_minutemen",
@@ -469,9 +431,6 @@
     "material": [ "leather" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 90,
-    "encumbrance": 17,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "3 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "3 kg", "moves": 80 },
@@ -482,7 +441,8 @@
     "material_thickness": 4,
     "environmental_protection": 2,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "WATERPROOF", "RAINPROOF" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "WATERPROOF", "RAINPROOF" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 17 }
   },
   {
     "id": "duster_minutemen_general",
@@ -497,9 +457,6 @@
     "material": [ "leather", "kevlar" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 12,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "4 L", "max_contains_weight": "5 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "4 L", "max_contains_weight": "5 kg", "moves": 80 },
@@ -510,7 +467,8 @@
     "material_thickness": 12,
     "environmental_protection": 4,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "WATERPROOF", "RAINPROOF", "FANCY" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "WATERPROOF", "RAINPROOF", "FANCY" ],
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 12 }
   },
   {
     "id": "coat_frock_red",
@@ -525,9 +483,6 @@
     "material": [ "leather" ],
     "symbol": "[",
     "color": "red",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 90,
-    "encumbrance": 17,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "5 L", "max_contains_weight": "7 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "5 L", "max_contains_weight": "7 kg", "moves": 80 },
@@ -538,7 +493,8 @@
     "material_thickness": 3,
     "environmental_protection": 1,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "WATERPROOF", "RAINPROOF", "FANCY" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "WATERPROOF", "RAINPROOF", "FANCY" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 17 }
   },
   {
     "id": "trenchcoat_general_green",
@@ -553,9 +509,6 @@
     "material": [ "leather" ],
     "symbol": "[",
     "color": "green",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 90,
-    "encumbrance": 17,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "3500 g", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "3500 g", "moves": 80 },
@@ -566,7 +519,8 @@
     "material_thickness": 3,
     "environmental_protection": 1,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "FANCY" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "FANCY" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 17 }
   },
   {
     "id": "trenchcoat_general_white",
@@ -581,9 +535,6 @@
     "material": [ "leather" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 90,
-    "encumbrance": 17,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "3500 g", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "3500 g", "moves": 80 },
@@ -594,7 +545,8 @@
     "material_thickness": 3,
     "environmental_protection": 1,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "FANCY" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "FANCY" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 17 }
   },
   {
     "id": "trenchcoat_general_black",
@@ -609,9 +561,6 @@
     "material": [ "leather" ],
     "symbol": "[",
     "color": "black",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 90,
-    "encumbrance": 17,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "3500 g", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "3500 g", "moves": 80 },
@@ -622,7 +571,8 @@
     "material_thickness": 5,
     "environmental_protection": 3,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "FANCY" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "FANCY" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 17 }
   },
   {
     "id": "cathedralrobe",
@@ -637,13 +587,15 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "torso", "head", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r" ],
-    "coverage": 65,
-    "encumbrance": 3,
     "warmth": 25,
     "material_thickness": 7,
     "environmental_protection": 5,
-    "flags": [ "OVERSIZE", "OUTER", "HELMET_COMPAT", "FANCY" ]
+    "flags": [ "OVERSIZE", "OUTER", "HELMET_COMPAT", "FANCY" ],
+    "armor": {
+      "coverage": 65,
+      "covers": [ "torso", "head", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r" ],
+      "encumbrance": 3
+    }
   },
   {
     "id": "hat_general_green",
@@ -657,13 +609,11 @@
     "symbol": "[",
     "looks_like": "hat_cotton",
     "color": "green",
-    "covers": [ "head" ],
-    "coverage": 50,
-    "encumbrance": 10,
     "warmth": 5,
     "material_thickness": 1,
     "environmental_protection": 2,
-    "flags": [ "SUN_GLASSES", "FANCY" ]
+    "flags": [ "SUN_GLASSES", "FANCY" ],
+    "armor": { "coverage": 50, "covers": [ "head" ], "encumbrance": 10 }
   },
   {
     "id": "hat_general_white",
@@ -677,13 +627,11 @@
     "symbol": "[",
     "looks_like": "hat_cotton",
     "color": "white",
-    "covers": [ "head" ],
-    "coverage": 50,
-    "encumbrance": 10,
     "warmth": 15,
     "material_thickness": 1,
     "environmental_protection": 2,
-    "flags": [ "SUN_GLASSES", "FANCY" ]
+    "flags": [ "SUN_GLASSES", "FANCY" ],
+    "armor": { "coverage": 50, "covers": [ "head" ], "encumbrance": 10 }
   },
   {
     "id": "hat_general_black",
@@ -697,13 +645,11 @@
     "symbol": "[",
     "looks_like": "hat_cotton",
     "color": "green",
-    "covers": [ "head" ],
-    "coverage": 50,
-    "encumbrance": 10,
     "warmth": 5,
     "material_thickness": 1,
     "environmental_protection": 2,
-    "flags": [ "SUN_GLASSES", "FANCY" ]
+    "flags": [ "SUN_GLASSES", "FANCY" ],
+    "armor": { "coverage": 50, "covers": [ "head" ], "encumbrance": 10 }
   },
   {
     "id": "wastehound_mask",
@@ -718,14 +664,12 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "head", "eyes", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 30,
     "warmth": 30,
     "material_thickness": 5,
     "environmental_protection": 3,
     "qualities": [ [ "GLARE", 1 ] ],
-    "flags": [ "VARSIZE", "SKINTIGHT", "SUN_GLASSES" ]
+    "flags": [ "VARSIZE", "SKINTIGHT", "SUN_GLASSES" ],
+    "armor": { "coverage": 100, "covers": [ "head", "eyes", "mouth" ], "encumbrance": 30 }
   },
   {
     "id": "helmet_biker_retro",
@@ -742,13 +686,11 @@
     "symbol": "[",
     "looks_like": "hat_hard",
     "color": "green",
-    "covers": [ "head" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "warmth": 20,
     "material_thickness": 5,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 95, "covers": [ "head" ], "encumbrance": 20 }
   },
   {
     "id": "hat_peoples",
@@ -762,11 +704,9 @@
     "symbol": "[",
     "looks_like": "hat_knit",
     "color": "brown",
-    "covers": [ "head" ],
-    "coverage": 95,
-    "encumbrance": 10,
     "warmth": 70,
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 95, "covers": [ "head" ], "encumbrance": 10 }
   },
   {
     "id": "mask_pint",
@@ -783,13 +723,11 @@
     "symbol": "[",
     "looks_like": "glasses_safety",
     "color": "white",
-    "covers": [ "mouth", "eyes" ],
-    "coverage": 100,
-    "encumbrance": 30,
     "warmth": 5,
     "material_thickness": 1,
     "environmental_protection": 1,
-    "flags": [ "STURDY" ]
+    "flags": [ "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "mouth", "eyes" ], "encumbrance": 30 }
   },
   {
     "id": "mask_pint_magic",
@@ -806,13 +744,11 @@
     "material": [ "paper" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "mouth", "eyes" ],
-    "coverage": 100,
-    "encumbrance": 5,
     "warmth": 5,
     "material_thickness": 20,
     "environmental_protection": 5,
-    "flags": [ "WATER_FRIENDLY", "STURDY" ]
+    "flags": [ "WATER_FRIENDLY", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "mouth", "eyes" ], "encumbrance": 5 }
   },
   {
     "id": "suit_benny",
@@ -827,16 +763,14 @@
     "symbol": "[",
     "looks_like": "jumpsuit",
     "color": "light_gray",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 15,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1 L", "max_contains_weight": "2 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1 L", "max_contains_weight": "2 kg", "moves": 80 }
     ],
     "warmth": 25,
     "material_thickness": 4,
-    "flags": [ "VARSIZE", "FANCY", "POCKETS" ]
+    "flags": [ "VARSIZE", "FANCY", "POCKETS" ],
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 15 }
   },
   {
     "id": "jacket_boomer",
@@ -851,9 +785,6 @@
     "material": [ "leather" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 90,
-    "encumbrance": 15,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1 kg", "moves": 80 }
@@ -862,7 +793,8 @@
     "material_thickness": 3,
     "environmental_protection": 1,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "FANCY" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "FANCY" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 15 }
   },
   {
     "id": "scrubs_bigmt",
@@ -875,13 +807,11 @@
     "material": [ "plastic" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 100,
-    "encumbrance": 25,
     "warmth": 10,
     "material_thickness": 1,
     "environmental_protection": 10,
-    "flags": [ "VARSIZE", "WATERPROOF", "HOOD", "RAINPROOF", "RAD_RESIST", "OUTER" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "HOOD", "RAINPROOF", "RAD_RESIST", "OUTER" ],
+    "armor": { "coverage": 100, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 25 }
   },
   {
     "id": "dress_shirt_NCR",
@@ -895,13 +825,11 @@
     "symbol": "[",
     "looks_like": "longshirt",
     "color": "brown",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 90,
-    "encumbrance": 5,
     "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "250 ml", "max_contains_weight": "500 g", "moves": 80 } ],
     "warmth": 10,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "FANCY" ]
+    "flags": [ "VARSIZE", "FANCY" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 5 }
   },
   {
     "id": "jeans_ncr",
@@ -916,16 +844,14 @@
     "symbol": "[",
     "looks_like": "pants",
     "color": "brown",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 16,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1 kg", "moves": 80 }
     ],
     "warmth": 10,
     "material_thickness": 3,
-    "flags": [ "VARSIZE", "POCKETS" ]
+    "flags": [ "VARSIZE", "POCKETS" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r" ], "encumbrance": 16 }
   },
   {
     "id": "ncr_armor",
@@ -940,9 +866,6 @@
     "symbol": "[",
     "looks_like": "jacket_leather",
     "color": "dark_gray",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 30,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "250 ml", "max_contains_weight": "750 g", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "250 ml", "max_contains_weight": "750 g", "moves": 80 }
@@ -950,7 +873,8 @@
     "warmth": 35,
     "material_thickness": 4,
     "environmental_protection": 5,
-    "flags": [ "VARSIZE", "RAINPROOF" ]
+    "flags": [ "VARSIZE", "RAINPROOF" ],
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 30 }
   },
   {
     "id": "armor_legate",
@@ -967,12 +891,10 @@
     "symbol": "[",
     "looks_like": "armor_larmor",
     "color": "brown",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "warmth": 20,
     "material_thickness": 4,
-    "flags": [ "VARSIZE", "OUTER", "STURDY", "FANCY" ]
+    "flags": [ "VARSIZE", "OUTER", "STURDY", "FANCY" ],
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 20 }
   },
   {
     "id": "helmet_legate",
@@ -988,14 +910,12 @@
     "symbol": "[",
     "looks_like": "helmet_barbute",
     "color": "brown",
-    "covers": [ "head", "eyes", "mouth" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "warmth": 25,
     "material_thickness": 4,
     "environmental_protection": 1,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "STURDY", "FANCY" ]
+    "flags": [ "STURDY", "FANCY" ],
+    "armor": { "coverage": 95, "covers": [ "head", "eyes", "mouth" ], "encumbrance": 20 }
   },
   {
     "id": "hazmat_suit_ghost",
@@ -1009,13 +929,15 @@
     "symbol": "[",
     "looks_like": "beekeeping_suit",
     "color": "brown",
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 50,
     "warmth": 40,
     "material_thickness": 8,
     "environmental_protection": 20,
-    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "GAS_PROOF", "RAD_PROOF", "ELECTRIC_IMMUNE", "OUTER" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "GAS_PROOF", "RAD_PROOF", "ELECTRIC_IMMUNE", "OUTER" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 50
+    }
   },
   {
     "id": "beret_recon",
@@ -1029,11 +951,10 @@
     "symbol": "[",
     "looks_like": "hat_cotton",
     "color": "red",
-    "covers": [ "head" ],
-    "coverage": 40,
     "warmth": 10,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "WATER_FRIENDLY", "FANCY" ]
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "FANCY" ],
+    "armor": { "coverage": 40, "covers": [ "head" ] }
   },
   {
     "id": "helmet_fiend",
@@ -1049,12 +970,10 @@
     "symbol": "[",
     "looks_like": "helmet_bike",
     "color": "white",
-    "covers": [ "head" ],
-    "coverage": 65,
-    "encumbrance": 20,
     "warmth": 10,
     "material_thickness": 4,
-    "techniques": [ "WBLOCK_1" ]
+    "techniques": [ "WBLOCK_1" ],
+    "armor": { "coverage": 65, "covers": [ "head" ], "encumbrance": 20 }
   },
   {
     "id": "jacket_db_varsity",
@@ -1068,16 +987,14 @@
     "symbol": "[",
     "looks_like": "jacket_windbreaker",
     "color": "green",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 90,
-    "encumbrance": 8,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1 kg", "moves": 80 }
     ],
     "warmth": 15,
     "material_thickness": 3,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "FANCY" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "FANCY" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 8 }
   },
   {
     "id": "armor_combat_light",
@@ -1095,9 +1012,6 @@
     "symbol": "[",
     "looks_like": "kevlar",
     "color": "green",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 85,
-    "encumbrance": 15,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "4 L", "max_contains_weight": "6 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "4 L", "max_contains_weight": "6 kg", "moves": 80 },
@@ -1106,7 +1020,8 @@
     ],
     "warmth": 10,
     "material_thickness": 6,
-    "flags": [ "STURDY", "WATERPROOF", "RAINPROOF", "POCKETS", "OUTER" ]
+    "flags": [ "STURDY", "WATERPROOF", "RAINPROOF", "POCKETS", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 15 }
   },
   {
     "id": "armor_combat_light_winter",
@@ -1124,9 +1039,6 @@
     "symbol": "[",
     "looks_like": "kevlar",
     "color": "green",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 85,
-    "encumbrance": 25,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "4 L", "max_contains_weight": "6 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "4 L", "max_contains_weight": "6 kg", "moves": 80 },
@@ -1135,7 +1047,8 @@
     ],
     "warmth": 30,
     "material_thickness": 6,
-    "flags": [ "STURDY", "WATERPROOF", "RAINPROOF", "POCKETS", "OUTER" ]
+    "flags": [ "STURDY", "WATERPROOF", "RAINPROOF", "POCKETS", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 25 }
   },
   {
     "id": "armor_combat_light_winter_medic",
@@ -1153,9 +1066,6 @@
     "material": [ "plastic", "cotton", "kevlar" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 85,
-    "encumbrance": 20,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "4 L", "max_contains_weight": "6 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "4 L", "max_contains_weight": "6 kg", "moves": 80 },
@@ -1164,7 +1074,8 @@
     ],
     "warmth": 30,
     "material_thickness": 5,
-    "flags": [ "STURDY", "WATERPROOF", "RAINPROOF", "POCKETS", "OUTER" ]
+    "flags": [ "STURDY", "WATERPROOF", "RAINPROOF", "POCKETS", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 20 }
   },
   {
     "id": "helmet_combat_light",
@@ -1182,13 +1093,11 @@
     "symbol": "[",
     "looks_like": "hat_hard",
     "color": "green",
-    "covers": [ "head" ],
-    "coverage": 85,
-    "encumbrance": 25,
     "warmth": 20,
     "material_thickness": 10,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 85, "covers": [ "head" ], "encumbrance": 25 }
   },
   {
     "id": "helmet_combat_light_winter",
@@ -1206,13 +1115,11 @@
     "symbol": "[",
     "looks_like": "hat_hard",
     "color": "white",
-    "covers": [ "head" ],
-    "coverage": 85,
-    "encumbrance": 25,
     "warmth": 25,
     "material_thickness": 10,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 85, "covers": [ "head" ], "encumbrance": 25 }
   },
   {
     "id": "balclava_winter",
@@ -1226,11 +1133,9 @@
     "symbol": "[",
     "looks_like": "balaclava",
     "color": "white",
-    "covers": [ "head", "mouth" ],
-    "coverage": 95,
-    "encumbrance": 10,
     "warmth": 30,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "SKINTIGHT" ]
+    "flags": [ "VARSIZE", "SKINTIGHT" ],
+    "armor": { "coverage": 95, "covers": [ "head", "mouth" ], "encumbrance": 10 }
   }
 ]

--- a/data/Unleash_The_Mods/mods/Fallout/Items/clothing/armor_gecko.json
+++ b/data/Unleash_The_Mods/mods/Fallout/Items/clothing/armor_gecko.json
@@ -14,13 +14,11 @@
     "symbol": "[",
     "looks_like": "dress_shoes",
     "color": "dark_gray",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 5,
     "warmth": 20,
     "material_thickness": 3,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "WATERPROOF" ]
+    "flags": [ "VARSIZE", "WATERPROOF" ],
+    "armor": { "coverage": 100, "covers": [ "foot_l", "foot_r" ], "encumbrance": 5 }
   },
   {
     "id": "boots_gecko_gold",
@@ -37,13 +35,11 @@
     "symbol": "[",
     "looks_like": "dress_shoes",
     "color": "dark_gray",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 5,
     "warmth": 20,
     "material_thickness": 3,
     "environmental_protection": 3,
-    "flags": [ "VARSIZE", "WATERPROOF", "FANCY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "FANCY" ],
+    "armor": { "coverage": 100, "covers": [ "foot_l", "foot_r" ], "encumbrance": 5 }
   },
   {
     "id": "gloves_leather_gecko",
@@ -58,13 +54,11 @@
     "symbol": "[",
     "looks_like": "gloves_light",
     "color": "light_gray",
-    "covers": [ "hand_l", "hand_r" ],
-    "coverage": 100,
-    "encumbrance": 5,
     "warmth": 25,
     "material_thickness": 1,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "VARSIZE", "WATERPROOF" ]
+    "flags": [ "VARSIZE", "WATERPROOF" ],
+    "armor": { "coverage": 100, "covers": [ "hand_l", "hand_r" ], "encumbrance": 5 }
   },
   {
     "id": "gloves_leather_gecko_gold",
@@ -79,13 +73,11 @@
     "symbol": "[",
     "looks_like": "gloves_light",
     "color": "yellow",
-    "covers": [ "hand_l", "hand_r" ],
-    "coverage": 100,
-    "encumbrance": 5,
     "warmth": 25,
     "material_thickness": 1,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "VARSIZE", "WATERPROOF", "FANCY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "FANCY" ],
+    "armor": { "coverage": 100, "covers": [ "hand_l", "hand_r" ], "encumbrance": 5 }
   },
   {
     "id": "backpack_leather_gecko",
@@ -100,10 +92,6 @@
     "symbol": "[",
     "looks_like": "backpack",
     "color": "light_gray",
-    "covers": [ "torso" ],
-    "coverage": 30,
-    "encumbrance": 2,
-    "max_encumbrance": 10,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "8 L", "max_contains_weight": "12 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "8 L", "max_contains_weight": "12 kg", "moves": 80 },
@@ -114,7 +102,8 @@
     ],
     "warmth": 9,
     "material_thickness": 3,
-    "flags": [ "BELTED", "WATER_FRIENDLY" ]
+    "flags": [ "BELTED", "WATER_FRIENDLY" ],
+    "armor": { "coverage": 30, "covers": [ "torso" ], "encumbrance": [ 2, 10 ] }
   },
   {
     "id": "backpack_leather_gecko_gold",
@@ -129,10 +118,6 @@
     "symbol": "[",
     "looks_like": "backpack",
     "color": "yellow",
-    "covers": [ "torso" ],
-    "coverage": 30,
-    "encumbrance": 2,
-    "max_encumbrance": 10,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "10 L", "max_contains_weight": "15 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "10 L", "max_contains_weight": "15 kg", "moves": 80 },
@@ -143,7 +128,8 @@
     ],
     "warmth": 9,
     "material_thickness": 3,
-    "flags": [ "BELTED", "WATER_FRIENDLY", "FANCY" ]
+    "flags": [ "BELTED", "WATER_FRIENDLY", "FANCY" ],
+    "armor": { "coverage": 30, "covers": [ "torso" ], "encumbrance": [ 2, 10 ] }
   },
   {
     "id": "armguard_leather_gecko",
@@ -159,13 +145,11 @@
     "symbol": "[",
     "looks_like": "arm_warmers",
     "color": "light_gray",
-    "covers": [ "arm_l", "arm_r" ],
-    "coverage": 90,
-    "encumbrance": 5,
     "warmth": 25,
     "material_thickness": 4,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "STURDY", "BELTED", "BLOCK_WHILE_WORN", "WATER_FRIENDLY" ]
+    "flags": [ "STURDY", "BELTED", "BLOCK_WHILE_WORN", "WATER_FRIENDLY" ],
+    "armor": { "coverage": 90, "covers": [ "arm_l", "arm_r" ], "encumbrance": 5 }
   },
   {
     "id": "armguard_leather_gecko_gold",
@@ -181,13 +165,11 @@
     "symbol": "[",
     "looks_like": "arm_warmers",
     "color": "yellow",
-    "covers": [ "arm_l", "arm_r" ],
-    "coverage": 10,
-    "encumbrance": 5,
     "warmth": 25,
     "material_thickness": 4,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "STURDY", "BELTED", "BLOCK_WHILE_WORN", "WATER_FRIENDLY", "FANCY" ]
+    "flags": [ "STURDY", "BELTED", "BLOCK_WHILE_WORN", "WATER_FRIENDLY", "FANCY" ],
+    "armor": { "coverage": 10, "covers": [ "arm_l", "arm_r" ], "encumbrance": 5 }
   },
   {
     "id": "armor_leather_gecko",
@@ -204,9 +186,6 @@
     "symbol": "[",
     "looks_like": "armor_larmor",
     "color": "light_gray",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 90,
-    "encumbrance": 22,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "3 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "3 kg", "moves": 80 },
@@ -216,7 +195,8 @@
     "warmth": 20,
     "material_thickness": 5,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "VARSIZE", "POCKETS", "STURDY" ]
+    "flags": [ "VARSIZE", "POCKETS", "STURDY" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 22 }
   },
   {
     "id": "armor_leather_gecko_gold",
@@ -233,9 +213,6 @@
     "symbol": "[",
     "looks_like": "armor_larmor",
     "color": "light_gray",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 100,
-    "encumbrance": 22,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "3 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "3 kg", "moves": 80 },
@@ -245,7 +222,8 @@
     "warmth": 20,
     "material_thickness": 5,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "VARSIZE", "POCKETS", "STURDY", "FANCY" ]
+    "flags": [ "VARSIZE", "POCKETS", "STURDY", "FANCY" ],
+    "armor": { "coverage": 100, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 22 }
   },
   {
     "id": "mask_gecko",
@@ -260,9 +238,6 @@
     "material": [ "leather_gecko" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "mouth", "eyes", "head" ],
-    "coverage": 100,
-    "encumbrance": 100,
     "warmth": 20,
     "material_thickness": 2,
     "environmental_protection": 1,
@@ -272,7 +247,8 @@
     "ammo": [ "gasfilter_m" ],
     "use_action": "GASMASK",
     "qualities": [ [ "GLARE", 2 ] ],
-    "flags": [ "SUN_GLASSES", "STURDY" ]
+    "flags": [ "SUN_GLASSES", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "mouth", "eyes", "head" ], "encumbrance": 100 }
   },
   {
     "id": "mask_gecko_gold",
@@ -287,9 +263,6 @@
     "material": [ "leather_gecko" ],
     "symbol": "[",
     "color": "yellow",
-    "covers": [ "mouth", "eyes", "head" ],
-    "coverage": 100,
-    "encumbrance": 100,
     "warmth": 20,
     "material_thickness": 2,
     "environmental_protection": 1,
@@ -299,7 +272,8 @@
     "ammo": [ "gasfilter_m" ],
     "use_action": "GASMASK",
     "qualities": [ [ "GLARE", 2 ] ],
-    "flags": [ "SUN_GLASSES", "STURDY", "FANCY" ]
+    "flags": [ "SUN_GLASSES", "STURDY", "FANCY" ],
+    "armor": { "coverage": 100, "covers": [ "mouth", "eyes", "head" ], "encumbrance": 100 }
   },
   {
     "id": "duster_leather_gecko",
@@ -314,9 +288,6 @@
     "symbol": "[",
     "looks_like": "duster",
     "color": "light_gray",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 90,
-    "encumbrance": 17,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "3 L", "max_contains_weight": "5 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "3 L", "max_contains_weight": "5 kg", "moves": 80 },
@@ -327,7 +298,8 @@
     "material_thickness": 3,
     "environmental_protection": 1,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "WATERPROOF", "RAINPROOF" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "WATERPROOF", "RAINPROOF" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 17 }
   },
   {
     "id": "duster_leather_gecko_gold",
@@ -342,9 +314,6 @@
     "symbol": "[",
     "looks_like": "duster",
     "color": "yellow",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 90,
-    "encumbrance": 17,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "3 L", "max_contains_weight": "5 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "3 L", "max_contains_weight": "5 kg", "moves": 80 },
@@ -355,6 +324,7 @@
     "material_thickness": 3,
     "environmental_protection": 1,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "WATERPROOF", "RAINPROOF", "FANCY" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "WATERPROOF", "RAINPROOF", "FANCY" ],
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 17 }
   }
 ]

--- a/data/Unleash_The_Mods/mods/Fallout/Items/clothing/armor_legion.json
+++ b/data/Unleash_The_Mods/mods/Fallout/Items/clothing/armor_legion.json
@@ -13,16 +13,14 @@
     "symbol": "[",
     "looks_like": "chestguard_hard",
     "color": "red",
-    "covers": [ "torso", "leg_l", "leg_r" ],
-    "coverage": 45,
-    "encumbrance": 25,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "750 ml", "max_contains_weight": "1500 g", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "750 ml", "max_contains_weight": "1500 g", "moves": 80 }
     ],
     "warmth": 10,
     "material_thickness": 6,
-    "flags": [ "VARSIZE", "STURDY" ]
+    "flags": [ "VARSIZE", "STURDY" ],
+    "armor": { "coverage": 45, "covers": [ "torso", "leg_l", "leg_r" ], "encumbrance": 25 }
   },
   {
     "id": "helmet_legion_recruit",
@@ -40,14 +38,12 @@
     "symbol": "[",
     "looks_like": "hat_hard",
     "color": "blue",
-    "covers": [ "head" ],
-    "coverage": 95,
-    "encumbrance": 10,
     "warmth": 15,
     "material_thickness": 3,
     "environmental_protection": 1,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "STURDY" ]
+    "flags": [ "STURDY" ],
+    "armor": { "coverage": 95, "covers": [ "head" ], "encumbrance": 10 }
   },
   {
     "id": "armor_legion_prime",
@@ -63,16 +59,14 @@
     "symbol": "[",
     "looks_like": "chestguard_hard",
     "color": "red",
-    "covers": [ "torso", "leg_l", "leg_r" ],
-    "coverage": 45,
-    "encumbrance": 30,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1 L", "max_contains_weight": "2 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1 L", "max_contains_weight": "2 kg", "moves": 80 }
     ],
     "warmth": 10,
     "material_thickness": 7,
-    "flags": [ "VARSIZE", "STURDY" ]
+    "flags": [ "VARSIZE", "STURDY" ],
+    "armor": { "coverage": 45, "covers": [ "torso", "leg_l", "leg_r" ], "encumbrance": 30 }
   },
   {
     "id": "helmet_legion_prime",
@@ -90,14 +84,12 @@
     "symbol": "[",
     "looks_like": "hat_hard",
     "color": "blue",
-    "covers": [ "head" ],
-    "coverage": 95,
-    "encumbrance": 10,
     "warmth": 15,
     "material_thickness": 4,
     "environmental_protection": 1,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "STURDY" ]
+    "flags": [ "STURDY" ],
+    "armor": { "coverage": 95, "covers": [ "head" ], "encumbrance": 10 }
   },
   {
     "id": "armor_legion_veteran",
@@ -113,16 +105,14 @@
     "symbol": "[",
     "looks_like": "chestguard_hard",
     "color": "red",
-    "covers": [ "torso", "leg_l", "leg_r" ],
-    "coverage": 45,
-    "encumbrance": 35,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "2 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "2 kg", "moves": 80 }
     ],
     "warmth": 10,
     "material_thickness": 8,
-    "flags": [ "VARSIZE", "STURDY" ]
+    "flags": [ "VARSIZE", "STURDY" ],
+    "armor": { "coverage": 45, "covers": [ "torso", "leg_l", "leg_r" ], "encumbrance": 35 }
   },
   {
     "id": "helmet_legion_veteran",
@@ -140,13 +130,11 @@
     "symbol": "[",
     "looks_like": "hat_hard",
     "color": "white",
-    "covers": [ "head" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "warmth": 15,
     "material_thickness": 5,
     "environmental_protection": 1,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "STURDY" ]
+    "flags": [ "STURDY" ],
+    "armor": { "coverage": 95, "covers": [ "head" ], "encumbrance": 20 }
   }
 ]

--- a/data/Unleash_The_Mods/mods/Fallout/Items/clothing/armor_power.json
+++ b/data/Unleash_The_Mods/mods/Fallout/Items/clothing/armor_power.json
@@ -13,9 +13,6 @@
     "material": [ "steel" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 30,
     "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "5 kg", "moves": 80 } ],
     "warmth": 90,
     "power_armor": true,
@@ -23,7 +20,12 @@
     "environmental_protection": 15,
     "ammo": [ "battery" ],
     "use_action": { "type": "transform", "msg": "The %s engages.", "target": "power_armor_t51_on", "active": true },
-    "flags": [ "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE" ]
+    "flags": [ "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 30
+    }
   },
   {
     "id": "power_armor_t51_on",
@@ -37,7 +39,7 @@
     "power_draw": 4000000,
     "revert_to": "power_armor_t51",
     "use_action": { "type": "transform", "menu_text": "Turn off", "msg": "The %s armor disengages.", "target": "power_armor_t51" },
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
+    "armor": { "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ] }
   },
   {
     "id": "power_armor_helmet_t51",
@@ -53,15 +55,13 @@
     "material": [ "steel" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "head", "eyes", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 30,
     "warmth": 90,
     "power_armor": true,
     "material_thickness": 15,
     "environmental_protection": 15,
     "qualities": [ [ "GLARE", 2 ] ],
-    "flags": [ "WATCH", "WATERPROOF", "STURDY", "PARTIAL_DEAF", "THERMOMETER", "SUN_GLASSES" ]
+    "flags": [ "WATCH", "WATERPROOF", "STURDY", "PARTIAL_DEAF", "THERMOMETER", "SUN_GLASSES" ],
+    "armor": { "coverage": 100, "covers": [ "head", "eyes", "mouth" ], "encumbrance": 30 }
   },
   {
     "id": "power_armor_t45",
@@ -77,16 +77,18 @@
     "material": [ "hardsteel", "steel" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 80,
     "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "4 L", "max_contains_weight": "5 kg", "moves": 80 } ],
     "warmth": 60,
     "power_armor": true,
     "material_thickness": 10,
     "environmental_protection": 16,
     "use_action": { "type": "transform", "msg": "The %s engages.", "target": "power_armor_t45_on", "active": true },
-    "flags": [ "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE" ]
+    "flags": [ "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 80
+    }
   },
   {
     "id": "power_armor_t45_on",
@@ -100,7 +102,7 @@
     "power_draw": 4000000,
     "revert_to": "power_armor_t45",
     "use_action": { "type": "transform", "menu_text": "Turn off", "msg": "The %s armor disengages.", "target": "power_armor_t45" },
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
+    "armor": { "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ] }
   },
   {
     "id": "power_armor_helmet_t45",
@@ -116,15 +118,13 @@
     "material": [ "hardsteel", "steel" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "head", "eyes", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 80,
     "warmth": 60,
     "power_armor": true,
     "material_thickness": 10,
     "environmental_protection": 16,
     "qualities": [ [ "GLARE", 2 ] ],
-    "flags": [ "WATCH", "WATERPROOF", "STURDY", "PARTIAL_DEAF", "THERMOMETER", "SUN_GLASSES" ]
+    "flags": [ "WATCH", "WATERPROOF", "STURDY", "PARTIAL_DEAF", "THERMOMETER", "SUN_GLASSES" ],
+    "armor": { "coverage": 100, "covers": [ "head", "eyes", "mouth" ], "encumbrance": 80 }
   },
   {
     "id": "power_armor_x01",
@@ -140,16 +140,18 @@
     "material": [ "ceramic", "superalloy" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 30,
     "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "4 kg", "moves": 80 } ],
     "warmth": 90,
     "power_armor": true,
     "material_thickness": 15,
     "environmental_protection": 35,
     "use_action": { "type": "transform", "msg": "The %s engages.", "target": "power_armor_x01_on", "active": true },
-    "flags": [ "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE" ]
+    "flags": [ "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 30
+    }
   },
   {
     "id": "power_armor_x01_on",
@@ -163,7 +165,7 @@
     "power_draw": 4000000,
     "revert_to": "power_armor_x01",
     "use_action": { "type": "transform", "menu_text": "Turn off", "msg": "The %s armor disengages.", "target": "power_armor_x01" },
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
+    "armor": { "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ] }
   },
   {
     "id": "power_armor_helmet_x01",
@@ -179,9 +181,6 @@
     "material": [ "ceramic", "superalloy" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "head", "eyes", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 30,
     "warmth": 90,
     "power_armor": true,
     "material_thickness": 15,
@@ -207,7 +206,8 @@
         "item_restriction": [ "heavy_battery_cell", "heavy_plus_battery_cell", "heavy_atomic_battery_cell", "heavy_disposable_cell" ]
       }
     ],
-    "flags": [ "WATCH", "WATERPROOF", "STURDY", "PARTIAL_DEAF", "THERMOMETER", "SUN_GLASSES" ]
+    "flags": [ "WATCH", "WATERPROOF", "STURDY", "PARTIAL_DEAF", "THERMOMETER", "SUN_GLASSES" ],
+    "armor": { "coverage": 100, "covers": [ "head", "eyes", "mouth" ], "encumbrance": 30 }
   },
   {
     "id": "power_armor_helmet_x01_on",
@@ -231,7 +231,7 @@
     "turns_per_charge": 2,
     "revert_to": "power_armor_helmet_x01",
     "use_action": { "menu_text": "Turn off", "type": "transform", "msg": "The %s flicks off.", "target": "power_armor_helmet_x01" },
-    "covers": [ "head" ],
-    "techniques": [ "WBLOCK_1" ]
+    "techniques": [ "WBLOCK_1" ],
+    "armor": { "covers": [ "head" ] }
   }
 ]

--- a/data/Unleash_The_Mods/mods/Fallout/Items/generic/clutter.json
+++ b/data/Unleash_The_Mods/mods/Fallout/Items/generic/clutter.json
@@ -147,11 +147,9 @@
     "weight": "500 g",
     "to_hit": -1,
     "color": "light_gray",
-    "covers": [ "hand_l", "hand_r" ],
     "price": "60 USD",
     "material": [ "plastic" ],
     "flags": [ "WATCH", "WATER_FRIENDLY", "BELTED", "FRAGILE", "ALLOWS_NATURAL_ATTACKS", "OVERSIZE" ],
-    "coverage": 15,
     "symbol": "[",
     "ammo": [ "battery" ],
     "pocket_data": [
@@ -172,7 +170,8 @@
         ]
       }
     ],
-    "use_action": "PORTABLE_GAME"
+    "use_action": "PORTABLE_GAME",
+    "armor": { "coverage": 15, "covers": [ "hand_l", "hand_r" ] }
   },
   {
     "id": "doll_nixon",

--- a/data/Unleash_The_Mods/mods/Fantasy_realm_scenarios/items.json
+++ b/data/Unleash_The_Mods/mods/Fantasy_realm_scenarios/items.json
@@ -5,7 +5,6 @@
     "name": { "str": "wooden breastplate" },
     "weight": "3175 g",
     "color": "brown",
-    "covers": [ "torso" ],
     "to_hit": -4,
     "symbol": "[",
     "description": "An orate cuirass carved from wood.",
@@ -16,11 +15,10 @@
     "warmth": 10,
     "phase": "solid",
     "environmental_protection": 0,
-    "encumbrance": 30,
     "bashing": 6,
     "flags": [ "VARSIZE", "OUTER" ],
-    "coverage": 90,
-    "material_thickness": 4
+    "material_thickness": 4,
+    "armor": { "coverage": 90, "covers": [ "torso" ], "encumbrance": 30 }
   },
   {
     "id": "mail_shirt_wood",
@@ -28,7 +26,6 @@
     "name": { "str": "wooden mail shirt" },
     "weight": "1229 g",
     "color": "brown",
-    "covers": [ "torso", "arm_l", "arm_r" ],
     "to_hit": -1,
     "symbol": "[",
     "description": "A very strange garment carved from countless small wooden rings, in apparent mimicry of chainmail.  It isn't clear how the rings fit together.",
@@ -38,11 +35,10 @@
     "cutting": 0,
     "warmth": 10,
     "phase": "solid",
-    "encumbrance": 20,
     "bashing": 0,
     "flags": [ "VARSIZE", "OUTER" ],
-    "coverage": 95,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 20 }
   },
   {
     "id": "helmet_wood",
@@ -51,7 +47,6 @@
     "name": { "str": "wooden helmet" },
     "weight": "870 g",
     "color": "brown",
-    "covers": [ "head" ],
     "techniques": [ "WBLOCK_1" ],
     "to_hit": 0,
     "symbol": "[",
@@ -63,11 +58,10 @@
     "warmth": 10,
     "phase": "solid",
     "environmental_protection": 0,
-    "encumbrance": 25,
     "bashing": 5,
     "flags": [ "VARSIZE", "STURDY" ],
-    "coverage": 80,
-    "material_thickness": 4
+    "material_thickness": 4,
+    "armor": { "coverage": 80, "covers": [ "head" ], "encumbrance": 25 }
   },
   {
     "id": "cap_wood",
@@ -76,7 +70,6 @@
     "name": { "str": "wooden cap" },
     "weight": "870 g",
     "color": "brown",
-    "covers": [ "head" ],
     "techniques": [ "WBLOCK_1" ],
     "to_hit": 0,
     "symbol": "[",
@@ -88,11 +81,10 @@
     "warmth": 10,
     "phase": "solid",
     "environmental_protection": 0,
-    "encumbrance": 15,
     "bashing": 3,
     "flags": [ "VARSIZE", "STURDY" ],
-    "coverage": 60,
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 60, "covers": [ "head" ], "encumbrance": 15 }
   },
   {
     "id": "legguard_wood",
@@ -101,7 +93,6 @@
     "category": "armor",
     "weight": "1130 g",
     "color": "brown",
-    "covers": [ "leg_l", "leg_r" ],
     "to_hit": 1,
     "symbol": "[",
     "description": "An ornate pair of leg guards, carved out of wood.",
@@ -113,10 +104,9 @@
     "warmth": 10,
     "phase": "solid",
     "environmental_protection": 1,
-    "encumbrance": 10,
     "bashing": 0,
-    "coverage": 70,
-    "material_thickness": 4
+    "material_thickness": 4,
+    "armor": { "coverage": 70, "covers": [ "leg_l", "leg_r" ], "encumbrance": 10 }
   },
   {
     "id": "leggings_wood",
@@ -125,7 +115,6 @@
     "category": "armor",
     "weight": "930 g",
     "color": "brown",
-    "covers": [ "leg_l", "leg_r" ],
     "to_hit": 1,
     "symbol": "[",
     "description": "An ornate pair of leggings, carved out of multiple overlapping pieces of wood.",
@@ -137,10 +126,9 @@
     "warmth": 10,
     "phase": "solid",
     "environmental_protection": 1,
-    "encumbrance": 10,
     "bashing": 0,
-    "coverage": 90,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 90, "covers": [ "leg_l", "leg_r" ], "encumbrance": 10 }
   },
   {
     "id": "boots_wood",
@@ -149,7 +137,6 @@
     "name": { "str": "pair of wooden high boots", "str_pl": "pairs of wooden high boots" },
     "weight": "604 g",
     "color": "brown",
-    "covers": [ "leg_l", "leg_r", "foot_l", "foot_r" ],
     "to_hit": -1,
     "symbol": "[",
     "description": "Ornate boots reaching nearly to the knees, carved from multiple pieces of wood, and carefully fitted together. Stiff but durable.",
@@ -160,10 +147,8 @@
     "warmth": 10,
     "phase": "solid",
     "environmental_protection": 2,
-    "encumbrance": 20,
     "bashing": 3,
     "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
-    "coverage": 70,
     "material_thickness": 5,
     "use_action": {
       "type": "holster",
@@ -172,7 +157,8 @@
       "multi": 2,
       "max_volume": 1,
       "flags": [ "SHEATH_KNIFE" ]
-    }
+    },
+    "armor": { "coverage": 70, "covers": [ "leg_l", "leg_r", "foot_l", "foot_r" ], "encumbrance": 20 }
   },
   {
     "id": "low_boots_wood",
@@ -181,7 +167,6 @@
     "name": { "str": "pair of wooden low boots", "str_pl": "pairs of wooden low boots" },
     "weight": "604 g",
     "color": "brown",
-    "covers": [ "foot_l", "foot_r" ],
     "to_hit": -1,
     "symbol": "[",
     "description": "Ornate boots carved from multiple pieces of wood, and carefully fitted together. Stiff but durable.",
@@ -192,10 +177,8 @@
     "warmth": 10,
     "phase": "solid",
     "environmental_protection": 2,
-    "encumbrance": 20,
     "bashing": 3,
     "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
-    "coverage": 90,
     "material_thickness": 5,
     "use_action": {
       "type": "holster",
@@ -204,7 +187,8 @@
       "multi": 2,
       "max_volume": 1,
       "flags": [ "SHEATH_KNIFE" ]
-    }
+    },
+    "armor": { "coverage": 90, "covers": [ "foot_l", "foot_r" ], "encumbrance": 20 }
   },
   {
     "id": "gauntlets_wood",
@@ -213,7 +197,6 @@
     "name": { "str": "pair of wooden gauntlets", "str_pl": "pairs of wooden gauntlets" },
     "weight": "300 g",
     "color": "brown",
-    "covers": [ "hand_l", "hand_r" ],
     "to_hit": -2,
     "symbol": "[",
     "description": "Ornate gauntlets carved from several pieces of wood, carefully fitted together. Not as unwieldy as you'd expect.",
@@ -224,11 +207,10 @@
     "warmth": 10,
     "phase": "solid",
     "environmental_protection": 0,
-    "encumbrance": 20,
     "bashing": 2,
     "flags": [ "VARSIZE", "STURDY" ],
-    "coverage": 75,
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 75, "covers": [ "hand_l", "hand_r" ], "encumbrance": 20 }
   },
   {
     "id": "breastplate_iron",
@@ -236,7 +218,6 @@
     "name": { "str": "iron breastplate" },
     "weight": "4535 g",
     "color": "light_gray",
-    "covers": [ "torso" ],
     "to_hit": -4,
     "symbol": "[",
     "description": "A simple cuirass hammered out of iron.",
@@ -247,11 +228,10 @@
     "warmth": 15,
     "phase": "solid",
     "environmental_protection": 0,
-    "encumbrance": 30,
     "bashing": 6,
     "flags": [ "VARSIZE", "OUTER" ],
-    "coverage": 90,
-    "material_thickness": 4
+    "material_thickness": 4,
+    "armor": { "coverage": 90, "covers": [ "torso" ], "encumbrance": 30 }
   },
   {
     "id": "shroom_wine",
@@ -500,18 +480,16 @@
     "description": "A cloth quiver worn on the back that can hold 20 arrows.  Activate to store arrows.",
     "price": "65 USD",
     "material": [ "cotton" ],
-    "covers": [ "torso" ],
     "volume": "500 ml",
     "cutting": 0,
     "bashing": 2,
     "warmth": 0,
     "phase": "solid",
     "environmental_protection": 0,
-    "encumbrance": 5,
-    "coverage": 5,
     "material_thickness": 1,
     "pocket_data": [ { "ammo_restriction": { "arrow": 20, "bolt": 20 }, "moves": 20 } ],
-    "flags": [ "QUIVER_20", "BELTED", "VARSIZE", "OVERSIZE" ]
+    "flags": [ "QUIVER_20", "BELTED", "VARSIZE", "OVERSIZE" ],
+    "armor": { "coverage": 5, "covers": [ "torso" ], "encumbrance": 5 }
   },
   {
     "id": "living_wood",

--- a/data/Unleash_The_Mods/mods/Maddre_Mod/items/madd_armor_override.json
+++ b/data/Unleash_The_Mods/mods/Maddre_Mod/items/madd_armor_override.json
@@ -10,13 +10,11 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 95,
-    "encumbrance": 12,
     "storage": 9,
     "warmth": 30,
     "material_thickness": 3,
-    "flags": [ "VARSIZE", "POCKETS", "HOOD" ]
+    "flags": [ "VARSIZE", "POCKETS", "HOOD" ],
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 12 }
   },
   {
     "id": "flag_shirt",
@@ -29,11 +27,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "light_red",
-    "covers": [ "torso" ],
-    "coverage": 90,
     "warmth": 10,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "SKINTIGHT" ]
+    "flags": [ "VARSIZE", "SKINTIGHT" ],
+    "armor": { "coverage": 90, "covers": [ "torso" ] }
   },
   {
     "id": "technician_shirt_gray",
@@ -46,13 +43,11 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "torso" ],
-    "coverage": 40,
-    "encumbrance": 5,
     "storage": 1,
     "warmth": 8,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "SKINTIGHT" ]
+    "flags": [ "VARSIZE", "SKINTIGHT" ],
+    "armor": { "coverage": 40, "covers": [ "torso" ], "encumbrance": 5 }
   },
   {
     "id": "technician_shirt_gray",
@@ -65,13 +60,11 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "torso" ],
-    "coverage": 40,
-    "encumbrance": 5,
     "storage": 1,
     "warmth": 8,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "SKINTIGHT" ]
+    "flags": [ "VARSIZE", "SKINTIGHT" ],
+    "armor": { "coverage": 40, "covers": [ "torso" ], "encumbrance": 5 }
   },
   {
     "id": "technician_shirt_gray",
@@ -84,13 +77,11 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "torso" ],
-    "coverage": 40,
-    "encumbrance": 5,
     "storage": 1,
     "warmth": 8,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "SKINTIGHT" ]
+    "flags": [ "VARSIZE", "SKINTIGHT" ],
+    "armor": { "coverage": 40, "covers": [ "torso" ], "encumbrance": 5 }
   },
   {
     "id": "tshirt",
@@ -103,10 +94,9 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "torso" ],
-    "coverage": 90,
     "warmth": 5,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "SKINTIGHT" ]
+    "flags": [ "VARSIZE", "SKINTIGHT" ],
+    "armor": { "coverage": 90, "covers": [ "torso" ] }
   }
 ]

--- a/data/Unleash_The_Mods/mods/Malkeus_Enhancement_Mod/Enhanced_Survivor_Harness_COREMOD.json
+++ b/data/Unleash_The_Mods/mods/Malkeus_Enhancement_Mod/Enhanced_Survivor_Harness_COREMOD.json
@@ -12,12 +12,10 @@
     "symbol": "[",
     "looks_like": "tacvest",
     "color": "green",
-    "covers": [ "torso" ],
-    "coverage": 30,
-    "encumbrance": 2,
     "storage": "6 L",
     "material_thickness": 3,
     "use_action": { "type": "holster", "max_volume": "6000 ml", "min_volume": "250 ml", "skills": [ "smg", "shotgun", "rifle" ] },
-    "flags": [ "VARSIZE", "WATER_FRIENDLY", "STURDY", "WAIST" ]
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "STURDY", "WAIST" ],
+    "armor": { "coverage": 30, "covers": [ "torso" ], "encumbrance": 2 }
   }
 ]

--- a/data/Unleash_The_Mods/mods/Merchant/merchantitem.json
+++ b/data/Unleash_The_Mods/mods/Merchant/merchantitem.json
@@ -13,9 +13,6 @@
     "material": [ "cotton", "plastic" ],
     "symbol": "[",
     "color": "green",
-    "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r" ],
-    "coverage": 1,
-    "encumbrance": 60,
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -26,6 +23,7 @@
       }
     ],
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "TARDIS" ]
+    "flags": [ "VARSIZE", "TARDIS" ],
+    "armor": { "coverage": 1, "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r" ], "encumbrance": 60 }
   }
 ]

--- a/data/Unleash_The_Mods/mods/Miscellaneous_Magiclysm_Expansions/armor.json
+++ b/data/Unleash_The_Mods/mods/Miscellaneous_Magiclysm_Expansions/armor.json
@@ -16,13 +16,15 @@
     "material": [ "demon_chitin" ],
     "symbol": "#",
     "color": "red",
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r", "head", "eyes", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 20,
     "warmth": 25,
     "material_thickness": 8,
     "environmental_protection": 40,
-    "flags": [ "STURDY" ]
+    "flags": [ "STURDY" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r", "head", "eyes", "mouth" ],
+      "encumbrance": 20
+    }
   },
   {
     "id": "cheat",
@@ -39,12 +41,14 @@
     "material": [ "cheatmetal" ],
     "symbol": "#",
     "color": "green",
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r", "head", "eyes", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 0,
     "warmth": 25,
     "material_thickness": 800,
     "environmental_protection": 2147483647,
-    "flags": [ "STURDY" ]
+    "flags": [ "STURDY" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r", "head", "eyes", "mouth" ],
+      "encumbrance": 0
+    }
   }
 ]

--- a/data/Unleash_The_Mods/mods/Miscellaneous_Magiclysm_Expansions/spells/eitems.json
+++ b/data/Unleash_The_Mods/mods/Miscellaneous_Magiclysm_Expansions/spells/eitems.json
@@ -12,13 +12,11 @@
     "material": [ "steel" ],
     "symbol": "[",
     "color": "blue",
-    "covers": [ "foot_r", "foot_l" ],
-    "coverage": 100,
-    "encumbrance": 0,
     "warmth": 30,
     "material_thickness": 3,
     "environmental_protection": 2,
     "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "MOVE_COST", "add": -15 } ] } ] },
-    "flags": [ "WATERPROOF", "ROLLER_QUAD", "BELTED" ]
+    "flags": [ "WATERPROOF", "ROLLER_QUAD", "BELTED" ],
+    "armor": { "coverage": 100, "covers": [ "foot_r", "foot_l" ], "encumbrance": 0 }
   }
 ]

--- a/data/Unleash_The_Mods/mods/More_Survivor_Stuff/items/armor.json
+++ b/data/Unleash_The_Mods/mods/More_Survivor_Stuff/items/armor.json
@@ -15,13 +15,11 @@
     "symbol": "[",
     "looks_like": "gloves_lsurvivor",
     "color": "green",
-    "covers": [ "hand_l", "hand_r" ],
-    "coverage": 100,
-    "encumbrance": 7,
     "warmth": 10,
     "material_thickness": 2,
     "environmental_protection": 3,
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "hand_l", "hand_r" ], "encumbrance": 7 }
   },
   {
     "id": "mss_boots_extralsurvivor",
@@ -40,13 +38,11 @@
     "symbol": "[",
     "looks_like": "boots",
     "color": "green",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 14,
     "warmth": 10,
     "material_thickness": 3,
     "environmental_protection": 3,
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "foot_l", "foot_r" ], "encumbrance": 14 }
   },
   {
     "id": "mss_helmet_lsurvivor",
@@ -65,14 +61,12 @@
     "symbol": "[",
     "looks_like": "helmet_army",
     "color": "dark_gray",
-    "covers": [ "head" ],
-    "coverage": 100,
-    "encumbrance": 18,
     "warmth": 10,
     "material_thickness": 4,
     "environmental_protection": 3,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "head" ], "encumbrance": 18 }
   },
   {
     "id": "mss_mask_extralsurvivor",
@@ -94,15 +88,13 @@
     "material": [ "kevlar", "cotton" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "mouth", "eyes" ],
-    "coverage": 100,
-    "encumbrance": 16,
     "warmth": 10,
     "material_thickness": 2,
     "environmental_protection": 1,
     "environmental_protection_with_filter": 15,
     "qualities": [ [ "GLARE", 1 ] ],
-    "flags": [ "VARSIZE", "STURDY", "SUN_GLASSES" ]
+    "flags": [ "VARSIZE", "STURDY", "SUN_GLASSES" ],
+    "armor": { "coverage": 100, "covers": [ "mouth", "eyes" ], "encumbrance": 16 }
   },
   {
     "id": "mss_hood_extralsurvivor",
@@ -120,13 +112,11 @@
     "symbol": "[",
     "looks_like": "hood_lsurvivor",
     "color": "green",
-    "covers": [ "head" ],
-    "coverage": 100,
-    "encumbrance": 10,
     "warmth": 10,
     "material_thickness": 3,
     "environmental_protection": 3,
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY", "OUTER", "HELMET_COMPAT" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY", "OUTER", "HELMET_COMPAT" ],
+    "armor": { "coverage": 100, "covers": [ "head" ], "encumbrance": 10 }
   },
   {
     "id": "mss_extralsurvivor_suit",
@@ -143,9 +133,6 @@
     "symbol": "[",
     "looks_like": "lsurvivor_suit",
     "color": "green",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 100,
-    "encumbrance": 11,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "3 L", "max_contains_weight": "5 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "3 L", "max_contains_weight": "5 kg", "moves": 75 },
@@ -155,7 +142,8 @@
     "warmth": 10,
     "material_thickness": 3,
     "environmental_protection": 3,
-    "flags": [ "VARSIZE", "WATERPROOF", "POCKETS", "HOOD", "RAINPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "POCKETS", "HOOD", "RAINPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 11 }
   },
   {
     "id": "mss_gloves_superhsurvivor",
@@ -173,13 +161,11 @@
     "symbol": "[",
     "looks_like": "gloves_hsurvivor",
     "color": "dark_gray",
-    "covers": [ "hand_l", "hand_r" ],
-    "coverage": 100,
-    "encumbrance": 35,
     "warmth": 15,
     "material_thickness": 5,
     "environmental_protection": 5,
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "hand_l", "hand_r" ], "encumbrance": 35 }
   },
   {
     "id": "mss_boots_superhsurvivor",
@@ -198,13 +184,11 @@
     "symbol": "[",
     "looks_like": "boots_hsurvivor",
     "color": "dark_gray",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 45,
     "warmth": 15,
     "material_thickness": 8,
     "environmental_protection": 5,
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "foot_l", "foot_r" ], "encumbrance": 45 }
   },
   {
     "id": "mss_helmet_superhsurvivor",
@@ -223,14 +207,12 @@
     "symbol": "[",
     "looks_like": "helmet_survivor",
     "color": "dark_gray",
-    "covers": [ "head" ],
-    "coverage": 100,
-    "encumbrance": 45,
     "warmth": 15,
     "material_thickness": 8,
     "environmental_protection": 5,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "head" ], "encumbrance": 45 }
   },
   {
     "id": "mss_mask_superhsurvivor",
@@ -252,15 +234,13 @@
     "symbol": "[",
     "looks_like": "mask_hsurvivor",
     "color": "dark_gray",
-    "covers": [ "mouth", "eyes" ],
-    "coverage": 100,
-    "encumbrance": 40,
     "warmth": 15,
     "material_thickness": 4,
     "environmental_protection": 1,
     "environmental_protection_with_filter": 17,
     "qualities": [ [ "GLARE", 1 ] ],
-    "flags": [ "VARSIZE", "STURDY", "SUN_GLASSES" ]
+    "flags": [ "VARSIZE", "STURDY", "SUN_GLASSES" ],
+    "armor": { "coverage": 100, "covers": [ "mouth", "eyes" ], "encumbrance": 40 }
   },
   {
     "id": "mss_hood_hsurvivor",
@@ -279,14 +259,12 @@
     "symbol": "[",
     "looks_like": "hood_survivor",
     "color": "dark_gray",
-    "covers": [ "head" ],
-    "coverage": 100,
-    "encumbrance": 30,
     "warmth": 15,
     "material_thickness": 5,
     "environmental_protection": 3,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY", "OUTER", "HELMET_COMPAT" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY", "OUTER", "HELMET_COMPAT" ],
+    "armor": { "coverage": 100, "covers": [ "head" ], "encumbrance": 30 }
   },
   {
     "id": "mss_superhsurvivor_suit",
@@ -305,9 +283,6 @@
     "symbol": "[",
     "looks_like": "hsurvivor_suit",
     "color": "dark_gray",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 98,
-    "encumbrance": 45,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "3 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "3 kg", "moves": 75 },
@@ -317,7 +292,8 @@
     "warmth": 15,
     "material_thickness": 8,
     "environmental_protection": 3,
-    "flags": [ "VARSIZE", "WATERPROOF", "POCKETS", "RAINPROOF", "STURDY", "SLOWS_MOVEMENT" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "POCKETS", "RAINPROOF", "STURDY", "SLOWS_MOVEMENT" ],
+    "armor": { "coverage": 98, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 45 }
   },
   {
     "id": "mss_cloak_hsurvivor",
@@ -334,13 +310,11 @@
     "symbol": "[",
     "looks_like": "cloak",
     "color": "dark_gray",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 18,
     "warmth": 40,
     "material_thickness": 6,
     "environmental_protection": 3,
-    "flags": [ "OVERSIZE", "OUTER", "WATERPROOF", "RAINPROOF" ]
+    "flags": [ "OVERSIZE", "OUTER", "WATERPROOF", "RAINPROOF" ],
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 18 }
   },
   {
     "id": "mss_rubber_survivor_undersuit",
@@ -355,13 +329,11 @@
     "material": [ "plastic", "rubber", "cotton" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 87,
-    "encumbrance": 7,
     "warmth": 5,
     "material_thickness": 1,
     "environmental_protection": 8,
-    "flags": [ "VARSIZE", "SKINTIGHT", "WATER_FRIENDLY" ]
+    "flags": [ "VARSIZE", "SKINTIGHT", "WATER_FRIENDLY" ],
+    "armor": { "coverage": 87, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 7 }
   },
   {
     "id": "mss_fancy_plate_gloves",
@@ -380,13 +352,11 @@
     "symbol": "[",
     "looks_like": "fire_gauntlets",
     "color": "dark_gray",
-    "covers": [ "hand_l", "hand_r" ],
-    "coverage": 100,
-    "encumbrance": 40,
     "warmth": 20,
     "material_thickness": 7,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "STURDY", "WATERPROOF", "SUPER_FANCY" ]
+    "flags": [ "VARSIZE", "STURDY", "WATERPROOF", "SUPER_FANCY" ],
+    "armor": { "coverage": 100, "covers": [ "hand_l", "hand_r" ], "encumbrance": 40 }
   },
   {
     "id": "mss_fancy_plate_boots",
@@ -405,13 +375,11 @@
     "symbol": "[",
     "looks_like": "boots_steel",
     "color": "dark_gray",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 40,
     "warmth": 20,
     "material_thickness": 9,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY", "SUPER_FANCY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY", "SUPER_FANCY" ],
+    "armor": { "coverage": 100, "covers": [ "foot_l", "foot_r" ], "encumbrance": 40 }
   },
   {
     "id": "mss_fancy_plate_helmet",
@@ -429,14 +397,12 @@
     "symbol": "[",
     "looks_like": "helmet_barbute",
     "color": "dark_gray",
-    "covers": [ "head", "eyes", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 45,
     "warmth": 20,
     "material_thickness": 10,
     "environmental_protection": 1,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "VARSIZE", "STURDY", "SUPER_FANCY", "WATERPROOF" ]
+    "flags": [ "VARSIZE", "STURDY", "SUPER_FANCY", "WATERPROOF" ],
+    "armor": { "coverage": 100, "covers": [ "head", "eyes", "mouth" ], "encumbrance": 45 }
   },
   {
     "id": "mss_fancy_plate_armor",
@@ -455,12 +421,10 @@
     "symbol": "[",
     "looks_like": "armor_lightplate",
     "color": "dark_gray",
-    "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ],
-    "coverage": 100,
-    "encumbrance": 45,
     "warmth": 20,
     "material_thickness": 8,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "STURDY", "SUPER_FANCY", "WATERPROOF", "RAINPROOF" ]
+    "flags": [ "VARSIZE", "STURDY", "SUPER_FANCY", "WATERPROOF", "RAINPROOF" ],
+    "armor": { "coverage": 100, "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ], "encumbrance": 45 }
   }
 ]

--- a/data/Unleash_The_Mods/mods/Ninja_mod/ninja_tools.json
+++ b/data/Unleash_The_Mods/mods/Ninja_mod/ninja_tools.json
@@ -146,9 +146,6 @@
     "material": [ "cotton", "leather" ],
     "symbol": "[",
     "color": "black",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 100,
-    "encumbrance": 14,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "4 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1 L", "max_contains_weight": "2 kg", "moves": 75 },
@@ -157,7 +154,8 @@
     "warmth": 8,
     "material_thickness": 2,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE" ]
+    "flags": [ "VARSIZE" ],
+    "armor": { "coverage": 100, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 14 }
   },
   {
     "id": "ninja_suit_survivor",
@@ -171,9 +169,6 @@
     "material": [ "kevlar", "cotton", "leather", "steel" ],
     "symbol": "[",
     "color": "red",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 100,
-    "encumbrance": 18,
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -202,7 +197,8 @@
     "material_thickness": 3,
     "environmental_protection": 4,
     "use_action": { "type": "holster" },
-    "flags": [ "VARSIZE", "RAINPROOF", "STURDY", "POCKETS", "FANCY", "TARDIS" ]
+    "flags": [ "VARSIZE", "RAINPROOF", "STURDY", "POCKETS", "FANCY", "TARDIS" ],
+    "armor": { "coverage": 100, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 18 }
   },
   {
     "id": "ninja_hood",
@@ -218,13 +214,11 @@
     "material": [ "cotton", "leather", "steel" ],
     "symbol": "[",
     "color": "black",
-    "covers": [ "head", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 14,
     "warmth": 8,
     "material_thickness": 2,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE" ]
+    "flags": [ "VARSIZE" ],
+    "armor": { "coverage": 100, "covers": [ "head", "mouth" ], "encumbrance": 14 }
   },
   {
     "id": "ninja_hood_survivor",
@@ -240,14 +234,12 @@
     "material": [ "kevlar", "cotton", "leather", "steel", "plastic" ],
     "symbol": "[",
     "color": "red",
-    "covers": [ "head", "eyes", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 18,
     "warmth": 8,
     "material_thickness": 3,
     "environmental_protection": 15,
     "qualities": [ [ "GLARE", 2 ] ],
-    "flags": [ "VARSIZE", "STURDY", "RAINPROOF", "SUN_GLASSES", "FLASH_PROTECTION", "FANCY" ]
+    "flags": [ "VARSIZE", "STURDY", "RAINPROOF", "SUN_GLASSES", "FLASH_PROTECTION", "FANCY" ],
+    "armor": { "coverage": 100, "covers": [ "head", "eyes", "mouth" ], "encumbrance": 18 }
   },
   {
     "id": "ninja_chainmail",
@@ -261,13 +253,11 @@
     "material": [ "steel" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "torso" ],
-    "coverage": 85,
-    "encumbrance": 26,
     "warmth": 5,
     "material_thickness": 2,
     "environmental_protection": 0,
-    "flags": [ "VARSIZE", "STURDY", "SKINTIGHT" ]
+    "flags": [ "VARSIZE", "STURDY", "SKINTIGHT" ],
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": 26 }
   },
   {
     "id": "ninja_chainmail_survivor",
@@ -281,13 +271,11 @@
     "material": [ "kevlar", "superalloy" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "torso" ],
-    "coverage": 100,
-    "encumbrance": 16,
     "warmth": 5,
     "material_thickness": 2,
     "environmental_protection": 0,
-    "flags": [ "VARSIZE", "STURDY", "SKINTIGHT" ]
+    "flags": [ "VARSIZE", "STURDY", "SKINTIGHT" ],
+    "armor": { "coverage": 100, "covers": [ "torso" ], "encumbrance": 16 }
   },
   {
     "id": "ninja_gloves",
@@ -301,13 +289,11 @@
     "material": [ "cotton", "steel" ],
     "symbol": "[",
     "color": "black",
-    "covers": [ "hand_l", "hand_r" ],
-    "coverage": 100,
-    "encumbrance": 14,
     "warmth": 8,
     "material_thickness": 2,
     "environmental_protection": 0,
-    "flags": [ "VARSIZE", "STURDY" ]
+    "flags": [ "VARSIZE", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "hand_l", "hand_r" ], "encumbrance": 14 }
   },
   {
     "id": "ninja_gloves_survivor",
@@ -321,13 +307,11 @@
     "material": [ "kevlar", "cotton", "leather", "steel" ],
     "symbol": "[",
     "color": "red",
-    "covers": [ "hand_l", "hand_r" ],
-    "coverage": 100,
-    "encumbrance": 18,
     "warmth": 8,
     "material_thickness": 2,
     "environmental_protection": 4,
-    "flags": [ "VARSIZE", "STURDY", "RAINPROOF", "FANCY" ]
+    "flags": [ "VARSIZE", "STURDY", "RAINPROOF", "FANCY" ],
+    "armor": { "coverage": 100, "covers": [ "hand_l", "hand_r" ], "encumbrance": 18 }
   },
   {
     "id": "ninja_shoes",
@@ -341,13 +325,11 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "black",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 14,
     "warmth": 8,
     "material_thickness": 2,
     "environmental_protection": 0,
-    "flags": [ "VARSIZE", "STURDY" ]
+    "flags": [ "VARSIZE", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "foot_l", "foot_r" ], "encumbrance": 14 }
   },
   {
     "id": "ninja_boots_survivor",
@@ -361,9 +343,6 @@
     "material": [ "kevlar", "cotton", "leather", "steel", "plastic", "nomex" ],
     "symbol": "[",
     "color": "red",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 12,
     "warmth": 8,
     "material_thickness": 2,
     "environmental_protection": 18,
@@ -378,7 +357,8 @@
       }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Sheath knife", "holster_msg": "You sheath your %s" },
-    "flags": [ "VARSIZE", "STURDY", "RAINPROOF", "FANCY" ]
+    "flags": [ "VARSIZE", "STURDY", "RAINPROOF", "FANCY" ],
+    "armor": { "coverage": 100, "covers": [ "foot_l", "foot_r" ], "encumbrance": 12 }
   },
   {
     "id": "ninja_ration",
@@ -413,8 +393,6 @@
     "material": [ "wood" ],
     "symbol": "[",
     "color": "red",
-    "coverage": 0,
-    "encumbrance": 0,
     "warmth": 0,
     "material_thickness": 0,
     "environmental_protection": 0,
@@ -428,7 +406,8 @@
         }
       ]
     },
-    "flags": [ "FANCY" ]
+    "flags": [ "FANCY" ],
+    "armor": { "coverage": 0, "encumbrance": 0 }
   },
   {
     "id": "ninja_jetpack",
@@ -448,9 +427,6 @@
     "initial_charges": 0,
     "max_charges": 50,
     "charges_per_use": 0,
-    "covers": [ "torso" ],
-    "coverage": 50,
-    "encumbrance": 20,
     "warmth": 0,
     "material_thickness": 1,
     "environmental_protection": 0,
@@ -462,7 +438,8 @@
       "need_charges_msg": "You need rocket fuel for your jet pack.",
       "type": "transform"
     },
-    "flags": [ "STURDY", "RAINPROOF", "BELTED", "FANCY" ]
+    "flags": [ "STURDY", "RAINPROOF", "BELTED", "FANCY" ],
+    "armor": { "coverage": 50, "covers": [ "torso" ], "encumbrance": 20 }
   },
   {
     "id": "ninja_jetpack_on",
@@ -483,15 +460,13 @@
     "max_charges": 50,
     "turns_per_charge": 30,
     "revert_to": "ninja_jetpack",
-    "covers": [ "torso" ],
-    "coverage": 50,
-    "encumbrance": 20,
     "warmth": 0,
     "material_thickness": 1,
     "environmental_protection": 0,
     "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "SPEED", "multiply": 0.5 } ] } ] },
     "use_action": { "target": "ninja_jetpack", "msg": "You stopped the jet pack", "active": false, "type": "transform" },
-    "flags": [ "STURDY", "RAINPROOF", "BELTED", "FANCY", "TRADER_AVOID" ]
+    "flags": [ "STURDY", "RAINPROOF", "BELTED", "FANCY", "TRADER_AVOID" ],
+    "armor": { "coverage": 50, "covers": [ "torso" ], "encumbrance": 20 }
   },
   {
     "id": "ninja_gun_ay893",

--- a/data/Unleash_The_Mods/mods/Reproduction_mod/Items/item.json
+++ b/data/Unleash_The_Mods/mods/Reproduction_mod/Items/item.json
@@ -105,9 +105,8 @@
         "moves": 1
       }
     ],
-    "covers": [ "torso" ],
     "warmth": 0,
-    "coverage": 0
+    "armor": { "coverage": 0, "covers": [ "torso" ] }
   },
   {
     "id": "human_pregnancy_item",
@@ -119,14 +118,12 @@
     "flags": [ "ONLY_ONE", "TRADER_AVOID", "NO_DROP", "ZERO_WEIGHT" ],
     "weight": "0 g",
     "volume": "1 ml",
-    "covers": [ "torso" ],
     "warmth": 10,
-    "coverage": 25,
-    "encumbrance": 15,
     "max_charges": 9,
     "initial_charges": 9,
     "turns_per_charge": 2592000,
-    "revert_to": "human_birth_item"
+    "revert_to": "human_birth_item",
+    "armor": { "coverage": 25, "covers": [ "torso" ], "encumbrance": 15 }
   },
   {
     "id": "human_birth_item",

--- a/data/Unleash_The_Mods/mods/Vamp_stuff/Modification_Files/Items/Armor_Set/Infused/v_bloodinfusedset.json
+++ b/data/Unleash_The_Mods/mods/Vamp_stuff/Modification_Files/Items/Armor_Set/Infused/v_bloodinfusedset.json
@@ -14,14 +14,12 @@
     "material": [ "compactblood", "kevlar", "leather" ],
     "symbol": "[",
     "color": "red",
-    "covers": [ "head" ],
-    "coverage": 100,
-    "encumbrance": 25,
     "warmth": 20,
     "material_thickness": 1,
     "environmental_protection": 2,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY", "OUTER", "HOOD" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY", "OUTER", "HOOD" ],
+    "armor": { "coverage": 100, "covers": [ "head" ], "encumbrance": 25 }
   },
   {
     "id": "bloodinfused_survivorpants",
@@ -35,9 +33,6 @@
     "material": [ "compactblood", "kevlar", "cotton" ],
     "symbol": "[",
     "color": "red",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 100,
-    "encumbrance": 20,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1750 ml", "max_contains_weight": "3500 g", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1750 ml", "max_contains_weight": "3500 g", "moves": 75 }
@@ -45,7 +40,8 @@
     "warmth": 10,
     "material_thickness": 1,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "POCKETS", "STURDY", "WATERPROOF" ]
+    "flags": [ "VARSIZE", "POCKETS", "STURDY", "WATERPROOF" ],
+    "armor": { "coverage": 100, "covers": [ "leg_l", "leg_r" ], "encumbrance": 20 }
   },
   {
     "id": "bloodinfused_survivorduster",
@@ -60,9 +56,6 @@
     "material": [ "compactblood", "kevlar", "cotton" ],
     "symbol": "[",
     "color": "red",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 85,
-    "encumbrance": 15,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "3 L", "max_contains_weight": "6 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "3 L", "max_contains_weight": "6 kg", "moves": 75 },
@@ -74,7 +67,8 @@
     "warmth": 15,
     "material_thickness": 1,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "POCKETS", "HOOD", "COLLAR", "STURDY", "WATERPROOF", "RAINPROOF", "OUTER" ]
+    "flags": [ "VARSIZE", "POCKETS", "HOOD", "COLLAR", "STURDY", "WATERPROOF", "RAINPROOF", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 15 }
   },
   {
     "id": "bloodinfused_survivorgloves",
@@ -89,13 +83,11 @@
     "material": [ "compactblood", "kevlar", "leather" ],
     "symbol": "[",
     "color": "red",
-    "covers": [ "hand_l", "hand_r" ],
-    "coverage": 100,
-    "encumbrance": 20,
     "warmth": 20,
     "material_thickness": 1,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "hand_l", "hand_r" ], "encumbrance": 20 }
   },
   {
     "id": "bloodinfused_survivorboots",
@@ -111,13 +103,11 @@
     "material": [ "compactblood", "kevlar", "leather" ],
     "symbol": "[",
     "color": "red",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 25,
     "warmth": 20,
     "material_thickness": 1,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "foot_l", "foot_r" ], "encumbrance": 25 }
   },
   {
     "id": "bloodinfused_survivortrenchcoat",
@@ -132,9 +122,6 @@
     "material": [ "compactblood", "kevlar", "cotton" ],
     "symbol": "[",
     "color": "red",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 85,
-    "encumbrance": 15,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "3 L", "max_contains_weight": "6 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "3 L", "max_contains_weight": "6 kg", "moves": 75 },
@@ -146,6 +133,7 @@
     "warmth": 15,
     "material_thickness": 1,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "POCKETS", "HOOD", "COLLAR", "STURDY", "WATERPROOF", "RAINPROOF", "OUTER" ]
+    "flags": [ "VARSIZE", "POCKETS", "HOOD", "COLLAR", "STURDY", "WATERPROOF", "RAINPROOF", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 15 }
   }
 ]

--- a/data/Unleash_The_Mods/mods/Vamp_stuff/Modification_Files/Items/Armor_Set/Normal/v_bloodset.json
+++ b/data/Unleash_The_Mods/mods/Vamp_stuff/Modification_Files/Items/Armor_Set/Normal/v_bloodset.json
@@ -13,13 +13,11 @@
     "material": [ "compactblood" ],
     "symbol": "[",
     "color": "red",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 100,
-    "encumbrance": 5,
     "warmth": 10,
     "material_thickness": 1,
     "environmental_protection": 1,
-    "flags": [ "WATERPROOF", "STURDY", "SKINTIGHT" ]
+    "flags": [ "WATERPROOF", "STURDY", "SKINTIGHT" ],
+    "armor": { "coverage": 100, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 5 }
   },
   {
     "id": "blood_hood",
@@ -35,13 +33,11 @@
     "material": [ "compactblood", "leather", "cotton" ],
     "symbol": "[",
     "color": "red",
-    "covers": [ "head" ],
-    "coverage": 100,
-    "encumbrance": 15,
     "warmth": 20,
     "material_thickness": 1,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY", "OUTER", "HOOD" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY", "OUTER", "HOOD" ],
+    "armor": { "coverage": 100, "covers": [ "head" ], "encumbrance": 15 }
   },
   {
     "id": "blood_duster",
@@ -56,9 +52,6 @@
     "material": [ "compactblood", "leather", "cotton" ],
     "symbol": "[",
     "color": "red",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 85,
-    "encumbrance": 10,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "5 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "5 kg", "moves": 75 },
@@ -70,7 +63,8 @@
     "warmth": 20,
     "material_thickness": 1,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "POCKETS", "HOOD", "COLLAR", "STURDY", "WATERPROOF", "RAINPROOF", "OUTER" ]
+    "flags": [ "VARSIZE", "POCKETS", "HOOD", "COLLAR", "STURDY", "WATERPROOF", "RAINPROOF", "OUTER" ],
+    "armor": { "coverage": 85, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 10 }
   },
   {
     "id": "blood_gloves",
@@ -85,13 +79,11 @@
     "material": [ "compactblood", "leather" ],
     "symbol": "[",
     "color": "red",
-    "covers": [ "hand_l", "hand_r" ],
-    "coverage": 100,
-    "encumbrance": 10,
     "warmth": 15,
     "material_thickness": 1,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "hand_l", "hand_r" ], "encumbrance": 10 }
   },
   {
     "id": "blood_pants",
@@ -105,13 +97,11 @@
     "material": [ "compactblood", "leather" ],
     "symbol": "[",
     "color": "red",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 100,
-    "encumbrance": 10,
     "warmth": 15,
     "material_thickness": 1,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "STURDY", "WATERPROOF" ]
+    "flags": [ "VARSIZE", "STURDY", "WATERPROOF" ],
+    "armor": { "coverage": 100, "covers": [ "leg_l", "leg_r" ], "encumbrance": 10 }
   },
   {
     "id": "blood_boots",
@@ -127,12 +117,10 @@
     "material": [ "compactblood", "leather" ],
     "symbol": "[",
     "color": "red",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 15,
     "warmth": 20,
     "material_thickness": 1,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "foot_l", "foot_r" ], "encumbrance": 15 }
   }
 ]

--- a/data/Unleash_The_Mods/mods/Vamp_stuff/Modification_Files/Items/Armor_Set/v_bloodgear.json
+++ b/data/Unleash_The_Mods/mods/Vamp_stuff/Modification_Files/Items/Armor_Set/v_bloodgear.json
@@ -11,9 +11,6 @@
     "material": [ "compactblood" ],
     "symbol": "[",
     "color": "red",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 10,
-    "encumbrance": 0,
     "material_thickness": 1,
     "pocket_data": [
       {
@@ -28,7 +25,8 @@
     ],
     "use_action": { "type": "holster", "holster_prompt": "Sheath knife", "holster_msg": "You have sheath your %s" },
     "looks_like": "sheath",
-    "flags": [ "BELTED", "OVERSIZE", "STURDY", "ALLOWS_NATURAL_ATTACKS", "WATER_FRIENDLY" ]
+    "flags": [ "BELTED", "OVERSIZE", "STURDY", "ALLOWS_NATURAL_ATTACKS", "WATER_FRIENDLY" ],
+    "armor": { "coverage": 10, "covers": [ "foot_l", "foot_r" ], "encumbrance": 0 }
   },
   {
     "id": "bloodwristsheath",
@@ -42,9 +40,6 @@
     "material": [ "compactblood" ],
     "symbol": "[",
     "color": "red",
-    "covers": [ "hand_l", "hand_r" ],
-    "coverage": 5,
-    "encumbrance": 1,
     "material_thickness": 1,
     "pocket_data": [
       {
@@ -59,7 +54,8 @@
     ],
     "use_action": { "type": "holster", "holster_prompt": "Sheath knife", "holster_msg": "You have sheath your %s" },
     "looks_like": "sheath",
-    "flags": [ "BELTED", "OVERSIZE", "STURDY", "ALLOWS_NATURAL_ATTACKS", "WATER_FRIENDLY" ]
+    "flags": [ "BELTED", "OVERSIZE", "STURDY", "ALLOWS_NATURAL_ATTACKS", "WATER_FRIENDLY" ],
+    "armor": { "coverage": 5, "covers": [ "hand_l", "hand_r" ], "encumbrance": 1 }
   },
   {
     "id": "bloodpack",
@@ -72,9 +68,6 @@
     "material": [ "compactblood", "cotton" ],
     "symbol": "[",
     "color": "red",
-    "covers": [ "torso" ],
-    "coverage": 5,
-    "encumbrance": 10,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "3 L", "max_contains_weight": "6 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "3 L", "max_contains_weight": "6 kg", "moves": 75 },
@@ -85,7 +78,8 @@
     ],
     "material_thickness": 1,
     "looks_like": "backpack",
-    "flags": [ "WATER_FRIENDLY", "STURDY", "BELTED" ]
+    "flags": [ "WATER_FRIENDLY", "STURDY", "BELTED" ],
+    "armor": { "coverage": 5, "covers": [ "torso" ], "encumbrance": 10 }
   },
   {
     "id": "bigbloodpack",
@@ -98,9 +92,6 @@
     "material": [ "compactblood", "cotton" ],
     "symbol": "[",
     "color": "red",
-    "covers": [ "torso" ],
-    "coverage": 10,
-    "encumbrance": 20,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "5 L", "max_contains_weight": "10 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "5 L", "max_contains_weight": "10 kg", "moves": 75 },
@@ -111,6 +102,7 @@
     ],
     "material_thickness": 1,
     "looks_like": "backpack",
-    "flags": [ "WATER_FRIENDLY", "STURDY", "BELTED" ]
+    "flags": [ "WATER_FRIENDLY", "STURDY", "BELTED" ],
+    "armor": { "coverage": 10, "covers": [ "torso" ], "encumbrance": 20 }
   }
 ]

--- a/data/Unleash_The_Mods/mods/Vamp_stuff/Modification_Files/Spells/_Misc/v_spell_item.json
+++ b/data/Unleash_The_Mods/mods/Vamp_stuff/Modification_Files/Spells/_Misc/v_spell_item.json
@@ -34,7 +34,6 @@
     "volume": "3 ml",
     "price": "0 cent",
     "material": [ "flesh" ],
-    "coverage": 100,
     "symbol": "0",
     "color": "red",
     "relic_data": {
@@ -47,8 +46,8 @@
         }
       ]
     },
-    "covers": [ "head", "torso", "arm_r", "arm_l", "leg_r", "leg_l" ],
-    "flags": [ "PERSONAL", "OVERSIZE", "BLOCK_WHILE_WORN", "SEMITANGIBLE", "NO_DROP" ]
+    "flags": [ "PERSONAL", "OVERSIZE", "BLOCK_WHILE_WORN", "SEMITANGIBLE", "NO_DROP" ],
+    "armor": { "coverage": 100, "covers": [ "head", "torso", "arm_r", "arm_l", "leg_r", "leg_l" ] }
   },
   {
     "id": "v_hemo_form_orus",
@@ -84,7 +83,6 @@
     "volume": "3 ml",
     "price": "0 cent",
     "material": [ "ethereal" ],
-    "coverage": 0,
     "symbol": "0",
     "color": "red",
     "relic_data": {
@@ -97,7 +95,7 @@
         }
       ]
     },
-    "covers": [ "arm_r", "arm_l" ],
-    "flags": [ "AURA", "ONLY_ONE", "SEMITANGIBLE", "NO_DROP" ]
+    "flags": [ "AURA", "ONLY_ONE", "SEMITANGIBLE", "NO_DROP" ],
+    "armor": { "coverage": 0, "covers": [ "arm_r", "arm_l" ] }
   }
 ]

--- a/data/Unleash_The_Mods/mods/Vorpal_Weapons/mizu_item.json
+++ b/data/Unleash_The_Mods/mods/Vorpal_Weapons/mizu_item.json
@@ -13,10 +13,8 @@
     "weight": "150 g",
     "volume": "1 L",
     "to_hit": -3,
-    "covers": [ "mouth" ],
-    "encumbrance": 40,
-    "coverage": 75,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 75, "covers": [ "mouth" ], "encumbrance": 40 }
   },
   {
     "id": "snorkel_makeshift_mizu",
@@ -32,10 +30,8 @@
     "weight": "350 g",
     "volume": "1250 ml",
     "to_hit": -3,
-    "covers": [ "mouth" ],
-    "encumbrance": 60,
-    "coverage": 75,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 75, "covers": [ "mouth" ], "encumbrance": 60 }
   },
   {
     "result": "snorkel_makeshift_mizu",

--- a/data/Unleash_The_Mods/mods/Vorpal_Weapons/vo_armor.json
+++ b/data/Unleash_The_Mods/mods/Vorpal_Weapons/vo_armor.json
@@ -11,13 +11,11 @@
     "material": [ "plastic" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "mouth" ],
-    "coverage": 100,
-    "encumbrance": 20,
     "warmth": 10,
     "extend": { "flags": [ "OVERSIZE" ] },
     "material_thickness": 2,
-    "environmental_protection": 7
+    "environmental_protection": 7,
+    "armor": { "coverage": 100, "covers": [ "mouth" ], "encumbrance": 20 }
   },
   {
     "id": "arm_warmers_xl_vo",
@@ -30,12 +28,10 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "arm_l", "arm_r" ],
-    "coverage": 80,
-    "encumbrance": 7,
     "warmth": 20,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "SKINTIGHT", "OVERSIZE" ]
+    "flags": [ "VARSIZE", "SKINTIGHT", "OVERSIZE" ],
+    "armor": { "coverage": 80, "covers": [ "arm_l", "arm_r" ], "encumbrance": 7 }
   },
   {
     "id": "quiver_leg_vo",
@@ -50,12 +46,10 @@
     "material": [ "leather" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 5,
-    "encumbrance": 7,
     "material_thickness": 1,
     "pocket_data": [ { "ammo_restriction": { "arrow": 10, "bolt": 10 }, "moves": 3 } ],
-    "flags": [ "WAIST", "VARSIZE", "OVERSIZE" ]
+    "flags": [ "WAIST", "VARSIZE", "OVERSIZE" ],
+    "armor": { "coverage": 5, "covers": [ "leg_l", "leg_r" ], "encumbrance": 7 }
   },
   {
     "id": "assist_armor_off_vo",
@@ -84,13 +78,11 @@
     "charges_per_use": 1,
     "ammo": [ "battery" ],
     "revert_to": "assist_armor_off_vo",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
     "warmth": 0,
     "environmental_protection": 0,
-    "encumbrance": 20,
-    "coverage": 40,
     "material_thickness": 2,
-    "use_action": [ { "type": "transform", "msg": "I turned on the assist function.", "active": true, "target": "assist_armor_on_vo" } ]
+    "use_action": [ { "type": "transform", "msg": "I turned on the assist function.", "active": true, "target": "assist_armor_on_vo" } ],
+    "armor": { "coverage": 40, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r", "foot_l", "foot_r" ], "encumbrance": 20 }
   },
   {
     "id": "assist_armor_on_vo",
@@ -119,11 +111,8 @@
     "turns_per_charge": 4,
     "ammo": [ "battery" ],
     "revert_to": "assist_armor_off_vo",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
     "warmth": 0,
     "environmental_protection": 0,
-    "encumbrance": 10,
-    "coverage": 40,
     "material_thickness": 2,
     "use_action": [ { "type": "transform", "msg": "Assist function turned off.", "target": "assist_armor_off_vo" } ],
     "relic_data": {
@@ -135,6 +124,7 @@
           "mutations": [ "STRONGBACK", "PACKMULE" ]
         }
       ]
-    }
+    },
+    "armor": { "coverage": 40, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r", "foot_l", "foot_r" ], "encumbrance": 10 }
   }
 ]

--- a/data/Unleash_The_Mods/mods/Vorpal_Weapons/vo_kaihen.json
+++ b/data/Unleash_The_Mods/mods/Vorpal_Weapons/vo_kaihen.json
@@ -4,7 +4,6 @@
     "id": "survivor_belt_notools",
     "type": "ARMOR",
     "name": { "str": "survivor belt" },
-    "encumbrance": 1,
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -15,7 +14,8 @@
         "flag_restriction": [ "SHEATH_KNIFE", "SHEATH_SWORD", "BELT_CLIP" ]
       }
     ],
-    "use_action": { "type": "holster", "holster_prompt": "Sheath blade", "holster_msg": "You sheath your %s" }
+    "use_action": { "type": "holster", "holster_prompt": "Sheath blade", "holster_msg": "You sheath your %s" },
+    "armor": { "encumbrance": 1 }
   },
   {
     "copy-from": "noise_emitter_on",
@@ -234,8 +234,7 @@
     "name": { "str": "pair of rollerskates", "str_pl": "pairs of rollerskates" },
     "volume": "3000 ml",
     "warmth": 0,
-    "encumbrance": 25,
     "flags": [ "VARSIZE", "WATERPROOF", "BELTED" ],
-    "coverage": 10
+    "armor": { "coverage": 10, "encumbrance": 25 }
   }
 ]

--- a/data/Unleash_The_Mods/mods/Vorpal_Weapons/vo_shield.json
+++ b/data/Unleash_The_Mods/mods/Vorpal_Weapons/vo_shield.json
@@ -6,18 +6,16 @@
     "description": "It is a big shield made by Kevlar. It has size enough to cover the whole body and high bulletproof performance, and it is adopted for security maintenance organization of each country.",
     "weight": "9535 g",
     "color": "light_gray",
-    "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ],
     "price": "5 kUSD",
     "material": [ "kevlar", "steel" ],
     "volume": "5500 ml",
     "to_hit": -1,
-    "encumbrance": 28,
     "bashing": 10,
     "symbol": "[",
     "flags": [ "OVERSIZE", "STURDY", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ],
     "techniques": [ "WBLOCK_3" ],
-    "coverage": 90,
-    "material_thickness": 4
+    "material_thickness": 4,
+    "armor": { "coverage": 90, "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ], "encumbrance": 28 }
   },
   {
     "id": "shield_bal_mid_vo",
@@ -26,17 +24,15 @@
     "description": "It is a Kevlar shield. It is compatible with portability and minimal protection range, and it is mainly used in special forces.",
     "weight": "3535 g",
     "color": "light_gray",
-    "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ],
     "price": "5 kUSD",
     "material": [ "kevlar", "steel" ],
     "volume": "3500 ml",
-    "encumbrance": 12,
     "bashing": 14,
     "symbol": "[",
     "flags": [ "OVERSIZE", "STURDY", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ],
     "techniques": [ "WBLOCK_2" ],
-    "coverage": 40,
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 40, "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ], "encumbrance": 12 }
   },
   {
     "id": "shield_riot_vo",
@@ -45,18 +41,16 @@
     "description": "It is a transparent shield made of reinforced resin. It is light in weight for size, has wide protection range and high visibility.",
     "weight": "3200 g",
     "color": "light_gray",
-    "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ],
     "price": "5 kUSD",
     "material": [ "plastic" ],
     "volume": "5 L",
     "to_hit": -1,
-    "encumbrance": 24,
     "bashing": 10,
     "symbol": "[",
     "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ],
     "techniques": [ "WBLOCK_3" ],
-    "coverage": 80,
-    "material_thickness": 5
+    "material_thickness": 5,
+    "armor": { "coverage": 80, "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ], "encumbrance": 24 }
   },
   {
     "id": "shield_pot_vo",
@@ -65,18 +59,16 @@
     "description": "It is a lid of a pan. I cloth is wrapped around the handle so as not to damage my hands. If you look only at the form you will not be able to insist as a shield.",
     "weight": "440 g",
     "color": "light_gray",
-    "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ],
     "price": "0 cent",
     "material": [ "iron" ],
     "volume": "1 L",
     "to_hit": -2,
-    "encumbrance": 8,
     "bashing": 6,
     "symbol": "[",
     "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN", "FRAGILE" ],
     "techniques": [ "WBLOCK_1" ],
-    "coverage": 20,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 20, "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ], "encumbrance": 8 }
   },
   {
     "id": "shield_briefcase_vo",
@@ -85,11 +77,9 @@
     "description": "Kevlar board is embedded inside this briefcase. The loading capacity is reduced by that much, but we will protect our lives as well as our luggage.",
     "weight": "4200 g",
     "color": "light_gray",
-    "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ],
     "price": "2400 USD",
     "material": [ "kevlar", "plastic" ],
     "volume": "1500 ml",
-    "encumbrance": 30,
     "to_hit": -2,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "3 kg", "moves": 80 },
@@ -101,8 +91,8 @@
     "symbol": "[",
     "flags": [ "FANCY", "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ],
     "techniques": [ "WBLOCK_1" ],
-    "coverage": 30,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 30, "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ], "encumbrance": 30 }
   },
   {
     "id": "helicopter",

--- a/data/Unleash_The_Mods/mods/battletech/Battle_Armor/Armors/Clan/armor.json
+++ b/data/Unleash_The_Mods/mods/battletech/Battle_Armor/Armors/Clan/armor.json
@@ -15,8 +15,6 @@
     "max_charges": 50000,
     "warmth": 30,
     "environmental_protection": 5,
-    "encumbrance": 30,
-    "coverage": 90,
     "material_thickness": 8,
     "flags": [
       "VARSIZE",
@@ -40,13 +38,17 @@
       "name": { "str": "socks" },
       "valid_mod_locations": [ [ "accessories", 250 ] ]
     },
-    "covers": [ "head", "mouth", "eyes", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
     "use_action": { "type": "transform", "msg": "You activate the suit.", "target": "elemental_ON", "active": true },
     "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "mutations": [ "AEP_STR_UP" ] } ] },
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "5 kg", "moves": 120 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "5 kg", "moves": 120 }
-    ]
+    ],
+    "armor": {
+      "coverage": 90,
+      "covers": [ "head", "mouth", "eyes", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 30
+    }
   },
   {
     "id": "elemental_ON",
@@ -65,8 +67,6 @@
     "ammo": [ "h_cell" ],
     "warmth": 30,
     "environmental_protection": 15,
-    "encumbrance": 10,
-    "coverage": 100,
     "material_thickness": 12,
     "flags": [
       "VARSIZE",
@@ -90,12 +90,16 @@
       "name": { "str": "socks" },
       "valid_mod_locations": [ [ "accessories", 4 ] ]
     },
-    "covers": [ "head", "mouth", "eyes", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
     "use_action": { "type": "transform", "menu_text": "Turn off", "msg": "You deactivate the suit..", "target": "power_armor_basic" },
     "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "mutations": [ "AEP_STR_UP", "AEP_STR_UP" ] } ] },
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "2 kg", "moves": 120 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "2 kg", "moves": 120 }
-    ]
+    ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "head", "mouth", "eyes", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 10
+    }
   }
 ]

--- a/data/Unleash_The_Mods/mods/battletech/Battle_Armor/Armors/Inner_Sphere/armor.json
+++ b/data/Unleash_The_Mods/mods/battletech/Battle_Armor/Armors/Inner_Sphere/armor.json
@@ -15,9 +15,6 @@
     "symbol": "[",
     "color": "light_gray",
     "max_charges": 30000,
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 30,
     "warmth": 90,
     "power_armor": true,
     "material_thickness": 11,
@@ -36,7 +33,8 @@
       { "pocket_type": "CONTAINER", "max_contains_volume": "1000 ml", "max_contains_weight": "5 kg", "moves": 120 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1000 ml", "max_contains_weight": "5 kg", "moves": 120 }
     ],
-    "flags": [ "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE", "RECHARGE", "POWERED", "UPS" ]
+    "flags": [ "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE", "RECHARGE", "POWERED", "UPS" ],
+    "armor": { "coverage": 100, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r", "foot_l", "foot_r" ], "encumbrance": 30 }
   },
   {
     "id": "tornado_on",
@@ -55,9 +53,6 @@
     "color": "light_gray",
     "turns_per_charge": 1,
     "max_charges": 30000,
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 30,
     "warmth": 90,
     "power_armor": true,
     "material_thickness": 11,
@@ -71,6 +66,7 @@
       { "pocket_type": "CONTAINER", "max_contains_volume": "1000 ml", "max_contains_weight": "5 kg", "moves": 120 }
     ],
     "use_action": { "type": "transform", "target": "tornado", "active": false, "msg": "You deactivate the armor." },
-    "flags": [ "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE", "RECHARGE", "POWERED", "UPS" ]
+    "flags": [ "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE", "RECHARGE", "POWERED", "UPS" ],
+    "armor": { "coverage": 100, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r", "foot_l", "foot_r" ], "encumbrance": 30 }
   }
 ]

--- a/data/Unleash_The_Mods/mods/mycus/item/armor.json
+++ b/data/Unleash_The_Mods/mods/mycus/item/armor.json
@@ -11,13 +11,11 @@
     "material": [ "veggy" ],
     "symbol": "[",
     "color": "light_red",
-    "covers": [ "head" ],
-    "coverage": 70,
-    "encumbrance": 30,
     "warmth": 5,
     "material_thickness": 2,
     "environmental_protection": 2,
-    "flags": [ "WATER_FRIENDLY", "SUN_GLASSES", "OVERSIZE" ]
+    "flags": [ "WATER_FRIENDLY", "SUN_GLASSES", "OVERSIZE" ],
+    "armor": { "coverage": 70, "covers": [ "head" ], "encumbrance": 30 }
   },
   {
     "id": "mushroom_helmet01",
@@ -31,13 +29,11 @@
     "material": [ "veggy" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "head" ],
-    "coverage": 100,
-    "encumbrance": 60,
     "warmth": 10,
     "material_thickness": 5,
     "environmental_protection": 2,
-    "flags": [ "WATER_FRIENDLY", "SUN_GLASSES", "OVERSIZE", "STURDY" ]
+    "flags": [ "WATER_FRIENDLY", "SUN_GLASSES", "OVERSIZE", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "head" ], "encumbrance": 60 }
   },
   {
     "id": "mushroom_helmet02",
@@ -51,13 +47,11 @@
     "material": [ "veggy" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "head" ],
-    "coverage": 100,
-    "encumbrance": 60,
     "warmth": 10,
     "material_thickness": 14,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "WATER_FRIENDLY", "WATERPROOF", "SUN_GLASSES", "OVERSIZE", "STURDY" ]
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "WATERPROOF", "SUN_GLASSES", "OVERSIZE", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "head" ], "encumbrance": 60 }
   },
   {
     "id": "mushroom_suit01",
@@ -70,14 +64,12 @@
     "material": [ "veggy" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 70,
-    "encumbrance": 8,
     "storage": 4,
     "warmth": 10,
     "material_thickness": 1,
     "environmental_protection": 2,
-    "flags": [ "OVERSIZE", "WATER_FRIENDLY" ]
+    "flags": [ "OVERSIZE", "WATER_FRIENDLY" ],
+    "armor": { "coverage": 70, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 8 }
   },
   {
     "id": "mushroom_armor01",
@@ -90,14 +82,12 @@
     "material": [ "veggy" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 87,
-    "encumbrance": 24,
     "storage": 6,
     "warmth": 10,
     "material_thickness": 10,
     "environmental_protection": 2,
-    "flags": [ "OVERSIZE", "WATER_FRIENDLY", "STURDY" ]
+    "flags": [ "OVERSIZE", "WATER_FRIENDLY", "STURDY" ],
+    "armor": { "coverage": 87, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 24 }
   },
   {
     "id": "mushroom_armor02",
@@ -110,15 +100,13 @@
     "material": [ "veggy" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 100,
-    "encumbrance": 27,
     "storage": 8,
     "warmth": 10,
     "material_thickness": 14,
     "environmental_protection": 2,
     "flags": [ "VARSIZE", "OVERSIZE", "WATERPROOF", "RAINPROOF", "WATER_FRIENDLY", "STURDY" ],
-    "use_action": { "type": "holster", "max_volume": 15, "draw_cost": 150, "skills": [ "smg", "shotgun", "rifle", "launcher" ] }
+    "use_action": { "type": "holster", "max_volume": 15, "draw_cost": 150, "skills": [ "smg", "shotgun", "rifle", "launcher" ] },
+    "armor": { "coverage": 100, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 27 }
   },
   {
     "id": "mushroom_shoes",
@@ -131,13 +119,11 @@
     "material": [ "veggy" ],
     "symbol": "[",
     "color": "light_red",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 80,
-    "encumbrance": 20,
     "warmth": 4,
     "material_thickness": 1,
     "environmental_protection": 1,
-    "flags": [ "OVERSIZE", "WATER_FRIENDLY" ]
+    "flags": [ "OVERSIZE", "WATER_FRIENDLY" ],
+    "armor": { "coverage": 80, "covers": [ "foot_l", "foot_r" ], "encumbrance": 20 }
   },
   {
     "id": "mushroom_boots",
@@ -150,9 +136,6 @@
     "material": [ "veggy" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 27,
     "warmth": 9,
     "material_thickness": 12,
     "environmental_protection": 2,
@@ -164,7 +147,8 @@
       "max_volume": 2,
       "draw_cost": 30,
       "flags": [ "SHEATH_KNIFE" ]
-    }
+    },
+    "armor": { "coverage": 100, "covers": [ "foot_l", "foot_r" ], "encumbrance": 27 }
   },
   {
     "id": "mushroom_boots02",
@@ -177,9 +161,6 @@
     "material": [ "veggy" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 27,
     "warmth": 9,
     "material_thickness": 14,
     "environmental_protection": 2,
@@ -191,7 +172,8 @@
       "max_volume": 2,
       "draw_cost": 30,
       "flags": [ "SHEATH_KNIFE" ]
-    }
+    },
+    "armor": { "coverage": 100, "covers": [ "foot_l", "foot_r" ], "encumbrance": 27 }
   },
   {
     "id": "mushroom_gloves",
@@ -204,13 +186,11 @@
     "material": [ "veggy" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "hand_l", "hand_r" ],
-    "coverage": 80,
-    "encumbrance": 8,
     "warmth": 10,
     "material_thickness": 2,
     "environmental_protection": 2,
-    "flags": [ "OVERSIZE", "WATER_FRIENDLY" ]
+    "flags": [ "OVERSIZE", "WATER_FRIENDLY" ],
+    "armor": { "coverage": 80, "covers": [ "hand_l", "hand_r" ], "encumbrance": 8 }
   },
   {
     "id": "mushroom_gauntlet",
@@ -223,13 +203,11 @@
     "material": [ "veggy" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "hand_l", "hand_r" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "warmth": 10,
     "material_thickness": 9,
     "environmental_protection": 2,
-    "flags": [ "OVERSIZE", "WATER_FRIENDLY", "STURDY" ]
+    "flags": [ "OVERSIZE", "WATER_FRIENDLY", "STURDY" ],
+    "armor": { "coverage": 95, "covers": [ "hand_l", "hand_r" ], "encumbrance": 20 }
   },
   {
     "id": "mushroom_gauntlet02",
@@ -242,13 +220,11 @@
     "material": [ "veggy" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "hand_l", "hand_r" ],
-    "coverage": 100,
-    "encumbrance": 24,
     "warmth": 10,
     "material_thickness": 14,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "OVERSIZE", "WATER_FRIENDLY", "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "OVERSIZE", "WATER_FRIENDLY", "WATERPROOF", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "hand_l", "hand_r" ], "encumbrance": 24 }
   },
   {
     "id": "cloak_mushroom",
@@ -262,13 +238,11 @@
     "material": [ "veggy" ],
     "symbol": "[",
     "color": "light_red",
-    "covers": [ "torso", "head", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 95,
-    "encumbrance": 6,
     "warmth": 50,
     "material_thickness": 2,
     "environmental_protection": 3,
-    "flags": [ "OVERSIZE", "HOOD", "OUTER", "WATER_FRIENDLY" ]
+    "flags": [ "OVERSIZE", "HOOD", "OUTER", "WATER_FRIENDLY" ],
+    "armor": { "coverage": 95, "covers": [ "torso", "head", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 6 }
   },
   {
     "id": "armor_cloak_mushroom",
@@ -282,14 +256,12 @@
     "material": [ "veggy" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso", "arm_l", "arm_r", "mouth", "eyes", "leg_l", "leg_r" ],
-    "coverage": 100,
-    "encumbrance": 30,
     "warmth": 30,
     "material_thickness": 6,
     "environmental_protection": 9,
     "flags": [ "VARSIZE", "OVERSIZE", "HOOD", "OUTER", "WATER_FRIENDLY", "STURDY", "RAD_RESIST", "GAS_PROOF" ],
-    "use_action": { "type": "holster", "max_volume": 15, "draw_cost": 150, "skills": [ "smg", "shotgun", "rifle", "launcher" ] }
+    "use_action": { "type": "holster", "max_volume": 15, "draw_cost": 150, "skills": [ "smg", "shotgun", "rifle", "launcher" ] },
+    "armor": { "coverage": 100, "covers": [ "torso", "arm_l", "arm_r", "mouth", "eyes", "leg_l", "leg_r" ], "encumbrance": 30 }
   },
   {
     "id": "armor_mask_mushroom02",
@@ -303,13 +275,11 @@
     "material": [ "veggy" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "eyes", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 10,
     "warmth": 30,
     "material_thickness": 9,
     "environmental_protection": 14,
-    "flags": [ "VARSIZE", "OVERSIZE", "HOOD", "OUTER", "WATER_FRIENDLY", "STURDY", "RAD_RESIST", "GAS_PROOF" ]
+    "flags": [ "VARSIZE", "OVERSIZE", "HOOD", "OUTER", "WATER_FRIENDLY", "STURDY", "RAD_RESIST", "GAS_PROOF" ],
+    "armor": { "coverage": 100, "covers": [ "eyes", "mouth" ], "encumbrance": 10 }
   },
   {
     "id": "mushroom_pochi",
@@ -322,11 +292,8 @@
     "material": [ "veggy" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "torso" ],
     "to_hit": -2,
     "bashing": 2,
-    "coverage": 4,
-    "encumbrance": 6,
     "storage": 12,
     "warmth": 0,
     "material_thickness": 1,
@@ -338,7 +305,8 @@
       "max_volume": 3,
       "draw_cost": 160,
       "flags": [ "SHEATH_SWORD", "SHEATH_KNIFE" ]
-    }
+    },
+    "armor": { "coverage": 4, "covers": [ "torso" ], "encumbrance": 6 }
   },
   {
     "id": "mushroom_bag",
@@ -351,11 +319,8 @@
     "material": [ "veggy" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "torso" ],
     "to_hit": -2,
     "bashing": 2,
-    "coverage": 15,
-    "encumbrance": 12,
     "storage": 36,
     "warmth": 0,
     "material_thickness": 1,
@@ -367,7 +332,8 @@
       "max_volume": 15,
       "draw_cost": 140,
       "flags": [ "SHEATH_KNIFE", "SHEATH_SWORD" ]
-    }
+    },
+    "armor": { "coverage": 15, "covers": [ "torso" ], "encumbrance": 12 }
   },
   {
     "id": "mushroom_bag02",
@@ -380,11 +346,8 @@
     "material": [ "veggy" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "torso" ],
     "to_hit": -2,
     "bashing": 2,
-    "coverage": 15,
-    "encumbrance": 10,
     "storage": 46,
     "warmth": 0,
     "material_thickness": 1,
@@ -396,7 +359,8 @@
       "max_volume": 15,
       "draw_cost": 140,
       "flags": [ "SHEATH_KNIFE", "SHEATH_SWORD" ]
-    }
+    },
+    "armor": { "coverage": 15, "covers": [ "torso" ], "encumbrance": 10 }
   },
   {
     "id": "mushroom_legpouch",
@@ -410,9 +374,6 @@
     "material": [ "veggy" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 20,
-    "encumbrance": 5,
     "material_thickness": 1,
     "storage": 2,
     "use_action": {
@@ -423,7 +384,8 @@
       "draw_cost": 60,
       "flags": [ "MAG_COMPACT", "MAG_BULKY" ]
     },
-    "flags": [ "OVERSIZE", "WATER_FRIENDLY", "BELTED" ]
+    "flags": [ "OVERSIZE", "WATER_FRIENDLY", "BELTED" ],
+    "armor": { "coverage": 20, "covers": [ "leg_l", "leg_r" ], "encumbrance": 5 }
   },
   {
     "id": "shield_mushroom",
@@ -437,13 +399,11 @@
     "material": [ "veggy" ],
     "symbol": "[",
     "color": "light_red",
-    "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 40,
-    "encumbrance": 20,
     "warmth": 0,
     "material_thickness": 2,
     "environmental_protection": 2,
-    "flags": [ "OVERSIZE", "BLOCK_WHILE_WORN", "BELTED", "WATER_FRIENDLY" ]
+    "flags": [ "OVERSIZE", "BLOCK_WHILE_WORN", "BELTED", "WATER_FRIENDLY" ],
+    "armor": { "coverage": 40, "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 20 }
   },
   {
     "id": "large_shield_mushroom",
@@ -457,13 +417,11 @@
     "material": [ "veggy" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 100,
-    "encumbrance": 45,
     "warmth": 0,
     "material_thickness": 11,
     "environmental_protection": 3,
-    "flags": [ "OVERSIZE", "BLOCK_WHILE_WORN", "BELTED", "STURDY", "WATER_FRIENDLY" ]
+    "flags": [ "OVERSIZE", "BLOCK_WHILE_WORN", "BELTED", "STURDY", "WATER_FRIENDLY" ],
+    "armor": { "coverage": 100, "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 45 }
   },
   {
     "id": "large_shield_mushroom02",
@@ -477,13 +435,11 @@
     "material": [ "veggy" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 100,
-    "encumbrance": 45,
     "warmth": 0,
     "material_thickness": 14,
     "environmental_protection": 3,
-    "flags": [ "OVERSIZE", "VARSIZE", "BLOCK_WHILE_WORN", "BELTED", "STURDY", "WATER_FRIENDLY" ]
+    "flags": [ "OVERSIZE", "VARSIZE", "BLOCK_WHILE_WORN", "BELTED", "STURDY", "WATER_FRIENDLY" ],
+    "armor": { "coverage": 100, "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 45 }
   },
   {
     "id": "umbrella_mushroom",

--- a/data/broken_mods/Shelved/PKs_Rebalancing/items/armor.json
+++ b/data/broken_mods/Shelved/PKs_Rebalancing/items/armor.json
@@ -10,9 +10,9 @@
     "material": [ "leather" ],
     "symbol": "[",
     "color": "dark_gray",
-    "armor_data": { "covers": [ "arm_l", "arm_r" ], "sided": true, "coverage": 10, "encumbrance": 3, "material_thickness": 1 },
     "pocket_data": [ { "ammo_restriction": { "bomblet": 12 }, "moves": 15 } ],
-    "flags": [ "WATER_FRIENDLY", "BELTED", "OVERSIZE", "STURDY", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "WATER_FRIENDLY", "BELTED", "OVERSIZE", "STURDY", "ALLOWS_NATURAL_ATTACKS" ],
+    "armor": { "covers": [ "arm_l", "arm_r" ], "sided": true, "coverage": 10, "encumbrance": 3, "material_thickness": 1 }
   },
   {
     "id": "megaarmor_torso_1",
@@ -29,9 +29,6 @@
     "looks_like": "swat_armor",
     "symbol": "[",
     "color": "light_green",
-    "covers": [ "torso" ],
-    "coverage": 96,
-    "encumbrance": 24,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "4 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "4 kg", "moves": 80 },
@@ -48,7 +45,8 @@
     "material_thickness": 3,
     "environmental_protection": 4,
     "use_action": { "type": "holster" },
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY", "OUTER" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY", "OUTER" ],
+    "armor": { "coverage": 96, "covers": [ "torso" ], "encumbrance": 24 }
   },
   {
     "id": "megaarmor_torso_2",
@@ -63,9 +61,6 @@
     "looks_like": "jumpsuit",
     "symbol": "[",
     "color": "blue",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
-    "coverage": 100,
-    "encumbrance": 10,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "250 ml", "max_contains_weight": "745 g", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "250 ml", "max_contains_weight": "745 g", "moves": 80 }
@@ -73,7 +68,8 @@
     "warmth": 20,
     "material_thickness": 1,
     "environmental_protection": 5,
-    "flags": [ "VARSIZE", "WATERPROOF", "SKINTIGHT", "RAD_RESIST", "STURDY", "SUPER_FANCY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "SKINTIGHT", "RAD_RESIST", "STURDY", "SUPER_FANCY" ],
+    "armor": { "coverage": 100, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "encumbrance": 10 }
   },
   {
     "id": "megaarmor_torso_3",
@@ -89,9 +85,6 @@
     "symbol": "[",
     "color": "light_red",
     "initial_charges": 25,
-    "covers": [ "torso", "leg_l", "leg_r", "foot_l", "foot_r", "arm_l", "arm_r", "hand_r", "hand_l" ],
-    "coverage": 100,
-    "encumbrance": 38,
     "ammo": [ "battery" ],
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1750 ml", "max_contains_weight": "4 kg", "moves": 80 },
@@ -125,7 +118,12 @@
       "target": "megaarmor_torso_3_act",
       "active": true
     },
-    "flags": [ "VARSIZE", "OVERSIZE", "WATERPROOF", "STURDY", "NO_REPAIR" ]
+    "flags": [ "VARSIZE", "OVERSIZE", "WATERPROOF", "STURDY", "NO_REPAIR" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "leg_l", "leg_r", "foot_l", "foot_r", "arm_l", "arm_r", "hand_r", "hand_l" ],
+      "encumbrance": 38
+    }
   },
   {
     "id": "megaarmor_torso_3_act",
@@ -140,9 +138,6 @@
     "looks_like": "depowered_armor",
     "symbol": "[",
     "color": "light_red",
-    "covers": [ "torso", "leg_l", "leg_r", "foot_l", "foot_r", "arm_l", "arm_r", "hand_l", "hand_r" ],
-    "coverage": 100,
-    "encumbrance": 24,
     "ammo": [ "battery" ],
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1750 ml", "max_contains_weight": "4 kg", "moves": 80 },
@@ -178,7 +173,12 @@
       ]
     },
     "use_action": { "type": "transform", "msg": "The exoskeleton silently powers down.", "target": "megaarmor_torso_3" },
-    "flags": [ "VARSIZE", "OVERSIZE", "WATERPROOF", "STURDY", "NO_REPAIR" ]
+    "flags": [ "VARSIZE", "OVERSIZE", "WATERPROOF", "STURDY", "NO_REPAIR" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "leg_l", "leg_r", "foot_l", "foot_r", "arm_l", "arm_r", "hand_l", "hand_r" ],
+      "encumbrance": 24
+    }
   },
   {
     "id": "megaarmor_head_1",
@@ -195,14 +195,12 @@
     "looks_like": "depowered_helmet",
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "head", "eyes", "mouth" ],
-    "coverage": 100,
-    "encumbrance": 30,
     "warmth": 30,
     "material_thickness": 4,
     "environmental_protection": 5,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "VARSIZE", "STURDY", "SUN_GLASSES", "WATERPROOF", "THERMOMETER", "HYGROMETER", "BAROMETER", "WATCH" ]
+    "flags": [ "VARSIZE", "STURDY", "SUN_GLASSES", "WATERPROOF", "THERMOMETER", "HYGROMETER", "BAROMETER", "WATCH" ],
+    "armor": { "coverage": 100, "covers": [ "head", "eyes", "mouth" ], "encumbrance": 30 }
   },
   {
     "id": "megaarmor_leggings_1",
@@ -217,9 +215,6 @@
     "looks_like": "legguard_hard",
     "symbol": "[",
     "color": "light_green",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 98,
-    "encumbrance": 20,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "750 ml", "max_contains_weight": "1500 g", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "750 ml", "max_contains_weight": "1500 g", "moves": 80 }
@@ -227,7 +222,8 @@
     "warmth": 25,
     "material_thickness": 2,
     "environmental_protection": 3,
-    "flags": [ "VARSIZE", "STURDY", "WATERPROOF" ]
+    "flags": [ "VARSIZE", "STURDY", "WATERPROOF" ],
+    "armor": { "coverage": 98, "covers": [ "leg_l", "leg_r" ], "encumbrance": 20 }
   },
   {
     "id": "megaarmor_boots_1",
@@ -244,13 +240,11 @@
     "looks_like": "boots_combat",
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "foot_l", "foot_r" ],
-    "coverage": 100,
-    "encumbrance": 40,
     "warmth": 30,
     "material_thickness": 3,
     "environmental_protection": 4,
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY", "OUTER" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY", "OUTER" ],
+    "armor": { "coverage": 100, "covers": [ "foot_l", "foot_r" ], "encumbrance": 40 }
   },
   {
     "id": "megaarmor_gloves_1",
@@ -266,13 +260,11 @@
     "looks_like": "gloves_tactical",
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "hand_l", "hand_r" ],
-    "coverage": 90,
-    "encumbrance": 12,
     "warmth": 15,
     "material_thickness": 2,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "STURDY", "SKINTIGHT", "WATERPROOF" ]
+    "flags": [ "VARSIZE", "STURDY", "SKINTIGHT", "WATERPROOF" ],
+    "armor": { "coverage": 90, "covers": [ "hand_l", "hand_r" ], "encumbrance": 12 }
   },
   {
     "id": "megaarmor_armguards_1",
@@ -286,13 +278,11 @@
     "looks_like": "armguard_soft",
     "symbol": "[",
     "color": "light_green",
-    "covers": [ "hand_l", "hand_r" ],
-    "coverage": 96,
-    "encumbrance": 6,
     "warmth": 25,
     "material_thickness": 2,
     "environmental_protection": 2,
-    "flags": [ "SKINTIGHT", "STURDY", "WATERPROOF" ]
+    "flags": [ "SKINTIGHT", "STURDY", "WATERPROOF" ],
+    "armor": { "coverage": 96, "covers": [ "hand_l", "hand_r" ], "encumbrance": 6 }
   },
   {
     "id": "helmet_bone_megabear",
@@ -309,13 +299,11 @@
     "looks_like": "helmet_bone",
     "symbol": "]",
     "color": "white",
-    "covers": [ "head", "eyes" ],
-    "coverage": 80,
-    "encumbrance": 22,
     "warmth": 10,
     "material_thickness": 5,
     "environmental_protection": 3,
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY", "FANCY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY", "FANCY" ],
+    "armor": { "coverage": 80, "covers": [ "head", "eyes" ], "encumbrance": 22 }
   },
   {
     "id": "vest_leather_zuicide_short",
@@ -329,9 +317,6 @@
     "material": [ "leather" ],
     "symbol": "[",
     "color": "brown",
-    "covers": [ "torso" ],
-    "coverage": 90,
-    "encumbrance": 8,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "750 ml", "max_contains_weight": "1500 g", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "750 ml", "max_contains_weight": "1500 g", "moves": 80 }
@@ -346,7 +331,8 @@
       "moves": 200,
       "type": "transform"
     },
-    "flags": [ "VARSIZE", "POCKETS", "OUTER" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER" ],
+    "armor": { "coverage": 90, "covers": [ "torso" ], "encumbrance": 8 }
   },
   {
     "id": "vest_leather_zuicide_short_active",
@@ -363,9 +349,6 @@
     "initial_charges": 60,
     "max_charges": 120,
     "turns_per_charge": 1,
-    "covers": [ "torso" ],
-    "coverage": 90,
-    "encumbrance": 8,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "750 ml", "max_contains_weight": "1500 g", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "750 ml", "max_contains_weight": "1500 g", "moves": 80 }
@@ -380,7 +363,8 @@
       "no_deactivate_msg": "COWARD!!",
       "explosion": { "power": 40, "shrapnel": 3 }
     },
-    "flags": [ "VARSIZE", "POCKETS", "OUTER" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER" ],
+    "armor": { "coverage": 90, "covers": [ "torso" ], "encumbrance": 8 }
   },
   {
     "id": "sac_purse",
@@ -398,13 +382,11 @@
     "symbol": "o",
     "color": "green",
     "sub": "clay_canister",
-    "covers": [ "torso" ],
-    "coverage": 2,
-    "encumbrance": 0,
     "material_thickness": 1,
     "pocket_data": [ { "max_contains_volume": "300 ml", "max_contains_weight": "500 g", "watertight": true, "rigid": true } ],
     "use_action": { "target": "sac_purse_arm", "msg": "You take a moment to adjust the strings of your pouch.", "type": "transform" },
-    "flags": [ "FRAGILE", "TARDIS" ]
+    "flags": [ "FRAGILE", "TARDIS" ],
+    "armor": { "coverage": 2, "covers": [ "torso" ], "encumbrance": 0 }
   },
   {
     "id": "sac_purse_arm",
@@ -421,10 +403,10 @@
     "symbol": "o",
     "color": "green",
     "sub": "clay_canister",
-    "armor_data": { "covers": [ "arm_l", "arm_r" ], "sided": true, "coverage": 2, "encumbrance": 0, "material_thickness": 1 },
     "pocket_data": [ { "max_contains_volume": "300 ml", "max_contains_weight": "500 g", "watertight": true, "rigid": true } ],
     "use_action": { "target": "sac_purse_leg", "msg": "You take a moment to adjust the strings of your arm-pouch.", "type": "transform" },
-    "flags": [ "FRAGILE", "TARDIS" ]
+    "flags": [ "FRAGILE", "TARDIS" ],
+    "armor": { "covers": [ "arm_l", "arm_r" ], "sided": true, "coverage": 2, "encumbrance": 0, "material_thickness": 1 }
   },
   {
     "id": "sac_purse_leg",
@@ -442,14 +424,14 @@
     "symbol": "o",
     "color": "green",
     "sub": "clay_canister",
-    "armor_data": { "covers": [ "leg_l", "leg_r" ], "sided": true, "coverage": 2, "encumbrance": 0, "material_thickness": 1 },
     "pocket_data": [ { "max_contains_volume": "300 ml", "max_contains_weight": "500 g", "watertight": true, "rigid": true } ],
     "use_action": {
       "target": "sac_purse_ankle",
       "msg": "You take a moment to adjust the strings of your leg-pouch.",
       "type": "transform"
     },
-    "flags": [ "FRAGILE", "TARDIS" ]
+    "flags": [ "FRAGILE", "TARDIS" ],
+    "armor": { "covers": [ "leg_l", "leg_r" ], "sided": true, "coverage": 2, "encumbrance": 0, "material_thickness": 1 }
   },
   {
     "id": "sac_purse_ankle",
@@ -466,10 +448,10 @@
     "symbol": "o",
     "color": "green",
     "sub": "clay_canister",
-    "armor_data": { "covers": [ "foot_l", "foot_r" ], "sided": true, "coverage": 2, "encumbrance": 0, "material_thickness": 1 },
     "pocket_data": [ { "max_contains_volume": "300 ml", "max_contains_weight": "500 g", "watertight": true, "rigid": true } ],
     "use_action": { "target": "sac_purse", "msg": "You take a moment to reset the strings of your pouch.", "type": "transform" },
-    "flags": [ "FRAGILE", "TARDIS" ]
+    "flags": [ "FRAGILE", "TARDIS" ],
+    "armor": { "covers": [ "foot_l", "foot_r" ], "sided": true, "coverage": 2, "encumbrance": 0, "material_thickness": 1 }
   },
   {
     "id": "swat_shield",
@@ -478,20 +460,18 @@
     "description": "A ballistic shield designed to protect the approach of its holder and anybody standing behind them.  It is heavy and somewhat cumbersome, but its protection cannot be denied.  When activated it will be held close and in front of you.",
     "weight": "8840 g",
     "color": "dark_gray",
-    "covers": [ "hand_l", "hand_r" ],
     "price": "8 kUSD",
     "material": [ "hardsteel", "plastic" ],
     "looks_like": "waterskin",
     "volume": "4500 ml",
     "to_hit": -1,
-    "encumbrance": 22,
     "bashing": 8,
     "symbol": "{",
     "flags": [ "OVERSIZE", "RESTRICT_HANDS", "ALLOWS_NATURAL_ATTACKS", "BLOCK_WHILE_WORN" ],
     "techniques": [ "WBLOCK_3", "BRUTAL" ],
-    "coverage": 45,
     "material_thickness": 2,
-    "use_action": { "type": "transform", "msg": "The tactical shield is pulled to a defensive posture!", "target": "swat_shield_act" }
+    "use_action": { "type": "transform", "msg": "The tactical shield is pulled to a defensive posture!", "target": "swat_shield_act" },
+    "armor": { "coverage": 45, "covers": [ "hand_l", "hand_r" ], "encumbrance": 22 }
   },
   {
     "id": "swat_shield_act",
@@ -500,18 +480,20 @@
     "description": "A ballistic shield designed to protect the approach of its holder and anybody standing behind them.  It is heavy and somewhat cumbersome, but its protection cannot be denied.  It is currently being used, and slowing you down.",
     "weight": "8840 g",
     "color": "dark_gray",
-    "covers": [ "torso", "leg_l", "leg_r", "eyes", "mouth", "arm_l", "arm_r", "hand_l", "hand_r" ],
     "price": "8 kUSD",
     "material": [ "hardsteel", "plastic" ],
     "volume": "4500 ml",
     "to_hit": -1,
-    "encumbrance": 26,
     "symbol": "{",
     "flags": [ "OVERSIZE", "RESTRICT_HANDS", "ALLOWS_NATURAL_ATTACKS", "BLOCK_WHILE_WORN" ],
     "techniques": [ "WBLOCK_3", "BRUTAL" ],
-    "coverage": 80,
     "material_thickness": 2,
-    "use_action": { "type": "transform", "msg": "The tactical shield is lowered.", "target": "swat_shield" }
+    "use_action": { "type": "transform", "msg": "The tactical shield is lowered.", "target": "swat_shield" },
+    "armor": {
+      "coverage": 80,
+      "covers": [ "torso", "leg_l", "leg_r", "eyes", "mouth", "arm_l", "arm_r", "hand_l", "hand_r" ],
+      "encumbrance": 26
+    }
   },
   {
     "id": "kevlar_tee",
@@ -528,12 +510,10 @@
     "looks_like": "kevlar",
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "torso" ],
-    "coverage": 85,
-    "encumbrance": 4,
     "warmth": 20,
     "material_thickness": 3,
-    "flags": [ "STURDY", "SKINTIGHT" ]
+    "flags": [ "STURDY", "SKINTIGHT" ],
+    "armor": { "coverage": 85, "covers": [ "torso" ], "encumbrance": 4 }
   },
   {
     "id": "armguard_larmor_mod",
@@ -549,13 +529,11 @@
     "looks_like": "armguard_larmor",
     "symbol": "[",
     "color": "brown",
-    "covers": [ "hand_l", "hand_r" ],
-    "coverage": 92,
-    "encumbrance": 16,
     "warmth": 25,
     "material_thickness": 3,
     "environmental_protection": 2,
-    "flags": [ "STURDY", "BLOCK_WHILE_WORN", "BELTED" ]
+    "flags": [ "STURDY", "BLOCK_WHILE_WORN", "BELTED" ],
+    "armor": { "coverage": 92, "covers": [ "hand_l", "hand_r" ], "encumbrance": 16 }
   },
   {
     "id": "locket_lucy",
@@ -567,12 +545,11 @@
     "material_thickness": 0,
     "description": "A small locket with a frame inside to store photographs or small objects.  Inside is a picture of a lovely looking woman and the etched words 'Lucy, my love'.",
     "color": "light_gray",
-    "encumbrance": 0,
     "price": "40 USD",
     "material": [ "silver" ],
-    "coverage": 0,
     "symbol": "[",
     "warmth": 0,
-    "flags": [ "FANCY", "ZERO_WEIGHT" ]
+    "flags": [ "FANCY", "ZERO_WEIGHT" ],
+    "armor": { "coverage": 0, "encumbrance": 0 }
   }
 ]

--- a/data/broken_mods/Shelved/PKs_Rebalancing/items/armor_override.json
+++ b/data/broken_mods/Shelved/PKs_Rebalancing/items/armor_override.json
@@ -6,13 +6,13 @@
     "copy-from": "duster",
     "name": { "str": "duster" },
     "description": "A rugged full-length duster coat.  Has many pockets for storage.",
-    "encumbrance": 12,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "3800 g", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "3800 g", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1 L", "max_contains_weight": "2 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1 L", "max_contains_weight": "2 kg", "moves": 80 }
-    ]
+    ],
+    "armor": { "encumbrance": 12 }
   },
   {
     "id": "duster_survivor",
@@ -21,7 +21,7 @@
     "category": "armor",
     "name": { "str": "survivor duster" },
     "description": "A Kevlar armored custom full-length duster, covered with pouches and pockets.  Comfortable, durable, and great for storage.",
-    "encumbrance": 14
+    "armor": { "encumbrance": 14 }
   },
   {
     "id": "sleeveless_duster",
@@ -29,7 +29,7 @@
     "copy-from": "sleeveless_duster",
     "name": { "str": "sleeveless duster" },
     "description": "A rugged full-length duster that leaves your arms unencumbered.  Has plenty of storage space due to its many pockets.",
-    "encumbrance": 12
+    "armor": { "encumbrance": 12 }
   },
   {
     "id": "sleeveless_duster_survivor",
@@ -38,7 +38,7 @@
     "category": "armor",
     "name": { "str": "sleeveless survivor duster" },
     "description": "A custom Kevlar armored full-length duster without sleeves, covered with pouches and pockets.  Comfortable, durable, and great for storage.",
-    "encumbrance": 14
+    "armor": { "encumbrance": 14 }
   },
   {
     "id": "jacket_leather_mod",
@@ -46,8 +46,7 @@
     "copy-from": "jacket_leather_mod",
     "name": { "str": "armored leather jacket" },
     "description": "An armored jacket made from thick leather and metal plates.  Cumbersome, but offers excellent protection from harm.",
-    "coverage": 92,
-    "encumbrance": 18
+    "armor": { "coverage": 92, "encumbrance": 18 }
   },
   {
     "id": "vest_leather_mod",
@@ -55,8 +54,7 @@
     "copy-from": "vest_leather_mod",
     "name": { "str": "armored leather vest" },
     "description": "An armored vest made from thick leather and metal plates.  Cumbersome, but offers excellent protection from harm.",
-    "coverage": 92,
-    "encumbrance": 18
+    "armor": { "coverage": 92, "encumbrance": 18 }
   },
   {
     "id": "dive_bag",
@@ -70,9 +68,6 @@
     "material": [ "plastic" ],
     "symbol": "[",
     "color": "yellow",
-    "covers": [ "torso" ],
-    "coverage": 40,
-    "encumbrance": 9,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "3 L", "max_contains_weight": "5 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "3 L", "max_contains_weight": "5 kg", "moves": 80 },
@@ -80,7 +75,8 @@
       { "pocket_type": "CONTAINER", "max_contains_volume": "1750 ml", "max_contains_weight": "2500 g", "moves": 80 }
     ],
     "material_thickness": 1,
-    "flags": [ "WATER_FRIENDLY", "BELTED" ]
+    "flags": [ "WATER_FRIENDLY", "BELTED" ],
+    "armor": { "coverage": 40, "covers": [ "torso" ], "encumbrance": 9 }
   },
   {
     "id": "fireman_belt",
@@ -94,9 +90,6 @@
     "material": [ "leather", "steel" ],
     "symbol": "[",
     "color": "yellow",
-    "covers": [ "torso" ],
-    "coverage": 6,
-    "encumbrance": 4,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1 kg", "moves": 80 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1 kg", "moves": 80 },
@@ -112,7 +105,8 @@
     "warmth": 2,
     "material_thickness": 1,
     "use_action": { "type": "holster", "holster_prompt": "Attach what to belt loop?", "holster_msg": "You clip your %s to your %s" },
-    "flags": [ "FANCY", "WAIST", "NO_QUICKDRAW", "VARSIZE", "STURDY" ]
+    "flags": [ "FANCY", "WAIST", "NO_QUICKDRAW", "VARSIZE", "STURDY" ],
+    "armor": { "coverage": 6, "covers": [ "torso" ], "encumbrance": 4 }
   },
   {
     "id": "leather_cat_ears",
@@ -125,12 +119,10 @@
     "material": [ "leather", "plastic" ],
     "symbol": "^",
     "color": "dark_gray",
-    "covers": [ "head" ],
-    "coverage": 2,
-    "encumbrance": 0,
     "warmth": 0,
     "material_thickness": 1,
-    "flags": [ "FANCY" ]
+    "flags": [ "FANCY" ],
+    "armor": { "coverage": 2, "covers": [ "head" ], "encumbrance": 0 }
   },
   {
     "id": "fur_cat_ears",
@@ -143,12 +135,10 @@
     "material": [ "fur", "plastic" ],
     "symbol": "^",
     "color": "brown",
-    "covers": [ "head" ],
-    "coverage": 2,
-    "encumbrance": 0,
     "warmth": 0,
     "material_thickness": 1,
-    "flags": [ "FANCY" ]
+    "flags": [ "FANCY" ],
+    "armor": { "coverage": 2, "covers": [ "head" ], "encumbrance": 0 }
   },
   {
     "id": "leather_cat_tail",
@@ -162,12 +152,10 @@
     "material": [ "leather", "plastic" ],
     "symbol": "s",
     "color": "dark_gray",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 2,
-    "encumbrance": 0,
     "warmth": 0,
     "material_thickness": 1,
-    "flags": [ "FANCY", "FRAGILE" ]
+    "flags": [ "FANCY", "FRAGILE" ],
+    "armor": { "coverage": 2, "covers": [ "leg_l", "leg_r" ], "encumbrance": 0 }
   },
   {
     "id": "fur_cat_tail",
@@ -181,12 +169,10 @@
     "material": [ "fur", "plastic" ],
     "symbol": "s",
     "color": "brown",
-    "covers": [ "leg_l", "leg_r" ],
-    "coverage": 2,
-    "encumbrance": 0,
     "warmth": 0,
     "material_thickness": 1,
-    "flags": [ "FANCY", "FRAGILE" ]
+    "flags": [ "FANCY", "FRAGILE" ],
+    "armor": { "coverage": 2, "covers": [ "leg_l", "leg_r" ], "encumbrance": 0 }
   },
   {
     "id": "gold_dental_grill",
@@ -201,12 +187,10 @@
     "material": [ "gold" ],
     "symbol": "[",
     "color": "yellow",
-    "covers": [ "mouth" ],
-    "coverage": 1,
-    "encumbrance": 0,
     "warmth": 0,
     "material_thickness": 1,
-    "flags": [ "FANCY", "SKINTIGHT", "OVERSIZE" ]
+    "flags": [ "FANCY", "SKINTIGHT", "OVERSIZE" ],
+    "armor": { "coverage": 1, "covers": [ "mouth" ], "encumbrance": 0 }
   },
   {
     "id": "diamond_dental_grill",
@@ -221,12 +205,10 @@
     "material": [ "gold" ],
     "symbol": "[",
     "color": "yellow",
-    "covers": [ "mouth" ],
-    "coverage": 1,
-    "encumbrance": 10,
     "warmth": 0,
     "material_thickness": 1,
-    "flags": [ "SUPER_FANCY", "SKINTIGHT", "OVERSIZE" ]
+    "flags": [ "SUPER_FANCY", "SKINTIGHT", "OVERSIZE" ],
+    "armor": { "coverage": 1, "covers": [ "mouth" ], "encumbrance": 10 }
   },
   {
     "id": "wearable_rx12",
@@ -243,9 +225,9 @@
     "ammo": [ "ampoule" ],
     "max_charges": 2,
     "charges_per_use": 1,
-    "armor_data": { "covers": [ "arm_l", "arm_r" ], "sided": true, "coverage": 1, "encumbrance": 0, "material_thickness": 3 },
     "use_action": "JET_INJECTOR",
-    "flags": [ "OVERSIZE", "SKINTIGHT" ]
+    "flags": [ "OVERSIZE", "SKINTIGHT" ],
+    "armor": { "covers": [ "arm_l", "arm_r" ], "sided": true, "coverage": 1, "encumbrance": 0, "material_thickness": 3 }
   },
   {
     "id": "rx11_stimpack",
@@ -263,9 +245,9 @@
     "initial_charges": 5,
     "max_charges": 5,
     "charges_per_use": 1,
-    "armor_data": { "covers": [ "arm_l", "arm_r" ], "sided": true, "coverage": 1, "encumbrance": 0, "material_thickness": 3 },
     "use_action": "STIMPACK",
-    "flags": [ "OVERSIZE", "SKINTIGHT" ]
+    "flags": [ "OVERSIZE", "SKINTIGHT" ],
+    "armor": { "covers": [ "arm_l", "arm_r" ], "sided": true, "coverage": 1, "encumbrance": 0, "material_thickness": 3 }
   },
   {
     "id": "rad_monitor",
@@ -300,9 +282,9 @@
       }
     ],
     "charges_per_use": 1,
-    "armor_data": { "covers": [ "hand_l", "hand_r" ], "sided": true, "coverage": 5, "encumbrance": 2, "material_thickness": 1 },
     "use_action": "RADGLOVE",
-    "flags": [ "OUTER" ]
+    "flags": [ "OUTER" ],
+    "armor": { "covers": [ "hand_l", "hand_r" ], "sided": true, "coverage": 5, "encumbrance": 2, "material_thickness": 1 }
   },
   {
     "id": "harmonica_holder",
@@ -318,9 +300,6 @@
     "color": "brown",
     "initial_charges": 1,
     "max_charges": 1,
-    "covers": [ "head" ],
-    "coverage": 4,
-    "encumbrance": 2,
     "material_thickness": 1,
     "use_action": {
       "type": "musical_instrument",
@@ -331,7 +310,8 @@
       "description_frequency": 20,
       "player_descriptions": [ "You produce a happy tune on your harmonica.", "You whistle on your harmonica." ]
     },
-    "flags": [ "BELTED" ]
+    "flags": [ "BELTED" ],
+    "armor": { "coverage": 4, "covers": [ "head" ], "encumbrance": 2 }
   },
   {
     "id": "wristwatch",
@@ -345,8 +325,8 @@
     "material": [ "plastic", "steel" ],
     "symbol": "[",
     "color": "dark_gray",
-    "armor_data": { "covers": [ "hand_l", "hand_r" ], "sided": true, "coverage": 1, "encumbrance": 0, "material_thickness": 1 },
-    "flags": [ "WATCH", "ALARMCLOCK", "BELTED", "FRAGILE", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "WATCH", "ALARMCLOCK", "BELTED", "FRAGILE", "ALLOWS_NATURAL_ATTACKS" ],
+    "armor": { "covers": [ "hand_l", "hand_r" ], "sided": true, "coverage": 1, "encumbrance": 0, "material_thickness": 1 }
   },
   {
     "id": "diving_watch",
@@ -360,9 +340,9 @@
     "material": [ "steel" ],
     "symbol": "[",
     "color": "light_gray",
-    "armor_data": { "covers": [ "hand_l", "hand_r" ], "sided": true, "coverage": 1, "encumbrance": 0, "material_thickness": 1 },
     "use_action": "WEATHER_TOOL",
-    "flags": [ "WATCH", "STURDY", "WATER_FRIENDLY", "THERMOMETER", "BELTED", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "WATCH", "STURDY", "WATER_FRIENDLY", "THERMOMETER", "BELTED", "ALLOWS_NATURAL_ATTACKS" ],
+    "armor": { "covers": [ "hand_l", "hand_r" ], "sided": true, "coverage": 1, "encumbrance": 0, "material_thickness": 1 }
   },
   {
     "id": "gold_watch",
@@ -376,8 +356,8 @@
     "material": [ "steel", "gold" ],
     "symbol": "[",
     "color": "yellow",
-    "armor_data": { "covers": [ "hand_l", "hand_r" ], "sided": true, "coverage": 1, "encumbrance": 0, "material_thickness": 1 },
-    "flags": [ "WATCH", "FANCY", "BELTED", "FRAGILE", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "WATCH", "FANCY", "BELTED", "FRAGILE", "ALLOWS_NATURAL_ATTACKS" ],
+    "armor": { "covers": [ "hand_l", "hand_r" ], "sided": true, "coverage": 1, "encumbrance": 0, "material_thickness": 1 }
   },
   {
     "id": "sf_watch",
@@ -392,8 +372,8 @@
     "material": [ "gold", "silver" ],
     "symbol": "[",
     "color": "yellow",
-    "armor_data": { "covers": [ "hand_l", "hand_r" ], "sided": true, "coverage": 1, "encumbrance": 0, "material_thickness": 1 },
-    "flags": [ "WATCH", "SUPER_FANCY", "BELTED", "FRAGILE", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "WATCH", "SUPER_FANCY", "BELTED", "FRAGILE", "ALLOWS_NATURAL_ATTACKS" ],
+    "armor": { "covers": [ "hand_l", "hand_r" ], "sided": true, "coverage": 1, "encumbrance": 0, "material_thickness": 1 }
   },
   {
     "id": "fancy_sunglasses",
@@ -407,13 +387,11 @@
     "material": [ "glass", "plastic" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "eyes" ],
-    "coverage": 95,
-    "encumbrance": 4,
     "material_thickness": 1,
     "environmental_protection": 1,
     "qualities": [ [ "GLARE", 1 ] ],
-    "flags": [ "SKINTIGHT", "FANCY", "WATER_FRIENDLY", "SUN_GLASSES" ]
+    "flags": [ "SKINTIGHT", "FANCY", "WATER_FRIENDLY", "SUN_GLASSES" ],
+    "armor": { "coverage": 95, "covers": [ "eyes" ], "encumbrance": 4 }
   },
   {
     "id": "fitover_sunglasses",
@@ -427,13 +405,11 @@
     "material": [ "glass", "plastic" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "eyes" ],
-    "coverage": 98,
-    "encumbrance": 5,
     "material_thickness": 1,
     "environmental_protection": 1,
     "qualities": [ [ "GLARE", 1 ] ],
-    "flags": [ "WATER_FRIENDLY", "SUN_GLASSES", "VARSIZE" ]
+    "flags": [ "WATER_FRIENDLY", "SUN_GLASSES", "VARSIZE" ],
+    "armor": { "coverage": 98, "covers": [ "eyes" ], "encumbrance": 5 }
   },
   {
     "id": "glasses_bal",
@@ -447,14 +423,12 @@
     "material": [ "kevlar", "plastic" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "eyes" ],
-    "coverage": 100,
-    "encumbrance": 12,
     "warmth": 5,
     "material_thickness": 3,
     "environmental_protection": 4,
     "qualities": [ [ "GLARE", 1 ] ],
-    "flags": [ "OUTER", "WATER_FRIENDLY", "SUN_GLASSES", "STURDY" ]
+    "flags": [ "OUTER", "WATER_FRIENDLY", "SUN_GLASSES", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "eyes" ], "encumbrance": 12 }
   },
   {
     "id": "glasses_bifocal",
@@ -468,13 +442,11 @@
     "material": [ "glass", "plastic" ],
     "symbol": "[",
     "color": "cyan",
-    "covers": [ "eyes" ],
-    "coverage": 75,
-    "encumbrance": 3,
     "material_thickness": 1,
     "environmental_protection": 1,
     "use_action": { "type": "firestarter", "moves": 1000, "moves_slow": 25000, "need_sunlight": true },
-    "flags": [ "SKINTIGHT", "WATER_FRIENDLY", "FIX_FARSIGHT", "FIX_NEARSIGHT" ]
+    "flags": [ "SKINTIGHT", "WATER_FRIENDLY", "FIX_FARSIGHT", "FIX_NEARSIGHT" ],
+    "armor": { "coverage": 75, "covers": [ "eyes" ], "encumbrance": 3 }
   },
   {
     "id": "glasses_eye",
@@ -488,12 +460,10 @@
     "material": [ "glass", "plastic" ],
     "symbol": "[",
     "color": "cyan",
-    "covers": [ "eyes" ],
-    "coverage": 75,
-    "encumbrance": 3,
     "material_thickness": 1,
     "environmental_protection": 1,
-    "flags": [ "SKINTIGHT", "WATER_FRIENDLY", "FIX_NEARSIGHT" ]
+    "flags": [ "SKINTIGHT", "WATER_FRIENDLY", "FIX_NEARSIGHT" ],
+    "armor": { "coverage": 75, "covers": [ "eyes" ], "encumbrance": 3 }
   },
   {
     "id": "glasses_monocle",
@@ -508,13 +478,11 @@
     "material": [ "glass", "plastic" ],
     "symbol": "[",
     "color": "cyan",
-    "covers": [ "eyes" ],
-    "coverage": 20,
-    "encumbrance": 4,
     "material_thickness": 1,
     "environmental_protection": 1,
     "use_action": { "type": "firestarter", "moves": 1000, "moves_slow": 25000, "need_sunlight": true },
-    "flags": [ "OVERSIZE", "SUPER_FANCY", "WATER_FRIENDLY", "VARSIZE", "FIX_NEARSIGHT" ]
+    "flags": [ "OVERSIZE", "SUPER_FANCY", "WATER_FRIENDLY", "VARSIZE", "FIX_NEARSIGHT" ],
+    "armor": { "coverage": 20, "covers": [ "eyes" ], "encumbrance": 4 }
   },
   {
     "id": "glasses_reading",
@@ -528,13 +496,11 @@
     "material": [ "glass", "plastic" ],
     "symbol": "[",
     "color": "cyan",
-    "covers": [ "eyes" ],
-    "coverage": 75,
-    "encumbrance": 3,
     "material_thickness": 1,
     "environmental_protection": 1,
     "use_action": { "type": "firestarter", "moves": 1000, "moves_slow": 25000, "need_sunlight": true },
-    "flags": [ "SKINTIGHT", "WATER_FRIENDLY", "FIX_FARSIGHT" ]
+    "flags": [ "SKINTIGHT", "WATER_FRIENDLY", "FIX_FARSIGHT" ],
+    "armor": { "coverage": 75, "covers": [ "eyes" ], "encumbrance": 3 }
   },
   {
     "id": "glasses_safety",
@@ -548,13 +514,11 @@
     "material": [ "plastic" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "eyes" ],
-    "coverage": 98,
-    "encumbrance": 6,
     "warmth": 5,
     "material_thickness": 2,
     "environmental_protection": 1,
-    "flags": [ "WATER_FRIENDLY" ]
+    "flags": [ "WATER_FRIENDLY" ],
+    "armor": { "coverage": 98, "covers": [ "eyes" ], "encumbrance": 6 }
   },
   {
     "id": "goggles_ski",
@@ -568,14 +532,12 @@
     "material": [ "plastic" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "eyes" ],
-    "coverage": 100,
-    "encumbrance": 16,
     "warmth": 50,
     "material_thickness": 2,
     "environmental_protection": 6,
     "qualities": [ [ "GLARE", 1 ] ],
-    "flags": [ "SUN_GLASSES", "VARSIZE", "WATER_FRIENDLY", "OUTER", "FLASH_PROTECTION" ]
+    "flags": [ "SUN_GLASSES", "VARSIZE", "WATER_FRIENDLY", "OUTER", "FLASH_PROTECTION" ],
+    "armor": { "coverage": 100, "covers": [ "eyes" ], "encumbrance": 16 }
   },
   {
     "id": "goggles_swim",
@@ -589,13 +551,11 @@
     "material": [ "plastic" ],
     "symbol": "[",
     "color": "light_blue",
-    "covers": [ "eyes" ],
-    "coverage": 100,
-    "encumbrance": 10,
     "warmth": 10,
     "material_thickness": 1,
     "environmental_protection": 4,
-    "flags": [ "SUN_GLASSES", "SKINTIGHT", "WATER_FRIENDLY", "SWIM_GOGGLES", "VARSIZE" ]
+    "flags": [ "SUN_GLASSES", "SKINTIGHT", "WATER_FRIENDLY", "SWIM_GOGGLES", "VARSIZE" ],
+    "armor": { "coverage": 100, "covers": [ "eyes" ], "encumbrance": 10 }
   },
   {
     "id": "goggles_welding",
@@ -609,14 +569,12 @@
     "material": [ "plastic" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "eyes" ],
-    "coverage": 100,
-    "encumbrance": 60,
     "warmth": 10,
     "material_thickness": 4,
     "environmental_protection": 6,
     "qualities": [ [ "GLARE", 2 ] ],
-    "flags": [ "SUN_GLASSES", "FLASH_PROTECTION", "OUTER", "STURDY" ]
+    "flags": [ "SUN_GLASSES", "FLASH_PROTECTION", "OUTER", "STURDY" ],
+    "armor": { "coverage": 100, "covers": [ "eyes" ], "encumbrance": 60 }
   },
   {
     "id": "sunglasses",
@@ -630,13 +588,11 @@
     "material": [ "glass", "plastic" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "eyes" ],
-    "coverage": 85,
-    "encumbrance": 4,
     "material_thickness": 1,
     "environmental_protection": 1,
     "qualities": [ [ "GLARE", 1 ] ],
-    "flags": [ "SKINTIGHT", "WATER_FRIENDLY", "SUN_GLASSES" ]
+    "flags": [ "SKINTIGHT", "WATER_FRIENDLY", "SUN_GLASSES" ],
+    "armor": { "coverage": 85, "covers": [ "eyes" ], "encumbrance": 4 }
   },
   {
     "id": "survivor_goggles",
@@ -650,14 +606,12 @@
     "material": [ "kevlar", "leather" ],
     "symbol": "[",
     "color": "dark_gray",
-    "covers": [ "eyes" ],
-    "coverage": 100,
-    "encumbrance": 28,
     "warmth": 5,
     "material_thickness": 4,
     "environmental_protection": 15,
     "qualities": [ [ "GLARE", 1 ] ],
-    "flags": [ "WATER_FRIENDLY", "SUN_GLASSES", "OVERSIZE", "VARSIZE", "STURDY", "OUTER" ]
+    "flags": [ "WATER_FRIENDLY", "SUN_GLASSES", "OVERSIZE", "VARSIZE", "STURDY", "OUTER" ],
+    "armor": { "coverage": 100, "covers": [ "eyes" ], "encumbrance": 28 }
   },
   {
     "id": "mask_filter",
@@ -672,12 +626,10 @@
     "material": [ "plastic" ],
     "symbol": "[",
     "color": "light_gray",
-    "covers": [ "mouth" ],
-    "coverage": 100,
-    "encumbrance": 20,
     "warmth": 15,
     "material_thickness": 2,
-    "environmental_protection": 7
+    "environmental_protection": 7,
+    "armor": { "coverage": 100, "covers": [ "mouth" ], "encumbrance": 20 }
   },
   {
     "id": "mask_dust",
@@ -691,11 +643,9 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "white",
-    "covers": [ "mouth" ],
-    "coverage": 100,
-    "encumbrance": 8,
     "warmth": 5,
     "material_thickness": 1,
-    "environmental_protection": 3
+    "environmental_protection": 3,
+    "armor": { "coverage": 100, "covers": [ "mouth" ], "encumbrance": 8 }
   }
 ]

--- a/data/broken_mods/Shelved/PKs_Rebalancing/items/comestible.json
+++ b/data/broken_mods/Shelved/PKs_Rebalancing/items/comestible.json
@@ -58,9 +58,6 @@
     "material": [ "plastic" ],
     "symbol": "|",
     "color": "light_gray",
-    "covers": [ "hand_l", "hand_r", "arm_l", "arm_r" ],
-    "coverage": 10,
-    "encumbrance": 1,
     "material_thickness": 0,
     "use_action": {
       "target": "berserker_drug_act",
@@ -70,7 +67,8 @@
       "moves": 250,
       "type": "transform"
     },
-    "flags": [ "WATER_FRIENDLY", "BELTED", "ALLOWS_NATURAL_ATTACKS", "NO_RELOAD", "NO_UNLOAD", "NPC_SAFE" ]
+    "flags": [ "WATER_FRIENDLY", "BELTED", "ALLOWS_NATURAL_ATTACKS", "NO_RELOAD", "NO_UNLOAD", "NPC_SAFE" ],
+    "armor": { "coverage": 10, "covers": [ "hand_l", "hand_r", "arm_l", "arm_r" ], "encumbrance": 1 }
   },
   {
     "id": "berserker_drug_act",
@@ -88,12 +86,10 @@
     "max_charges": 7,
     "turns_per_charge": 1,
     "revert_to": "bag_plastic",
-    "covers": [ "hand_l", "hand_r", "arm_l", "arm_r" ],
-    "coverage": 10,
-    "encumbrance": 1,
     "material_thickness": 0,
     "use_action": { "type": "consume_drug", "effects": [ { "id": "doom_stimpack", "duration": 40 } ] },
-    "flags": [ "WATER_FRIENDLY", "BELTED", "ALLOWS_NATURAL_ATTACKS", "NO_RELOAD", "NPC_SAFE" ]
+    "flags": [ "WATER_FRIENDLY", "BELTED", "ALLOWS_NATURAL_ATTACKS", "NO_RELOAD", "NPC_SAFE" ],
+    "armor": { "coverage": 10, "covers": [ "hand_l", "hand_r", "arm_l", "arm_r" ], "encumbrance": 1 }
   },
   {
     "id": "stamina_vial",

--- a/data/broken_mods/Shelved/PKs_Rebalancing/items/tool.json
+++ b/data/broken_mods/Shelved/PKs_Rebalancing/items/tool.json
@@ -30,8 +30,6 @@
     "material": [ "aluminum" ],
     "symbol": ",",
     "color": "light_gray",
-    "coverage": 1,
-    "encumbrance": 0,
     "warmth": 0,
     "material_thickness": 1,
     "ammo": [ "gasoline" ],
@@ -39,7 +37,8 @@
     "rand_charges": [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 5, 7, 11, 13, 17, 21, 27 ],
     "charges_per_use": 1,
     "use_action": [ { "type": "firestarter", "moves": 60, "moves_slow": 600 } ],
-    "flags": [ "FIRE", "FLAMING" ]
+    "flags": [ "FIRE", "FLAMING" ],
+    "armor": { "coverage": 1, "encumbrance": 0 }
   },
   {
     "id": "candle_smoke",

--- a/workshop/Fear_and_loathing/items/armor.json
+++ b/workshop/Fear_and_loathing/items/armor.json
@@ -5,7 +5,6 @@
     "name": { "str": "socks" },
     "weight": "1 g",
     "color": "blue",
-    "covers": [ "foot_l", "foot_r" ],
     "to_hit": 0,
     "storage": 0,
     "symbol": "[",
@@ -20,8 +19,8 @@
     "rarity": 70,
     "encumberance": 0,
     "bashing": 0,
-    "coverage": 80,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 80, "covers": [ "foot_l", "foot_r" ] }
   },
   {
     "type": "ARMOR",
@@ -29,7 +28,6 @@
     "name": { "str": "wool socks" },
     "weight": "1 g",
     "color": "blue",
-    "covers": [ "foot_l", "foot_r" ],
     "to_hit": 0,
     "storage": 0,
     "symbol": "[",
@@ -44,8 +42,8 @@
     "rarity": 30,
     "encumberance": 0,
     "bashing": 0,
-    "coverage": 95,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 95, "covers": [ "foot_l", "foot_r" ] }
   },
   {
     "type": "ARMOR",
@@ -53,7 +51,6 @@
     "name": { "str": "sneakers" },
     "weight": "4 g",
     "color": "blue",
-    "covers": [ "foot_l", "foot_r" ],
     "to_hit": 0,
     "storage": 0,
     "symbol": "[",
@@ -69,8 +66,8 @@
     "encumberance": 0,
     "bashing": 0,
     "flags": [ "VARSIZE" ],
-    "coverage": 50,
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 50, "covers": [ "foot_l", "foot_r" ] }
   },
   {
     "type": "ARMOR",
@@ -78,7 +75,6 @@
     "name": { "str": "boots" },
     "weight": "6 g",
     "color": "blue",
-    "covers": [ "foot_l", "foot_r" ],
     "to_hit": -1,
     "storage": 0,
     "symbol": "[",
@@ -94,9 +90,9 @@
     "encumberance": 1,
     "bashing": 1,
     "flags": [ "VARSIZE" ],
-    "coverage": 95,
     "material_thickness": 4,
-    "use_action": "BOOTS"
+    "use_action": "BOOTS",
+    "armor": { "coverage": 95, "covers": [ "foot_l", "foot_r" ] }
   },
   {
     "type": "ARMOR",
@@ -104,7 +100,6 @@
     "name": { "str": "fur boots" },
     "weight": "6 g",
     "color": "blue",
-    "covers": [ "foot_l", "foot_r" ],
     "to_hit": -1,
     "storage": 0,
     "symbol": "[",
@@ -120,9 +115,9 @@
     "encumberance": 1,
     "bashing": 1,
     "flags": [ "VARSIZE" ],
-    "coverage": 95,
     "material_thickness": 6,
-    "use_action": "BOOTS"
+    "use_action": "BOOTS",
+    "armor": { "coverage": 95, "covers": [ "foot_l", "foot_r" ] }
   },
   {
     "type": "ARMOR",
@@ -130,7 +125,6 @@
     "name": { "str": "steeltoed boots" },
     "weight": "9 g",
     "color": "blue",
-    "covers": [ "foot_l", "foot_r" ],
     "to_hit": -1,
     "storage": 0,
     "symbol": "[",
@@ -146,9 +140,9 @@
     "encumberance": 1,
     "bashing": 4,
     "flags": [ "VARSIZE" ],
-    "coverage": 95,
     "material_thickness": 4,
-    "use_action": "BOOTS"
+    "use_action": "BOOTS",
+    "armor": { "coverage": 95, "covers": [ "foot_l", "foot_r" ] }
   },
   {
     "type": "ARMOR",
@@ -156,7 +150,6 @@
     "name": { "str": "winter boots" },
     "weight": "7 g",
     "color": "blue",
-    "covers": [ "foot_l", "foot_r" ],
     "to_hit": -1,
     "storage": 0,
     "symbol": "[",
@@ -172,9 +165,9 @@
     "encumberance": 2,
     "bashing": 0,
     "flags": [ "VARSIZE" ],
-    "coverage": 95,
     "material_thickness": 8,
-    "use_action": "BOOTS"
+    "use_action": "BOOTS",
+    "armor": { "coverage": 95, "covers": [ "foot_l", "foot_r" ] }
   },
   {
     "type": "ARMOR",
@@ -182,7 +175,6 @@
     "name": { "str": "mocassins" },
     "weight": "1 g",
     "color": "blue",
-    "covers": [ "foot_l", "foot_r" ],
     "to_hit": 0,
     "storage": 0,
     "symbol": "[",
@@ -197,8 +189,8 @@
     "rarity": 5,
     "encumberance": 0,
     "bashing": 0,
-    "coverage": 40,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 40, "covers": [ "foot_l", "foot_r" ] }
   },
   {
     "type": "ARMOR",
@@ -206,7 +198,6 @@
     "name": { "str": "flip-flops" },
     "weight": "1 g",
     "color": "blue",
-    "covers": [ "foot_l", "foot_r" ],
     "to_hit": -2,
     "storage": 0,
     "symbol": "[",
@@ -222,8 +213,8 @@
     "encumberance": 3,
     "bashing": 0,
     "flags": [ "VARSIZE" ],
-    "coverage": 20,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 20, "covers": [ "foot_l", "foot_r" ] }
   },
   {
     "type": "ARMOR",
@@ -231,7 +222,6 @@
     "name": { "str": "dress shoes" },
     "weight": "3 g",
     "color": "blue",
-    "covers": [ "foot_l", "foot_r" ],
     "to_hit": 1,
     "storage": 0,
     "symbol": "[",
@@ -247,8 +237,8 @@
     "encumberance": 1,
     "bashing": 1,
     "flags": [ "VARSIZE" ],
-    "coverage": 50,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 50, "covers": [ "foot_l", "foot_r" ] }
   },
   {
     "type": "ARMOR",
@@ -256,7 +246,6 @@
     "name": { "str": "heels" },
     "weight": "2 g",
     "color": "blue",
-    "covers": [ "foot_l", "foot_r" ],
     "to_hit": -2,
     "storage": 0,
     "symbol": "[",
@@ -272,8 +261,8 @@
     "encumberance": 4,
     "bashing": 6,
     "flags": [ "VARSIZE" ],
-    "coverage": 30,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 30, "covers": [ "foot_l", "foot_r" ] }
   },
   {
     "type": "ARMOR",
@@ -281,7 +270,6 @@
     "name": { "str": "chitinous boots" },
     "weight": "9 g",
     "color": "blue",
-    "covers": [ "foot_l", "foot_r" ],
     "to_hit": -1,
     "storage": 0,
     "symbol": "[",
@@ -296,8 +284,8 @@
     "rarity": 50,
     "encumberance": 1,
     "bashing": 4,
-    "coverage": 95,
-    "material_thickness": 5
+    "material_thickness": 5,
+    "armor": { "coverage": 95, "covers": [ "foot_l", "foot_r" ] }
   },
   {
     "type": "ARMOR",
@@ -305,7 +293,6 @@
     "name": { "str": "shorts" },
     "weight": "2 g",
     "color": "brown",
-    "covers": [ "leg_l", "leg_r" ],
     "to_hit": 1,
     "storage": 4,
     "symbol": "[",
@@ -321,8 +308,8 @@
     "encumberance": 0,
     "bashing": 0,
     "flags": [ "VARSIZE" ],
-    "coverage": 40,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 40, "covers": [ "leg_l", "leg_r" ] }
   },
   {
     "type": "ARMOR",
@@ -330,7 +317,6 @@
     "name": { "str": "cargo shorts" },
     "weight": "2 g",
     "color": "brown",
-    "covers": [ "leg_l", "leg_r" ],
     "to_hit": 1,
     "storage": 8,
     "symbol": "[",
@@ -346,8 +332,8 @@
     "encumberance": 0,
     "bashing": 0,
     "flags": [ "VARSIZE" ],
-    "coverage": 40,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 40, "covers": [ "leg_l", "leg_r" ] }
   },
   {
     "type": "ARMOR",
@@ -355,7 +341,6 @@
     "name": { "str": "jeans" },
     "weight": "4 g",
     "color": "brown",
-    "covers": [ "leg_l", "leg_r" ],
     "to_hit": 1,
     "storage": 2,
     "symbol": "[",
@@ -371,8 +356,8 @@
     "encumberance": 1,
     "bashing": 0,
     "flags": [ "VARSIZE" ],
-    "coverage": 95,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r" ] }
   },
   {
     "type": "ARMOR",
@@ -380,7 +365,6 @@
     "name": { "str": "pants" },
     "weight": "5 g",
     "color": "brown",
-    "covers": [ "leg_l", "leg_r" ],
     "to_hit": 1,
     "storage": 4,
     "symbol": "[",
@@ -396,8 +380,8 @@
     "encumberance": 1,
     "bashing": 0,
     "flags": [ "VARSIZE" ],
-    "coverage": 95,
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r" ] }
   },
   {
     "type": "ARMOR",
@@ -405,7 +389,6 @@
     "name": { "str": "leather pants" },
     "weight": "8 g",
     "color": "brown",
-    "covers": [ "leg_l", "leg_r" ],
     "to_hit": 1,
     "storage": 2,
     "symbol": "[",
@@ -421,8 +404,8 @@
     "encumberance": 2,
     "bashing": 0,
     "flags": [ "VARSIZE" ],
-    "coverage": 95,
-    "material_thickness": 4
+    "material_thickness": 4,
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r" ] }
   },
   {
     "type": "ARMOR",
@@ -430,7 +413,6 @@
     "name": { "str": "cargo pants" },
     "weight": "6 g",
     "color": "brown",
-    "covers": [ "leg_l", "leg_r" ],
     "to_hit": 0,
     "storage": 12,
     "symbol": "[",
@@ -446,8 +428,8 @@
     "encumberance": 1,
     "bashing": 0,
     "flags": [ "VARSIZE" ],
-    "coverage": 95,
-    "material_thickness": 4
+    "material_thickness": 4,
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r" ] }
   },
   {
     "type": "ARMOR",
@@ -455,7 +437,6 @@
     "name": { "str": "army pants" },
     "weight": "7 g",
     "color": "brown",
-    "covers": [ "leg_l", "leg_r" ],
     "to_hit": 0,
     "storage": 14,
     "symbol": "[",
@@ -471,8 +452,8 @@
     "encumberance": 1,
     "bashing": 0,
     "flags": [ "VARSIZE" ],
-    "coverage": 95,
-    "material_thickness": 4
+    "material_thickness": 4,
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r" ] }
   },
   {
     "type": "ARMOR",
@@ -480,7 +461,6 @@
     "name": { "str": "ski pants" },
     "weight": "6 g",
     "color": "brown",
-    "covers": [ "leg_l", "leg_r" ],
     "to_hit": 0,
     "storage": 4,
     "symbol": "[",
@@ -496,8 +476,8 @@
     "encumberance": 2,
     "bashing": 0,
     "flags": [ "VARSIZE" ],
-    "coverage": 95,
-    "material_thickness": 6
+    "material_thickness": 6,
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r" ] }
   },
   {
     "type": "ARMOR",
@@ -505,7 +485,6 @@
     "name": { "str": "fur pants" },
     "weight": "6 g",
     "color": "brown",
-    "covers": [ "leg_l", "leg_r" ],
     "to_hit": 1,
     "storage": 4,
     "symbol": "[",
@@ -521,8 +500,8 @@
     "encumberance": 2,
     "bashing": 0,
     "flags": [ "VARSIZE" ],
-    "coverage": 95,
-    "material_thickness": 10
+    "material_thickness": 10,
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r" ] }
   },
   {
     "type": "ARMOR",
@@ -530,7 +509,6 @@
     "name": { "str": "long underwear" },
     "weight": "2 g",
     "color": "brown",
-    "covers": [ "leg_l", "leg_r" ],
     "to_hit": 0,
     "storage": 0,
     "symbol": "[",
@@ -546,8 +524,8 @@
     "encumberance": 0,
     "bashing": 0,
     "flags": [ "VARSIZE" ],
-    "coverage": 95,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r" ] }
   },
   {
     "type": "ARMOR",
@@ -555,7 +533,6 @@
     "name": { "str": "skirt" },
     "weight": "2 g",
     "color": "brown",
-    "covers": [ "leg_l", "leg_r" ],
     "to_hit": 0,
     "storage": 1,
     "symbol": "[",
@@ -571,8 +548,8 @@
     "encumberance": -1,
     "bashing": 0,
     "flags": [ "VARSIZE" ],
-    "coverage": 60,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 60, "covers": [ "leg_l", "leg_r" ] }
   },
   {
     "type": "ARMOR",
@@ -580,7 +557,6 @@
     "name": { "str": "jumpsuit" },
     "weight": "6 g",
     "color": "yellow",
-    "covers": [ "leg_l", "leg_r", "torso" ],
     "to_hit": -3,
     "storage": 8,
     "symbol": "[",
@@ -596,8 +572,8 @@
     "encumberance": 0,
     "bashing": 0,
     "flags": [ "VARSIZE" ],
-    "coverage": 95,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r", "torso" ] }
   },
   {
     "type": "ARMOR",
@@ -605,7 +581,6 @@
     "name": { "str": "Rhinestone Jumpsuit" },
     "weight": "6 g",
     "color": "yellow",
-    "covers": [ "leg_l", "leg_r", "torso" ],
     "to_hit": 3,
     "storage": 8,
     "symbol": "[",
@@ -621,8 +596,8 @@
     "encumberance": 0,
     "bashing": 0,
     "flags": [ "VARSIZE" ],
-    "coverage": 95,
-    "material_thickness": 5
+    "material_thickness": 5,
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r", "torso" ] }
   },
   {
     "type": "ARMOR",
@@ -630,7 +605,6 @@
     "name": { "str": "wolf suit" },
     "weight": "19 g",
     "color": "yellow",
-    "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r", "mouth", "eyes" ],
     "to_hit": -3,
     "storage": 4,
     "symbol": "[",
@@ -645,8 +619,11 @@
     "rarity": 4,
     "encumberance": 1,
     "bashing": 0,
-    "coverage": 100,
-    "material_thickness": 10
+    "material_thickness": 10,
+    "armor": {
+      "coverage": 100,
+      "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r", "mouth", "eyes" ]
+    }
   },
   {
     "type": "ARMOR",
@@ -654,7 +631,6 @@
     "name": { "str": "dress" },
     "weight": "6 g",
     "color": "yellow",
-    "covers": [ "leg_l", "leg_r", "torso" ],
     "to_hit": -5,
     "storage": 0,
     "symbol": "[",
@@ -670,8 +646,8 @@
     "encumberance": 3,
     "bashing": 0,
     "flags": [ "VARSIZE" ],
-    "coverage": 80,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 80, "covers": [ "leg_l", "leg_r", "torso" ] }
   },
   {
     "type": "ARMOR",
@@ -679,7 +655,6 @@
     "name": { "str": "chitinous armor" },
     "weight": "10 g",
     "color": "yellow",
-    "covers": [ "leg_l", "leg_r", "torso" ],
     "to_hit": -5,
     "storage": 0,
     "symbol": "[",
@@ -694,8 +669,8 @@
     "rarity": 1,
     "encumberance": 2,
     "bashing": 2,
-    "coverage": 95,
-    "material_thickness": 5
+    "material_thickness": 5,
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r", "torso" ] }
   },
   {
     "type": "ARMOR",
@@ -703,7 +678,6 @@
     "name": { "str": "suit" },
     "weight": "7 g",
     "color": "yellow",
-    "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r" ],
     "to_hit": -5,
     "storage": 10,
     "symbol": "[",
@@ -719,8 +693,8 @@
     "encumberance": 1,
     "bashing": 0,
     "flags": [ "VARSIZE" ],
-    "coverage": 95,
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r" ] }
   },
   {
     "type": "ARMOR",
@@ -728,7 +702,6 @@
     "name": { "str": "hazmat suit" },
     "weight": "8 g",
     "color": "yellow",
-    "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r" ],
     "to_hit": -8,
     "storage": 12,
     "symbol": "[",
@@ -744,8 +717,8 @@
     "encumberance": 4,
     "bashing": 0,
     "flags": [ "VARSIZE" ],
-    "coverage": 100,
-    "material_thickness": 5
+    "material_thickness": 5,
+    "armor": { "coverage": 100, "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r" ] }
   },
   {
     "type": "ARMOR",
@@ -753,7 +726,6 @@
     "name": { "str": "plate mail" },
     "weight": "140 g",
     "color": "yellow",
-    "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ],
     "to_hit": -5,
     "storage": 0,
     "symbol": "[",
@@ -769,8 +741,8 @@
     "encumberance": 5,
     "bashing": 8,
     "flags": [ "VARSIZE" ],
-    "coverage": 100,
-    "material_thickness": 5
+    "material_thickness": 5,
+    "armor": { "coverage": 100, "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ] }
   },
   {
     "type": "ARMOR",
@@ -778,7 +750,6 @@
     "name": { "str": "t shirt" },
     "weight": "2 g",
     "color": "light_red",
-    "covers": [ "torso" ],
     "to_hit": 0,
     "storage": 0,
     "symbol": "[",
@@ -794,8 +765,8 @@
     "encumberance": 1,
     "bashing": 0,
     "flags": [ "VARSIZE" ],
-    "coverage": 80,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 80, "covers": [ "torso" ] }
   },
   {
     "type": "ARMOR",
@@ -803,7 +774,6 @@
     "name": { "str": "flag shirt" },
     "weight": "2 g",
     "color": "light_red",
-    "covers": [ "torso" ],
     "to_hit": 0,
     "storage": 0,
     "symbol": "[",
@@ -819,8 +789,8 @@
     "encumberance": 1,
     "bashing": 0,
     "flags": [ "VARSIZE" ],
-    "coverage": 80,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 80, "covers": [ "torso" ] }
   },
   {
     "type": "ARMOR",
@@ -828,7 +798,6 @@
     "name": { "str": "polo shirt" },
     "weight": "2 g",
     "color": "light_red",
-    "covers": [ "torso" ],
     "to_hit": 0,
     "storage": 0,
     "symbol": "[",
@@ -844,8 +813,8 @@
     "encumberance": 1,
     "bashing": 0,
     "flags": [ "VARSIZE" ],
-    "coverage": 85,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 85, "covers": [ "torso" ] }
   },
   {
     "type": "ARMOR",
@@ -853,7 +822,6 @@
     "name": { "str": "dress shirt" },
     "weight": "3 g",
     "color": "light_red",
-    "covers": [ "torso", "arm_l", "arm_r" ],
     "to_hit": 0,
     "storage": 1,
     "symbol": "[",
@@ -869,8 +837,8 @@
     "encumberance": 1,
     "bashing": 0,
     "flags": [ "VARSIZE" ],
-    "coverage": 90,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ] }
   },
   {
     "type": "ARMOR",
@@ -878,7 +846,6 @@
     "name": { "str": "tank top" },
     "weight": "1 g",
     "color": "light_red",
-    "covers": [ "torso" ],
     "to_hit": 0,
     "storage": 0,
     "symbol": "[",
@@ -894,8 +861,8 @@
     "encumberance": 0,
     "bashing": 0,
     "flags": [ "VARSIZE" ],
-    "coverage": 60,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 60, "covers": [ "torso" ] }
   },
   {
     "type": "ARMOR",
@@ -903,7 +870,6 @@
     "name": { "str": "sweatshirt" },
     "weight": "5 g",
     "color": "light_red",
-    "covers": [ "torso", "arm_l", "arm_r" ],
     "to_hit": 0,
     "storage": 0,
     "symbol": "[",
@@ -919,8 +885,8 @@
     "encumberance": 1,
     "bashing": 0,
     "flags": [ "VARSIZE" ],
-    "coverage": 95,
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r" ] }
   },
   {
     "type": "ARMOR",
@@ -928,7 +894,6 @@
     "name": { "str": "sweater" },
     "weight": "5 g",
     "color": "light_red",
-    "covers": [ "torso", "arm_l", "arm_r" ],
     "to_hit": 0,
     "storage": 0,
     "symbol": "[",
@@ -944,8 +909,8 @@
     "encumberance": 1,
     "bashing": 0,
     "flags": [ "VARSIZE" ],
-    "coverage": 95,
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r" ] }
   },
   {
     "type": "ARMOR",
@@ -953,7 +918,6 @@
     "name": { "str": "hoodie" },
     "weight": "5 g",
     "color": "light_red",
-    "covers": [ "torso", "arm_l", "arm_r" ],
     "to_hit": 0,
     "storage": 9,
     "symbol": "[",
@@ -969,8 +933,8 @@
     "encumberance": 1,
     "bashing": 0,
     "flags": [ "VARSIZE", "POCKETS" ],
-    "coverage": 95,
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r" ] }
   },
   {
     "type": "ARMOR",
@@ -978,7 +942,6 @@
     "name": { "str": "under armor" },
     "weight": "2 g",
     "color": "light_red",
-    "covers": [ "torso" ],
     "to_hit": 0,
     "storage": 0,
     "symbol": "[",
@@ -994,8 +957,8 @@
     "encumberance": 0,
     "bashing": 0,
     "flags": [ "VARSIZE" ],
-    "coverage": 95,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 95, "covers": [ "torso" ] }
   },
   {
     "type": "ARMOR",
@@ -1003,7 +966,6 @@
     "name": { "str": "light jacket" },
     "weight": "4 g",
     "color": "light_red",
-    "covers": [ "torso", "arm_l", "arm_r" ],
     "to_hit": 0,
     "storage": 4,
     "symbol": "[",
@@ -1019,8 +981,8 @@
     "encumberance": 1,
     "bashing": 0,
     "flags": [ "VARSIZE", "POCKETS" ],
-    "coverage": 95,
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r" ] }
   },
   {
     "type": "ARMOR",
@@ -1028,7 +990,6 @@
     "name": { "str": "jean jacket" },
     "weight": "5 g",
     "color": "light_red",
-    "covers": [ "torso", "arm_l", "arm_r" ],
     "to_hit": 0,
     "storage": 3,
     "symbol": "[",
@@ -1044,8 +1005,8 @@
     "encumberance": 1,
     "bashing": 0,
     "flags": [ "VARSIZE", "POCKETS" ],
-    "coverage": 95,
-    "material_thickness": 4
+    "material_thickness": 4,
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r" ] }
   },
   {
     "type": "ARMOR",
@@ -1053,7 +1014,6 @@
     "name": { "str": "blazer" },
     "weight": "6 g",
     "color": "light_red",
-    "covers": [ "torso", "arm_l", "arm_r" ],
     "to_hit": 0,
     "storage": 2,
     "symbol": "[",
@@ -1069,8 +1029,8 @@
     "encumberance": 2,
     "bashing": 0,
     "flags": [ "VARSIZE" ],
-    "coverage": 95,
-    "material_thickness": 4
+    "material_thickness": 4,
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r" ] }
   },
   {
     "type": "ARMOR",
@@ -1078,7 +1038,6 @@
     "name": { "str": "leather jacket" },
     "weight": "14 g",
     "color": "light_red",
-    "covers": [ "torso", "arm_l", "arm_r" ],
     "to_hit": 1,
     "storage": 4,
     "symbol": "[",
@@ -1094,8 +1053,8 @@
     "encumberance": 2,
     "bashing": 0,
     "flags": [ "VARSIZE" ],
-    "coverage": 95,
-    "material_thickness": 4
+    "material_thickness": 4,
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r" ] }
   },
   {
     "type": "ARMOR",
@@ -1103,7 +1062,6 @@
     "name": { "str": "kevlar vest" },
     "weight": "24 g",
     "color": "light_red",
-    "covers": [ "torso" ],
     "to_hit": -3,
     "storage": 4,
     "symbol": "[",
@@ -1119,8 +1077,8 @@
     "encumberance": 2,
     "bashing": 6,
     "flags": [ "VARSIZE" ],
-    "coverage": 80,
-    "material_thickness": 5
+    "material_thickness": 5,
+    "armor": { "coverage": 80, "covers": [ "torso" ] }
   },
   {
     "type": "ARMOR",
@@ -1128,7 +1086,6 @@
     "name": { "str": "rain coat" },
     "weight": "8 g",
     "color": "light_red",
-    "covers": [ "torso", "arm_l", "arm_r" ],
     "to_hit": 0,
     "storage": 7,
     "symbol": "[",
@@ -1144,8 +1101,8 @@
     "encumberance": 2,
     "bashing": 0,
     "flags": [ "VARSIZE" ],
-    "coverage": 95,
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r" ] }
   },
   {
     "type": "ARMOR",
@@ -1153,7 +1110,6 @@
     "name": { "str": "wool poncho" },
     "weight": "3 g",
     "color": "light_red",
-    "covers": [ "torso" ],
     "to_hit": -1,
     "storage": 0,
     "symbol": "[",
@@ -1169,8 +1125,8 @@
     "encumberance": 0,
     "bashing": 0,
     "flags": [ "VARSIZE" ],
-    "coverage": 95,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 95, "covers": [ "torso" ] }
   },
   {
     "type": "ARMOR",
@@ -1178,7 +1134,6 @@
     "name": { "str": "trenchcoat" },
     "weight": "6 g",
     "color": "light_red",
-    "covers": [ "torso", "arm_l", "arm_r" ],
     "to_hit": -1,
     "storage": 24,
     "symbol": "[",
@@ -1194,8 +1149,8 @@
     "encumberance": 1,
     "bashing": 0,
     "flags": [ "VARSIZE", "POCKETS" ],
-    "coverage": 95,
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r" ] }
   },
   {
     "type": "ARMOR",
@@ -1203,7 +1158,6 @@
     "name": { "str": "floataion vest" },
     "weight": "8 g",
     "color": "cyan",
-    "covers": [ "torso" ],
     "to_hit": -3,
     "storage": 0,
     "symbol": "[",
@@ -1219,8 +1173,8 @@
     "encumberance": 1,
     "bashing": 2,
     "flags": [ "FLOATATION" ],
-    "coverage": 40,
-    "material_thickness": 5
+    "material_thickness": 5,
+    "armor": { "coverage": 40, "covers": [ "torso" ] }
   },
   {
     "type": "ARMOR",
@@ -1228,7 +1182,6 @@
     "name": { "str": "leather trenchcoat" },
     "weight": "10 g",
     "color": "light_red",
-    "covers": [ "torso", "arm_l", "arm_r" ],
     "to_hit": -1,
     "storage": 24,
     "symbol": "[",
@@ -1244,8 +1197,8 @@
     "encumberance": 2,
     "bashing": 0,
     "flags": [ "VARSIZE", "POCKETS" ],
-    "coverage": 95,
-    "material_thickness": 4
+    "material_thickness": 4,
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r" ] }
   },
   {
     "type": "ARMOR",
@@ -1253,7 +1206,6 @@
     "name": { "str": "fur trenchcoat" },
     "weight": "10 g",
     "color": "light_red",
-    "covers": [ "torso", "arm_l", "arm_r" ],
     "to_hit": -1,
     "storage": 24,
     "symbol": "[",
@@ -1269,8 +1221,8 @@
     "encumberance": 2,
     "bashing": 0,
     "flags": [ "VARSIZE", "POCKETS" ],
-    "coverage": 95,
-    "material_thickness": 6
+    "material_thickness": 6,
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r" ] }
   },
   {
     "type": "ARMOR",
@@ -1278,7 +1230,6 @@
     "name": { "str": "winter coat" },
     "weight": "6 g",
     "color": "light_red",
-    "covers": [ "torso", "arm_l", "arm_r" ],
     "to_hit": -2,
     "storage": 12,
     "symbol": "[",
@@ -1294,8 +1245,8 @@
     "encumberance": 3,
     "bashing": 0,
     "flags": [ "VARSIZE", "POCKETS" ],
-    "coverage": 95,
-    "material_thickness": 8
+    "material_thickness": 8,
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r" ] }
   },
   {
     "type": "ARMOR",
@@ -1303,7 +1254,6 @@
     "name": { "str": "fur coat" },
     "weight": "12 g",
     "color": "light_red",
-    "covers": [ "torso", "arm_l", "arm_r" ],
     "to_hit": -5,
     "storage": 4,
     "symbol": "[",
@@ -1319,8 +1269,8 @@
     "encumberance": 2,
     "bashing": 0,
     "flags": [ "VARSIZE", "POCKETS" ],
-    "coverage": 95,
-    "material_thickness": 8
+    "material_thickness": 8,
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r" ] }
   },
   {
     "type": "ARMOR",
@@ -1328,7 +1278,6 @@
     "name": { "str": "peacoat" },
     "weight": "10 g",
     "color": "light_red",
-    "covers": [ "torso", "arm_l", "arm_r" ],
     "to_hit": -3,
     "storage": 10,
     "symbol": "[",
@@ -1344,8 +1293,8 @@
     "encumberance": 2,
     "bashing": 0,
     "flags": [ "VARSIZE", "POCKETS" ],
-    "coverage": 95,
-    "material_thickness": 8
+    "material_thickness": 8,
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r" ] }
   },
   {
     "type": "ARMOR",
@@ -1353,7 +1302,6 @@
     "name": { "str": "utility vest" },
     "weight": "3 g",
     "color": "light_red",
-    "covers": [ "torso" ],
     "to_hit": 0,
     "storage": 14,
     "symbol": "[",
@@ -1368,8 +1316,8 @@
     "rarity": 15,
     "encumberance": 0,
     "bashing": 0,
-    "coverage": 70,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 70, "covers": [ "torso" ] }
   },
   {
     "type": "ARMOR",
@@ -1377,7 +1325,6 @@
     "name": { "str": "leather vest" },
     "weight": "10 g",
     "color": "light_red",
-    "covers": [ "torso" ],
     "to_hit": 1,
     "storage": 4,
     "symbol": "[",
@@ -1393,8 +1340,8 @@
     "encumberance": 1,
     "bashing": 0,
     "flags": [ "VARSIZE" ],
-    "coverage": 95,
-    "material_thickness": 4
+    "material_thickness": 4,
+    "armor": { "coverage": 95, "covers": [ "torso" ] }
   },
   {
     "type": "ARMOR",
@@ -1402,7 +1349,6 @@
     "name": { "str": "belt rig" },
     "weight": "4 g",
     "color": "light_red",
-    "covers": [ "torso" ],
     "to_hit": 0,
     "storage": 18,
     "symbol": "[",
@@ -1417,8 +1363,8 @@
     "rarity": 10,
     "encumberance": 0,
     "bashing": 0,
-    "coverage": 70,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 70, "covers": [ "torso" ] }
   },
   {
     "type": "ARMOR",
@@ -1426,7 +1372,6 @@
     "name": { "str": "lab coat" },
     "weight": "7 g",
     "color": "light_red",
-    "covers": [ "torso", "arm_l", "arm_r" ],
     "to_hit": -2,
     "storage": 14,
     "symbol": "[",
@@ -1442,8 +1387,8 @@
     "encumberance": 1,
     "bashing": 0,
     "flags": [ "VARSIZE" ],
-    "coverage": 95,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r" ] }
   },
   {
     "type": "ARMOR",
@@ -1451,7 +1396,6 @@
     "name": { "str": "soft arm sleeves" },
     "weight": "0 g",
     "color": "blue",
-    "covers": [ "arm_l", "arm_r" ],
     "to_hit": 1,
     "storage": 0,
     "symbol": "[",
@@ -1466,8 +1410,8 @@
     "rarity": 40,
     "encumberance": 0,
     "bashing": 0,
-    "coverage": 50,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 50, "covers": [ "arm_l", "arm_r" ] }
   },
   {
     "type": "ARMOR",
@@ -1475,7 +1419,6 @@
     "name": { "str": "hard arm guards" },
     "weight": "0 g",
     "color": "blue",
-    "covers": [ "arm_l", "arm_r" ],
     "to_hit": 1,
     "storage": 0,
     "symbol": "[",
@@ -1490,8 +1433,8 @@
     "rarity": 20,
     "encumberance": 1,
     "bashing": 0,
-    "coverage": 50,
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 50, "covers": [ "arm_l", "arm_r" ] }
   },
   {
     "type": "ARMOR",
@@ -1499,7 +1442,6 @@
     "name": { "str": "chitin arm guards" },
     "weight": "0 g",
     "color": "blue",
-    "covers": [ "arm_l", "arm_r" ],
     "to_hit": 1,
     "storage": 0,
     "symbol": "[",
@@ -1514,8 +1456,8 @@
     "rarity": 10,
     "encumberance": 1,
     "bashing": 0,
-    "coverage": 50,
-    "material_thickness": 5
+    "material_thickness": 5,
+    "armor": { "coverage": 50, "covers": [ "arm_l", "arm_r" ] }
   },
   {
     "type": "ARMOR",
@@ -1523,7 +1465,6 @@
     "name": { "str": "metal arm guards" },
     "weight": "1 g",
     "color": "blue",
-    "covers": [ "arm_l", "arm_r" ],
     "to_hit": 1,
     "storage": 0,
     "symbol": "[",
@@ -1538,8 +1479,8 @@
     "rarity": 10,
     "encumberance": 1,
     "bashing": 0,
-    "coverage": 50,
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 50, "covers": [ "arm_l", "arm_r" ] }
   },
   {
     "type": "ARMOR",
@@ -1547,7 +1488,6 @@
     "name": { "str": "glove liners" },
     "weight": "0 g",
     "color": "light_blue",
-    "covers": [ "hand_l", "hand_r" ],
     "to_hit": 1,
     "storage": 0,
     "symbol": "[",
@@ -1563,8 +1503,8 @@
     "encumberance": 0,
     "bashing": 0,
     "flags": [ "VARSIZE" ],
-    "coverage": 75,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 75, "covers": [ "hand_l", "hand_r" ] }
   },
   {
     "type": "ARMOR",
@@ -1572,7 +1512,6 @@
     "name": { "str": "light gloves" },
     "weight": "0 g",
     "color": "light_blue",
-    "covers": [ "hand_l", "hand_r" ],
     "to_hit": 1,
     "storage": 0,
     "symbol": "[",
@@ -1587,8 +1526,8 @@
     "rarity": 35,
     "encumberance": 1,
     "bashing": 0,
-    "coverage": 75,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 75, "covers": [ "hand_l", "hand_r" ] }
   },
   {
     "type": "ARMOR",
@@ -1596,7 +1535,6 @@
     "name": { "str": "mittens" },
     "weight": "0 g",
     "color": "light_blue",
-    "covers": [ "hand_l", "hand_r" ],
     "to_hit": 1,
     "storage": 0,
     "symbol": "[",
@@ -1611,8 +1549,8 @@
     "rarity": 30,
     "encumberance": 8,
     "bashing": 0,
-    "coverage": 75,
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 75, "covers": [ "hand_l", "hand_r" ] }
   },
   {
     "type": "ARMOR",
@@ -1620,7 +1558,6 @@
     "name": { "str": "fur gloves" },
     "weight": "0 g",
     "color": "light_blue",
-    "covers": [ "hand_l", "hand_r" ],
     "to_hit": 1,
     "storage": 0,
     "symbol": "[",
@@ -1635,8 +1572,8 @@
     "rarity": 30,
     "encumberance": 3,
     "bashing": 0,
-    "coverage": 75,
-    "material_thickness": 4
+    "material_thickness": 4,
+    "armor": { "coverage": 75, "covers": [ "hand_l", "hand_r" ] }
   },
   {
     "type": "ARMOR",
@@ -1644,7 +1581,6 @@
     "name": { "str": "wool gloves" },
     "weight": "0 g",
     "color": "light_blue",
-    "covers": [ "hand_l", "hand_r" ],
     "to_hit": 1,
     "storage": 0,
     "symbol": "[",
@@ -1659,8 +1595,8 @@
     "rarity": 33,
     "encumberance": 3,
     "bashing": 0,
-    "coverage": 75,
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 75, "covers": [ "hand_l", "hand_r" ] }
   },
   {
     "type": "ARMOR",
@@ -1668,7 +1604,6 @@
     "name": { "str": "winter gloves" },
     "weight": "0 g",
     "color": "light_blue",
-    "covers": [ "hand_l", "hand_r" ],
     "to_hit": 1,
     "storage": 0,
     "symbol": "[",
@@ -1683,8 +1618,8 @@
     "rarity": 40,
     "encumberance": 5,
     "bashing": 0,
-    "coverage": 85,
-    "material_thickness": 5
+    "material_thickness": 5,
+    "armor": { "coverage": 85, "covers": [ "hand_l", "hand_r" ] }
   },
   {
     "type": "ARMOR",
@@ -1692,7 +1627,6 @@
     "name": { "str": "leather gloves" },
     "weight": "1 g",
     "color": "light_blue",
-    "covers": [ "hand_l", "hand_r" ],
     "to_hit": 2,
     "storage": 0,
     "symbol": "[",
@@ -1707,8 +1641,8 @@
     "rarity": 45,
     "encumberance": 1,
     "bashing": 0,
-    "coverage": 75,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 75, "covers": [ "hand_l", "hand_r" ] }
   },
   {
     "type": "ARMOR",
@@ -1716,7 +1650,6 @@
     "name": { "str": "fingerless gloves" },
     "weight": "0 g",
     "color": "light_blue",
-    "covers": [ "hand_l", "hand_r" ],
     "to_hit": 2,
     "storage": 0,
     "symbol": "[",
@@ -1731,8 +1664,8 @@
     "rarity": 20,
     "encumberance": 0,
     "bashing": 0,
-    "coverage": 40,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 40, "covers": [ "hand_l", "hand_r" ] }
   },
   {
     "type": "ARMOR",
@@ -1740,7 +1673,6 @@
     "name": { "str": "rubber gloves" },
     "weight": "1 g",
     "color": "light_blue",
-    "covers": [ "hand_l", "hand_r" ],
     "to_hit": 2,
     "storage": 0,
     "symbol": "[",
@@ -1755,8 +1687,8 @@
     "rarity": 20,
     "encumberance": 3,
     "bashing": 0,
-    "coverage": 95,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 95, "covers": [ "hand_l", "hand_r" ] }
   },
   {
     "type": "ARMOR",
@@ -1764,7 +1696,6 @@
     "name": { "str": "medical gloves" },
     "weight": "0 g",
     "color": "light_blue",
-    "covers": [ "hand_l", "hand_r" ],
     "to_hit": 1,
     "storage": 0,
     "symbol": "[",
@@ -1779,8 +1710,8 @@
     "rarity": 70,
     "encumberance": 0,
     "bashing": 0,
-    "coverage": 75,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 75, "covers": [ "hand_l", "hand_r" ] }
   },
   {
     "type": "ARMOR",
@@ -1788,7 +1719,6 @@
     "name": { "str": "fire gauntlets" },
     "weight": "5 g",
     "color": "light_blue",
-    "covers": [ "hand_l", "hand_r" ],
     "to_hit": 2,
     "storage": 0,
     "symbol": "[",
@@ -1803,8 +1733,8 @@
     "rarity": 5,
     "encumberance": 6,
     "bashing": 0,
-    "coverage": 95,
-    "material_thickness": 5
+    "material_thickness": 5,
+    "armor": { "coverage": 95, "covers": [ "hand_l", "hand_r" ] }
   },
   {
     "type": "ARMOR",
@@ -1812,7 +1742,6 @@
     "name": { "str": "chitinous gauntlets" },
     "weight": "1 g",
     "color": "light_blue",
-    "covers": [ "hand_l", "hand_r" ],
     "to_hit": -2,
     "storage": 0,
     "symbol": "[",
@@ -1827,8 +1756,8 @@
     "rarity": 1,
     "encumberance": 1,
     "bashing": 2,
-    "coverage": 95,
-    "material_thickness": 5
+    "material_thickness": 5,
+    "armor": { "coverage": 95, "covers": [ "hand_l", "hand_r" ] }
   },
   {
     "type": "ARMOR",
@@ -1836,7 +1765,6 @@
     "name": { "str": "dust mask" },
     "weight": "0 g",
     "color": "white",
-    "covers": [ "mouth" ],
     "to_hit": -3,
     "storage": 0,
     "symbol": "[",
@@ -1851,8 +1779,8 @@
     "rarity": 65,
     "encumberance": 1,
     "bashing": 0,
-    "coverage": 50,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 50, "covers": [ "mouth" ] }
   },
   {
     "type": "ARMOR",
@@ -1860,7 +1788,6 @@
     "name": { "str": "bandana" },
     "weight": "0 g",
     "color": "white",
-    "covers": [ "mouth" ],
     "to_hit": -1,
     "storage": 0,
     "symbol": "[",
@@ -1875,8 +1802,8 @@
     "rarity": 35,
     "encumberance": 0,
     "bashing": 0,
-    "coverage": 60,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 60, "covers": [ "mouth" ] }
   },
   {
     "type": "ARMOR",
@@ -1884,7 +1811,6 @@
     "name": { "str": "scarf" },
     "weight": "3 g",
     "color": "white",
-    "covers": [ "mouth" ],
     "to_hit": -3,
     "storage": 0,
     "symbol": "[",
@@ -1899,8 +1825,8 @@
     "rarity": 45,
     "encumberance": 1,
     "bashing": 0,
-    "coverage": 85,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 85, "covers": [ "mouth" ] }
   },
   {
     "type": "ARMOR",
@@ -1908,7 +1834,6 @@
     "name": { "str": "scarf" },
     "weight": "3 g",
     "color": "white",
-    "covers": [ "mouth" ],
     "to_hit": -3,
     "storage": 0,
     "symbol": "[",
@@ -1923,8 +1848,8 @@
     "rarity": 45,
     "encumberance": 1,
     "bashing": 0,
-    "coverage": 85,
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 85, "covers": [ "mouth" ] }
   },
   {
     "type": "ARMOR",
@@ -1932,7 +1857,6 @@
     "name": { "str": "filter mask" },
     "weight": "6 g",
     "color": "white",
-    "covers": [ "mouth" ],
     "to_hit": 1,
     "storage": 0,
     "symbol": "[",
@@ -1947,8 +1871,8 @@
     "rarity": 30,
     "encumberance": 2,
     "bashing": 1,
-    "coverage": 85,
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 85, "covers": [ "mouth" ] }
   },
   {
     "type": "ARMOR",
@@ -1956,7 +1880,6 @@
     "name": { "str": "gas mask" },
     "weight": "8 g",
     "color": "white",
-    "covers": [ "mouth", "eyes" ],
     "to_hit": -3,
     "storage": 0,
     "symbol": "[",
@@ -1971,8 +1894,8 @@
     "rarity": 10,
     "encumberance": 4,
     "bashing": 0,
-    "coverage": 95,
-    "material_thickness": 4
+    "material_thickness": 4,
+    "armor": { "coverage": 95, "covers": [ "mouth", "eyes" ] }
   },
   {
     "type": "ARMOR",
@@ -1980,7 +1903,6 @@
     "name": { "str": "eyeglasses" },
     "weight": "0 g",
     "color": "cyan",
-    "covers": [ "eyes" ],
     "to_hit": -2,
     "storage": 0,
     "symbol": "[",
@@ -1995,8 +1917,8 @@
     "rarity": 90,
     "encumberance": 0,
     "bashing": 0,
-    "coverage": 75,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 75, "covers": [ "eyes" ] }
   },
   {
     "type": "ARMOR",
@@ -2004,7 +1926,6 @@
     "name": { "str": "reading glasses" },
     "weight": "0 g",
     "color": "cyan",
-    "covers": [ "eyes" ],
     "to_hit": -2,
     "storage": 0,
     "symbol": "[",
@@ -2019,8 +1940,8 @@
     "rarity": 90,
     "encumberance": 0,
     "bashing": 0,
-    "coverage": 75,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 75, "covers": [ "eyes" ] }
   },
   {
     "type": "ARMOR",
@@ -2028,7 +1949,6 @@
     "name": { "str": "bifocal glasses" },
     "weight": "0 g",
     "color": "cyan",
-    "covers": [ "eyes" ],
     "to_hit": -2,
     "storage": 0,
     "symbol": "[",
@@ -2044,8 +1964,8 @@
     "rarity": 90,
     "encumberance": 0,
     "bashing": 0,
-    "coverage": 75,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 75, "covers": [ "eyes" ] }
   },
   {
     "type": "ARMOR",
@@ -2053,7 +1973,6 @@
     "name": { "str": "safety glasses" },
     "weight": "0 g",
     "color": "cyan",
-    "covers": [ "eyes" ],
     "to_hit": -2,
     "storage": 0,
     "symbol": "[",
@@ -2068,8 +1987,8 @@
     "rarity": 40,
     "encumberance": 0,
     "bashing": 0,
-    "coverage": 75,
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 75, "covers": [ "eyes" ] }
   },
   {
     "type": "ARMOR",
@@ -2077,7 +1996,6 @@
     "name": { "str": "swim goggles" },
     "weight": "0 g",
     "color": "cyan",
-    "covers": [ "eyes" ],
     "to_hit": -2,
     "storage": 0,
     "symbol": "[",
@@ -2092,8 +2010,8 @@
     "rarity": 50,
     "encumberance": 2,
     "bashing": 0,
-    "coverage": 85,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 85, "covers": [ "eyes" ] }
   },
   {
     "type": "ARMOR",
@@ -2101,7 +2019,6 @@
     "name": { "str": "ski goggles" },
     "weight": "1 g",
     "color": "cyan",
-    "covers": [ "eyes" ],
     "to_hit": -2,
     "storage": 0,
     "symbol": "[",
@@ -2116,8 +2033,8 @@
     "rarity": 30,
     "encumberance": 1,
     "bashing": 0,
-    "coverage": 95,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 95, "covers": [ "eyes" ] }
   },
   {
     "type": "ARMOR",
@@ -2125,7 +2042,6 @@
     "name": { "str": "welding goggles" },
     "weight": "4 g",
     "color": "cyan",
-    "covers": [ "eyes" ],
     "to_hit": -3,
     "storage": 0,
     "symbol": "[",
@@ -2140,8 +2056,8 @@
     "rarity": 70,
     "encumberance": 6,
     "bashing": 0,
-    "coverage": 95,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 95, "covers": [ "eyes" ] }
   },
   {
     "type": "ARMOR",
@@ -2149,7 +2065,6 @@
     "name": { "str": "light amp goggles" },
     "weight": "6 g",
     "color": "cyan",
-    "covers": [ "eyes" ],
     "to_hit": -2,
     "storage": 0,
     "symbol": "[",
@@ -2164,8 +2079,8 @@
     "rarity": 1,
     "encumberance": 2,
     "bashing": 1,
-    "coverage": 95,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 95, "covers": [ "eyes" ] }
   },
   {
     "type": "ARMOR",
@@ -2173,7 +2088,6 @@
     "name": { "str": "monocle" },
     "weight": "0 g",
     "color": "cyan",
-    "covers": [ "eyes" ],
     "to_hit": -2,
     "storage": 0,
     "symbol": "[",
@@ -2188,8 +2102,8 @@
     "rarity": 2,
     "encumberance": 0,
     "bashing": 0,
-    "coverage": 40,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 40, "covers": [ "eyes" ] }
   },
   {
     "type": "ARMOR",
@@ -2197,7 +2111,6 @@
     "name": { "str": "sunglasses" },
     "weight": "0 g",
     "color": "cyan",
-    "covers": [ "eyes" ],
     "to_hit": -2,
     "storage": 0,
     "symbol": "[",
@@ -2212,8 +2125,8 @@
     "rarity": 90,
     "encumberance": 0,
     "bashing": 0,
-    "coverage": 75,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 75, "covers": [ "eyes" ] }
   },
   {
     "type": "ARMOR",
@@ -2221,7 +2134,6 @@
     "name": { "str": "baseball cap" },
     "weight": "1 g",
     "color": "dark_gray",
-    "covers": [ "head" ],
     "to_hit": 0,
     "storage": 0,
     "symbol": "[",
@@ -2236,8 +2148,8 @@
     "rarity": 30,
     "encumberance": 0,
     "bashing": 0,
-    "coverage": 60,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 60, "covers": [ "head" ] }
   },
   {
     "type": "ARMOR",
@@ -2245,7 +2157,6 @@
     "name": { "str": "boonie hat" },
     "weight": "1 g",
     "color": "dark_gray",
-    "covers": [ "head" ],
     "to_hit": 0,
     "storage": 0,
     "symbol": "[",
@@ -2260,8 +2171,8 @@
     "rarity": 10,
     "encumberance": 0,
     "bashing": 0,
-    "coverage": 75,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 75, "covers": [ "head" ] }
   },
   {
     "type": "ARMOR",
@@ -2269,7 +2180,6 @@
     "name": { "str": "cotton hat" },
     "weight": "1 g",
     "color": "dark_gray",
-    "covers": [ "head" ],
     "to_hit": 0,
     "storage": 0,
     "symbol": "[",
@@ -2284,8 +2194,8 @@
     "rarity": 45,
     "encumberance": 0,
     "bashing": 0,
-    "coverage": 75,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 75, "covers": [ "head" ] }
   },
   {
     "type": "ARMOR",
@@ -2293,7 +2203,6 @@
     "name": { "str": "knit hat" },
     "weight": "1 g",
     "color": "dark_gray",
-    "covers": [ "head" ],
     "to_hit": 0,
     "storage": 0,
     "symbol": "[",
@@ -2308,8 +2217,8 @@
     "rarity": 25,
     "encumberance": 0,
     "bashing": 0,
-    "coverage": 65,
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 65, "covers": [ "head" ] }
   },
   {
     "type": "ARMOR",
@@ -2317,7 +2226,6 @@
     "name": { "str": "hunting cap" },
     "weight": "2 g",
     "color": "dark_gray",
-    "covers": [ "head" ],
     "to_hit": 0,
     "storage": 0,
     "symbol": "[",
@@ -2332,8 +2240,8 @@
     "rarity": 20,
     "encumberance": 0,
     "bashing": 0,
-    "coverage": 85,
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 85, "covers": [ "head" ] }
   },
   {
     "type": "ARMOR",
@@ -2341,7 +2249,6 @@
     "name": { "str": "fur hat" },
     "weight": "2 g",
     "color": "dark_gray",
-    "covers": [ "head" ],
     "to_hit": 0,
     "storage": 0,
     "symbol": "[",
@@ -2356,8 +2263,8 @@
     "rarity": 15,
     "encumberance": 1,
     "bashing": 0,
-    "coverage": 85,
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 85, "covers": [ "head" ] }
   },
   {
     "type": "ARMOR",
@@ -2365,7 +2272,6 @@
     "name": { "str": "balaclava" },
     "weight": "2 g",
     "color": "dark_gray",
-    "covers": [ "head", "mouth" ],
     "to_hit": 0,
     "storage": 0,
     "symbol": "[",
@@ -2380,8 +2286,8 @@
     "rarity": 15,
     "encumberance": 0,
     "bashing": 0,
-    "coverage": 95,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 95, "covers": [ "head", "mouth" ] }
   },
   {
     "type": "ARMOR",
@@ -2389,7 +2295,6 @@
     "name": { "str": "hard hat" },
     "weight": "4 g",
     "color": "dark_gray",
-    "covers": [ "head" ],
     "techniques": [ "WBLOCK_1" ],
     "to_hit": 0,
     "storage": 0,
@@ -2405,8 +2310,8 @@
     "rarity": 50,
     "encumberance": 1,
     "bashing": 6,
-    "coverage": 70,
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 70, "covers": [ "head" ] }
   },
   {
     "type": "ARMOR",
@@ -2414,7 +2319,6 @@
     "name": { "str": "pickelhaube" },
     "weight": "8 g",
     "color": "dark_gray",
-    "covers": [ "head" ],
     "to_hit": 1,
     "storage": 0,
     "symbol": "[",
@@ -2429,8 +2333,8 @@
     "rarity": 50,
     "encumberance": 1,
     "bashing": 10,
-    "coverage": 70,
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 70, "covers": [ "head" ] }
   },
   {
     "type": "ARMOR",
@@ -2438,7 +2342,6 @@
     "name": { "str": "beret" },
     "weight": "1 g",
     "color": "dark_gray",
-    "covers": [ "head" ],
     "to_hit": 0,
     "storage": 0,
     "symbol": "[",
@@ -2453,8 +2356,8 @@
     "rarity": 50,
     "encumberance": 0,
     "bashing": 0,
-    "coverage": 60,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 60, "covers": [ "head" ] }
   },
   {
     "type": "ARMOR",
@@ -2462,7 +2365,6 @@
     "name": { "str": "bike helmet" },
     "weight": "2 g",
     "color": "dark_gray",
-    "covers": [ "head" ],
     "techniques": [ "WBLOCK_1" ],
     "to_hit": 0,
     "storage": 0,
@@ -2478,8 +2380,8 @@
     "rarity": 35,
     "encumberance": 1,
     "bashing": 4,
-    "coverage": 75,
-    "material_thickness": 4
+    "material_thickness": 4,
+    "armor": { "coverage": 75, "covers": [ "head" ] }
   },
   {
     "type": "ARMOR",
@@ -2487,7 +2389,6 @@
     "name": { "str": "skid lid" },
     "weight": "5 g",
     "color": "dark_gray",
-    "covers": [ "head" ],
     "techniques": [ "WBLOCK_1" ],
     "to_hit": 0,
     "storage": 0,
@@ -2503,8 +2404,8 @@
     "rarity": 30,
     "encumberance": 2,
     "bashing": 8,
-    "coverage": 75,
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 75, "covers": [ "head" ] }
   },
   {
     "type": "ARMOR",
@@ -2512,7 +2413,6 @@
     "name": { "str": "baseball helmet" },
     "weight": "6 g",
     "color": "dark_gray",
-    "covers": [ "head" ],
     "techniques": [ "WBLOCK_1" ],
     "to_hit": -1,
     "storage": 0,
@@ -2528,8 +2428,8 @@
     "rarity": 45,
     "encumberance": 2,
     "bashing": 7,
-    "coverage": 80,
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 80, "covers": [ "head" ] }
   },
   {
     "type": "ARMOR",
@@ -2537,7 +2437,6 @@
     "name": { "str": "army helmet" },
     "weight": "8 g",
     "color": "dark_gray",
-    "covers": [ "head" ],
     "techniques": [ "WBLOCK_1" ],
     "to_hit": -1,
     "storage": 0,
@@ -2553,8 +2452,8 @@
     "rarity": 40,
     "encumberance": 2,
     "bashing": 10,
-    "coverage": 85,
-    "material_thickness": 4
+    "material_thickness": 4,
+    "armor": { "coverage": 85, "covers": [ "head" ] }
   },
   {
     "type": "ARMOR",
@@ -2562,7 +2461,6 @@
     "name": { "str": "riot helmet" },
     "weight": "7 g",
     "color": "dark_gray",
-    "covers": [ "head", "eyes", "mouth" ],
     "techniques": [ "WBLOCK_1" ],
     "to_hit": -1,
     "storage": 0,
@@ -2578,8 +2476,8 @@
     "rarity": 25,
     "encumberance": 2,
     "bashing": 8,
-    "coverage": 95,
-    "material_thickness": 4
+    "material_thickness": 4,
+    "armor": { "coverage": 95, "covers": [ "head", "eyes", "mouth" ] }
   },
   {
     "type": "ARMOR",
@@ -2587,7 +2485,6 @@
     "name": { "str": "motorcycle helmet" },
     "weight": "8 g",
     "color": "dark_gray",
-    "covers": [ "head", "mouth" ],
     "techniques": [ "WBLOCK_1" ],
     "to_hit": -1,
     "storage": 0,
@@ -2603,8 +2500,8 @@
     "rarity": 40,
     "encumberance": 3,
     "bashing": 7,
-    "coverage": 95,
-    "material_thickness": 5
+    "material_thickness": 5,
+    "armor": { "coverage": 95, "covers": [ "head", "mouth" ] }
   },
   {
     "type": "ARMOR",
@@ -2612,7 +2509,6 @@
     "name": { "str": "chitinous helmet" },
     "weight": "1 g",
     "color": "dark_gray",
-    "covers": [ "head", "eyes", "mouth" ],
     "to_hit": -2,
     "storage": 0,
     "symbol": "[",
@@ -2627,8 +2523,8 @@
     "rarity": 1,
     "encumberance": 1,
     "bashing": 2,
-    "coverage": 95,
-    "material_thickness": 5
+    "material_thickness": 5,
+    "armor": { "coverage": 95, "covers": [ "head", "eyes", "mouth" ] }
   },
   {
     "type": "ARMOR",
@@ -2636,7 +2532,6 @@
     "name": { "str": "great helm" },
     "weight": "15 g",
     "color": "dark_gray",
-    "covers": [ "head", "eyes", "mouth" ],
     "techniques": [ "WBLOCK_1" ],
     "to_hit": 0,
     "storage": 0,
@@ -2652,8 +2547,8 @@
     "rarity": 1,
     "encumberance": 4,
     "bashing": 10,
-    "coverage": 95,
-    "material_thickness": 5
+    "material_thickness": 5,
+    "armor": { "coverage": 95, "covers": [ "head", "eyes", "mouth" ] }
   },
   {
     "type": "ARMOR",
@@ -2661,7 +2556,6 @@
     "name": { "str": "top hat" },
     "weight": "1 g",
     "color": "dark_gray",
-    "covers": [ "head" ],
     "to_hit": 0,
     "storage": 0,
     "symbol": "[",
@@ -2676,8 +2570,8 @@
     "rarity": 10,
     "encumberance": 0,
     "bashing": 0,
-    "coverage": 60,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 60, "covers": [ "head" ] }
   },
   {
     "type": "ARMOR",
@@ -2685,7 +2579,6 @@
     "name": { "str": "backpack" },
     "weight": "2 g",
     "color": "green",
-    "covers": [ "torso" ],
     "to_hit": 0,
     "storage": 40,
     "symbol": "[",
@@ -2700,8 +2593,8 @@
     "rarity": 38,
     "encumberance": 1,
     "bashing": 0,
-    "coverage": 50,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 50, "covers": [ "torso" ] }
   },
   {
     "type": "ARMOR",
@@ -2709,7 +2602,6 @@
     "name": { "str": "military rucksack" },
     "weight": "3 g",
     "color": "green",
-    "covers": [ "torso" ],
     "to_hit": 0,
     "storage": 80,
     "symbol": "[",
@@ -2724,8 +2616,8 @@
     "rarity": 20,
     "encumberance": 2,
     "bashing": 0,
-    "coverage": 50,
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 50, "covers": [ "torso" ] }
   },
   {
     "type": "ARMOR",
@@ -2733,7 +2625,6 @@
     "name": { "str": "purse" },
     "weight": "3 g",
     "color": "green",
-    "covers": [ "torso" ],
     "to_hit": 2,
     "storage": 20,
     "symbol": "[",
@@ -2748,8 +2639,8 @@
     "rarity": 40,
     "encumberance": 1,
     "bashing": 2,
-    "coverage": 30,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 30, "covers": [ "torso" ] }
   },
   {
     "type": "ARMOR",
@@ -2757,7 +2648,6 @@
     "name": { "str": "messenger bag" },
     "weight": "2 g",
     "color": "green",
-    "covers": [ "torso" ],
     "to_hit": 1,
     "storage": 20,
     "symbol": "[",
@@ -2772,8 +2662,8 @@
     "rarity": 20,
     "encumberance": 0,
     "bashing": 1,
-    "coverage": 40,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 40, "covers": [ "torso" ] }
   },
   {
     "type": "ARMOR",
@@ -2789,14 +2679,14 @@
     "encumberance": 0,
     "price": 100,
     "material": [ "cotton", "plastic" ],
-    "coverage": 0,
     "rarity": 10,
     "symbol": "[",
     "bashing": 1,
     "cutting": 0,
     "warmth": 0,
     "enviromental_protection": 0,
-    "phase": "solid"
+    "phase": "solid",
+    "armor": { "coverage": 0 }
   },
   {
     "type": "ARMOR",
@@ -2812,14 +2702,14 @@
     "encumberance": 0,
     "price": 90,
     "material": [ "leather" ],
-    "coverage": 0,
     "rarity": 8,
     "symbol": "[",
     "bashing": 2,
     "cutting": 0,
     "warmth": 0,
     "enviromental_protection": 0,
-    "phase": "solid"
+    "phase": "solid",
+    "armor": { "coverage": 0 }
   },
   {
     "type": "ARMOR",
@@ -2827,7 +2717,6 @@
     "name": { "str": "bootstrap" },
     "weight": "1 g",
     "color": "green",
-    "covers": [ "leg_l", "leg_r" ],
     "to_hit": -1,
     "storage": 2,
     "symbol": "[",
@@ -2842,8 +2731,8 @@
     "rarity": 3,
     "encumberance": 0,
     "bashing": 0,
-    "coverage": 30,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 30, "covers": [ "leg_l", "leg_r" ] }
   },
   {
     "type": "ARMOR",
@@ -2851,7 +2740,6 @@
     "name": { "str": "pouch" },
     "weight": "2 g",
     "color": "green",
-    "covers": [ "torso" ],
     "to_hit": 1,
     "storage": 12,
     "symbol": "[",
@@ -2866,8 +2754,8 @@
     "rarity": 20,
     "encumberance": 1,
     "bashing": 1,
-    "coverage": 20,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 20, "covers": [ "torso" ] }
   },
   {
     "type": "ARMOR",
@@ -2875,7 +2763,6 @@
     "name": { "str": "leather pouch" },
     "weight": "2 g",
     "color": "green",
-    "covers": [ "torso" ],
     "to_hit": 1,
     "storage": 12,
     "symbol": "[",
@@ -2890,8 +2777,8 @@
     "rarity": 20,
     "encumberance": 0,
     "bashing": 1,
-    "coverage": 20,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 20, "covers": [ "torso" ] }
   },
   {
     "type": "ARMOR",
@@ -2907,14 +2794,14 @@
     "encumberance": 0,
     "price": 600,
     "material": [ "silver" ],
-    "coverage": 0,
     "rarity": 12,
     "symbol": "[",
     "bashing": 0,
     "cutting": 0,
     "warmth": 0,
     "enviromental_protection": 0,
-    "phase": "solid"
+    "phase": "solid",
+    "armor": { "coverage": 0 }
   },
   {
     "type": "ARMOR",
@@ -2930,14 +2817,14 @@
     "encumberance": 0,
     "price": 500,
     "material": [ "silver" ],
-    "coverage": 0,
     "rarity": 14,
     "symbol": "[",
     "bashing": 0,
     "cutting": 0,
     "warmth": 0,
     "enviromental_protection": 0,
-    "phase": "solid"
+    "phase": "solid",
+    "armor": { "coverage": 0 }
   },
   {
     "type": "ARMOR",
@@ -2953,14 +2840,14 @@
     "encumberance": 0,
     "price": 10,
     "material": [ "silver" ],
-    "coverage": 0,
     "rarity": 14,
     "symbol": "[",
     "bashing": 0,
     "cutting": 0,
     "warmth": 0,
     "enviromental_protection": 0,
-    "phase": "solid"
+    "phase": "solid",
+    "armor": { "coverage": 0 }
   },
   {
     "type": "ARMOR",
@@ -2976,14 +2863,14 @@
     "encumberance": 0,
     "price": 1000,
     "material": [ "plastic" ],
-    "coverage": 0,
     "rarity": 10,
     "symbol": "[",
     "bashing": 0,
     "cutting": 0,
     "warmth": 0,
     "enviromental_protection": 0,
-    "phase": "solid"
+    "phase": "solid",
+    "armor": { "coverage": 0 }
   },
   {
     "type": "ARMOR",
@@ -2999,7 +2886,6 @@
     "encumberance": 0,
     "price": 500,
     "material": [ "silver" ],
-    "coverage": 0,
     "bashing_protection": 0,
     "rarity": 14,
     "symbol": "[",
@@ -3007,7 +2893,8 @@
     "cutting": 0,
     "warmth": 0,
     "enviromental_protection": 0,
-    "phase": "solid"
+    "phase": "solid",
+    "armor": { "coverage": 0 }
   },
   {
     "type": "ARMOR",
@@ -3015,11 +2902,9 @@
     "name": { "str": "american flag" },
     "weight": "3 g",
     "color": "light_red",
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
     "to_hit": -1,
     "storage": 0,
     "symbol": "[",
-    "coverage": 60,
     "description": "A large American flag made to fly in even the worst conditions.",
     "price": 500,
     "material": [ "cotton" ],
@@ -3032,7 +2917,8 @@
     "encumberance": 0,
     "bashing": 0,
     "flags": [ "OVERSIZE" ],
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 60, "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ] }
   },
   {
     "type": "ARMOR",
@@ -3040,7 +2926,6 @@
     "name": { "str": "blanket" },
     "weight": "3 g",
     "color": "light_red",
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
     "to_hit": -1,
     "storage": 0,
     "symbol": "[",
@@ -3055,9 +2940,9 @@
     "rarity": 20,
     "encumberance": 5,
     "bashing": 0,
-    "coverage": 100,
     "flags": [ "OVERSIZE" ],
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 100, "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ] }
   },
   {
     "type": "ARMOR",
@@ -3065,7 +2950,6 @@
     "name": { "str": "fur blanket" },
     "weight": "10 g",
     "color": "light_red",
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
     "to_hit": -1,
     "storage": 0,
     "symbol": "[",
@@ -3080,9 +2964,9 @@
     "rarity": 20,
     "encumberance": 5,
     "bashing": 0,
-    "coverage": 100,
     "flags": [ "OVERSIZE" ],
-    "material_thickness": 4
+    "material_thickness": 4,
+    "armor": { "coverage": 100, "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ] }
   },
   {
     "type": "ARMOR",
@@ -3090,7 +2974,6 @@
     "name": { "str": "emergency blanket" },
     "weight": "2 g",
     "color": "light_red",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
     "to_hit": -1,
     "storage": 0,
     "symbol": "[",
@@ -3105,9 +2988,9 @@
     "rarity": 20,
     "encumberance": 5,
     "bashing": 0,
-    "coverage": 100,
     "flags": [ "OVERSIZE" ],
-    "material_thickness": 4
+    "material_thickness": 4,
+    "armor": { "coverage": 100, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ] }
   },
   {
     "type": "ARMOR",
@@ -3115,7 +2998,6 @@
     "name": { "str": "sleeping bag" },
     "weight": "5 g",
     "color": "light_red",
-    "covers": [ "torso", "head", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
     "to_hit": -1,
     "storage": 0,
     "symbol": "[",
@@ -3130,9 +3012,12 @@
     "rarity": 10,
     "encumberance": 5,
     "bashing": 0,
-    "coverage": 100,
     "flags": [ "OVERSIZE" ],
-    "material_thickness": 4
+    "material_thickness": 4,
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "head", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
+    }
   },
   {
     "type": "ARMOR",
@@ -3140,7 +3025,6 @@
     "name": { "str": "fur sleeping bag" },
     "weight": "5 g",
     "color": "light_red",
-    "covers": [ "torso", "head", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
     "to_hit": -1,
     "storage": 0,
     "symbol": "[",
@@ -3155,9 +3039,12 @@
     "rarity": 10,
     "encumberance": 5,
     "bashing": 0,
-    "coverage": 100,
     "flags": [ "OVERSIZE" ],
-    "material_thickness": 6
+    "material_thickness": 6,
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "head", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
+    }
   },
   {
     "type": "ARMOR",
@@ -3165,7 +3052,6 @@
     "name": { "str": "house coat" },
     "weight": "6 g",
     "color": "light_red",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
     "to_hit": -1,
     "storage": 6,
     "symbol": "[",
@@ -3180,9 +3066,9 @@
     "rarity": 25,
     "encumberance": 1,
     "bashing": 0,
-    "coverage": 95,
     "flags": [ "OVERSIZE" ],
-    "material_thickness": 4
+    "material_thickness": 4,
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ] }
   },
   {
     "type": "ARMOR",
@@ -3190,7 +3076,6 @@
     "name": { "str": "snuggie" },
     "weight": "6 g",
     "color": "light_red",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
     "to_hit": -1,
     "storage": 0,
     "symbol": "[",
@@ -3205,9 +3090,9 @@
     "rarity": 5,
     "encumberance": 2,
     "bashing": 0,
-    "coverage": 95,
     "flags": [ "OVERSIZE" ],
-    "material_thickness": 4
+    "material_thickness": 4,
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ] }
   },
   {
     "type": "ARMOR",
@@ -3215,7 +3100,6 @@
     "name": { "str": "cloak" },
     "weight": "15 g",
     "color": "light_red",
-    "covers": [ "torso", "head", "arm_l", "arm_r", "leg_l", "leg_r" ],
     "to_hit": -1,
     "storage": 0,
     "symbol": "[",
@@ -3230,9 +3114,9 @@
     "rarity": 5,
     "encumberance": 1,
     "bashing": 0,
-    "coverage": 95,
     "flags": [ "OVERSIZE" ],
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 95, "covers": [ "torso", "head", "arm_l", "arm_r", "leg_l", "leg_r" ] }
   },
   {
     "type": "ARMOR",
@@ -3240,7 +3124,6 @@
     "name": { "str": "fur cloak" },
     "weight": "15 g",
     "color": "light_red",
-    "covers": [ "torso", "head", "arm_l", "arm_r", "leg_l", "leg_r" ],
     "to_hit": -1,
     "storage": 0,
     "symbol": "[",
@@ -3255,9 +3138,9 @@
     "rarity": 5,
     "encumberance": 1,
     "bashing": 0,
-    "coverage": 95,
     "flags": [ "OVERSIZE" ],
-    "material_thickness": 4
+    "material_thickness": 4,
+    "armor": { "coverage": 95, "covers": [ "torso", "head", "arm_l", "arm_r", "leg_l", "leg_r" ] }
   },
   {
     "type": "ARMOR",
@@ -3265,7 +3148,6 @@
     "name": { "str": "leather cloak" },
     "weight": "25 g",
     "color": "light_red",
-    "covers": [ "torso", "head", "arm_l", "arm_r", "leg_l", "leg_r" ],
     "to_hit": -1,
     "storage": 0,
     "symbol": "[",
@@ -3280,9 +3162,9 @@
     "rarity": 5,
     "encumberance": 1,
     "bashing": 0,
-    "coverage": 95,
     "flags": [ "OVERSIZE" ],
-    "material_thickness": 4
+    "material_thickness": 4,
+    "armor": { "coverage": 95, "covers": [ "torso", "head", "arm_l", "arm_r", "leg_l", "leg_r" ] }
   },
   {
     "type": "ARMOR",
@@ -3290,7 +3172,6 @@
     "name": { "str": "jedi cloak" },
     "weight": "14 g",
     "color": "light_red",
-    "covers": [ "torso", "head", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r" ],
     "to_hit": -1,
     "storage": 0,
     "symbol": "[",
@@ -3305,9 +3186,9 @@
     "rarity": 1,
     "encumberance": 0,
     "bashing": 0,
-    "coverage": 95,
     "flags": [ "OVERSIZE" ],
-    "material_thickness": 4
+    "material_thickness": 4,
+    "armor": { "coverage": 95, "covers": [ "torso", "head", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r" ] }
   },
   {
     "type": "ARMOR",
@@ -3319,7 +3200,6 @@
     "color": "yellow",
     "symbol": "[",
     "material": [ "steel" ],
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
     "price": 1000,
     "cutting": 0,
     "phase": "solid",
@@ -3331,8 +3211,8 @@
     "warmth": 90,
     "encumberance": 5,
     "bashing": 1,
-    "coverage": 100,
-    "material_thickness": 10
+    "material_thickness": 10,
+    "armor": { "coverage": 100, "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ] }
   },
   {
     "type": "ARMOR",
@@ -3344,7 +3224,6 @@
     "color": "dark_gray",
     "symbol": "[",
     "material": [ "steel" ],
-    "covers": [ "head", "eyes", "mouth" ],
     "price": 500,
     "cutting": 0,
     "phase": "solid",
@@ -3356,8 +3235,8 @@
     "warmth": 90,
     "encumberance": 5,
     "bashing": 1,
-    "coverage": 100,
-    "material_thickness": 10
+    "material_thickness": 10,
+    "armor": { "coverage": 100, "covers": [ "head", "eyes", "mouth" ] }
   },
   {
     "type": "ARMOR",
@@ -3369,7 +3248,6 @@
     "color": "yellow",
     "symbol": "[",
     "material": [ "steel", "plastic" ],
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
     "price": 1500,
     "cutting": 0,
     "phase": "solid",
@@ -3381,8 +3259,8 @@
     "warmth": 60,
     "encumberance": 4,
     "bashing": 1,
-    "coverage": 100,
-    "material_thickness": 9
+    "material_thickness": 9,
+    "armor": { "coverage": 100, "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ] }
   },
   {
     "type": "ARMOR",
@@ -3394,7 +3272,6 @@
     "color": "dark_gray",
     "symbol": "[",
     "material": [ "steel", "plastic" ],
-    "covers": [ "head", "eyes", "mouth" ],
     "price": 750,
     "cutting": 0,
     "phase": "solid",
@@ -3406,8 +3283,8 @@
     "warmth": 60,
     "encumberance": 4,
     "bashing": 1,
-    "coverage": 100,
-    "material_thickness": 9
+    "material_thickness": 9,
+    "armor": { "coverage": 100, "covers": [ "head", "eyes", "mouth" ] }
   },
   {
     "type": "ARMOR",
@@ -3419,7 +3296,6 @@
     "color": "yellow",
     "symbol": "[",
     "material": [ "steel" ],
-    "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
     "price": 1500,
     "cutting": 0,
     "phase": "solid",
@@ -3431,8 +3307,8 @@
     "warmth": 60,
     "encumberance": 5,
     "bashing": 1,
-    "coverage": 100,
-    "material_thickness": 13
+    "material_thickness": 13,
+    "armor": { "coverage": 100, "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ] }
   },
   {
     "type": "ARMOR",
@@ -3444,7 +3320,6 @@
     "color": "dark_gray",
     "symbol": "[",
     "material": [ "steel" ],
-    "covers": [ "head", "eyes", "mouth" ],
     "price": 750,
     "cutting": 0,
     "phase": "solid",
@@ -3456,8 +3331,8 @@
     "warmth": 60,
     "encumberance": 5,
     "bashing": 1,
-    "coverage": 100,
-    "material_thickness": 13
+    "material_thickness": 13,
+    "armor": { "coverage": 100, "covers": [ "head", "eyes", "mouth" ] }
   },
   {
     "type": "ARMOR",
@@ -3480,8 +3355,8 @@
     "encumberance": 4,
     "bashing": 1,
     "symbol": "[",
-    "coverage": 100,
-    "material_thickness": 10
+    "material_thickness": 10,
+    "armor": { "coverage": 100 }
   },
   {
     "type": "ARMOR",
@@ -3490,7 +3365,6 @@
     "description": "A tool to help set bones and hold them in place",
     "weight": "10 g",
     "color": "light_red",
-    "covers": [ "arm_l", "arm_r" ],
     "price": 200,
     "material": [ "wood", "cotton" ],
     "volume": "5000 ml",
@@ -3504,8 +3378,8 @@
     "encumberance": 7,
     "bashing": 0,
     "symbol": "[",
-    "coverage": 75,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 75, "covers": [ "arm_l", "arm_r" ] }
   },
   {
     "type": "ARMOR",
@@ -3514,7 +3388,6 @@
     "description": "A tool to help set bones and hold them in place",
     "weight": "10 g",
     "color": "light_red",
-    "covers": [ "leg_l", "leg_r" ],
     "price": 200,
     "material": [ "wood", "cotton" ],
     "volume": "5000 ml",
@@ -3528,8 +3401,8 @@
     "encumberance": 7,
     "bashing": 0,
     "symbol": "[",
-    "coverage": 75,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 75, "covers": [ "leg_l", "leg_r" ] }
   },
   {
     "type": "ARMOR",
@@ -3537,7 +3410,6 @@
     "name": { "str": "hard leg guards" },
     "weight": "4 g",
     "color": "blue",
-    "covers": [ "leg_l", "leg_r" ],
     "to_hit": 1,
     "storage": 0,
     "symbol": "[",
@@ -3552,8 +3424,8 @@
     "rarity": 15,
     "encumberance": 1,
     "bashing": 0,
-    "coverage": 65,
-    "material_thickness": 4
+    "material_thickness": 4,
+    "armor": { "coverage": 65, "covers": [ "leg_l", "leg_r" ] }
   },
   {
     "type": "ARMOR",
@@ -3561,7 +3433,6 @@
     "name": { "str": "metal leg guards" },
     "weight": "8 g",
     "color": "blue",
-    "covers": [ "leg_l", "leg_r" ],
     "to_hit": 1,
     "storage": 0,
     "symbol": "[",
@@ -3576,8 +3447,8 @@
     "rarity": 10,
     "encumberance": 2,
     "bashing": 0,
-    "coverage": 70,
-    "material_thickness": 4
+    "material_thickness": 4,
+    "armor": { "coverage": 70, "covers": [ "leg_l", "leg_r" ] }
   },
   {
     "type": "ARMOR",
@@ -3594,14 +3465,14 @@
     "price": 50,
     "material": [ "plastic", "steel" ],
     "flags": [ "WATCH", "ALARM" ],
-    "coverage": 1,
     "rarity": 5,
     "symbol": "[",
     "bashing": 0,
     "cutting": 0,
     "warmth": 0,
     "enviromental_protection": 0,
-    "phase": "solid"
+    "phase": "solid",
+    "armor": { "coverage": 1 }
   },
   {
     "type": "ARMOR",
@@ -3609,7 +3480,6 @@
     "name": { "str": "black knit cap" },
     "weight": "1 g",
     "color": "dark_gray",
-    "covers": [ "head" ],
     "to_hit": 0,
     "storage": 0,
     "symbol": "[",
@@ -3624,8 +3494,8 @@
     "rarity": 45,
     "encumberance": 0,
     "bashing": 0,
-    "coverage": 75,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 75, "covers": [ "head" ] }
   },
   {
     "type": "ARMOR",
@@ -3633,7 +3503,6 @@
     "name": { "str": "panama hat" },
     "weight": "1 g",
     "color": "dark_gray",
-    "covers": [ "head" ],
     "to_hit": 0,
     "storage": 10,
     "symbol": "[",
@@ -3648,8 +3517,8 @@
     "rarity": 45,
     "encumberance": 0,
     "bashing": 0,
-    "coverage": 75,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 75, "covers": [ "head" ] }
   },
   {
     "type": "ARMOR",
@@ -3665,14 +3534,14 @@
     "encumberance": 0,
     "price": 100,
     "material": [ "leather", "plastic" ],
-    "coverage": 0,
     "rarity": 10,
     "symbol": "[",
     "bashing": 10,
     "cutting": 0,
     "warmth": 0,
     "enviromental_protection": 0,
-    "phase": "solid"
+    "phase": "solid",
+    "armor": { "coverage": 0 }
   },
   {
     "type": "ARMOR",
@@ -3688,14 +3557,14 @@
     "encumberance": 0,
     "price": 600,
     "material": [ "silver" ],
-    "coverage": 0,
     "rarity": 12,
     "symbol": "[",
     "bashing": 0,
     "cutting": 0,
     "warmth": 0,
     "enviromental_protection": 0,
-    "phase": "solid"
+    "phase": "solid",
+    "armor": { "coverage": 0 }
   },
   {
     "type": "ARMOR",
@@ -3703,7 +3572,6 @@
     "name": { "str": "Football Jersey" },
     "weight": "3 g",
     "color": "light_red",
-    "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
     "to_hit": -1,
     "storage": 6,
     "symbol": "[",
@@ -3718,9 +3586,9 @@
     "rarity": 25,
     "encumberance": 0,
     "bashing": 5,
-    "coverage": 95,
     "flags": [ "OVERSIZE" ],
-    "material_thickness": 4
+    "material_thickness": 4,
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ] }
   },
   {
     "type": "ARMOR",
@@ -3728,7 +3596,6 @@
     "name": { "str": "Woman Suit" },
     "weight": "19 g",
     "color": "yellow",
-    "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r", "mouth", "eyes" ],
     "to_hit": -3,
     "storage": 10,
     "symbol": "[",
@@ -3743,8 +3610,11 @@
     "rarity": 4,
     "encumberance": 1,
     "bashing": 0,
-    "coverage": 100,
-    "material_thickness": 10
+    "material_thickness": 10,
+    "armor": {
+      "coverage": 100,
+      "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r", "mouth", "eyes" ]
+    }
   },
   {
     "type": "ARMOR",
@@ -3752,7 +3622,6 @@
     "name": { "str": "Acapulco Shirt" },
     "weight": "2 g",
     "color": "light_red",
-    "covers": [ "torso" ],
     "to_hit": 0,
     "storage": 10,
     "symbol": "[",
@@ -3768,8 +3637,8 @@
     "encumberance": -2,
     "bashing": 10,
     "flags": [ "VARSIZE" ],
-    "coverage": 80,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 80, "covers": [ "torso" ] }
   },
   {
     "type": "ARMOR",
@@ -3777,7 +3646,6 @@
     "name": { "str": "bloody gloves" },
     "weight": "1 g",
     "color": "light_blue",
-    "covers": [ "hand_l", "hand_r" ],
     "to_hit": 2,
     "storage": 0,
     "symbol": "[",
@@ -3792,8 +3660,8 @@
     "rarity": 45,
     "encumberance": 1,
     "bashing": 0,
-    "coverage": 75,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 75, "covers": [ "hand_l", "hand_r" ] }
   },
   {
     "type": "ARMOR",
@@ -3801,7 +3669,6 @@
     "name": { "str": "Aviator T-Shades" },
     "weight": "0 g",
     "color": "cyan",
-    "covers": [ "eyes" ],
     "to_hit": 9,
     "storage": 2,
     "symbol": "[",
@@ -3816,8 +3683,8 @@
     "rarity": 90,
     "encumberance": 0,
     "bashing": 0,
-    "coverage": 75,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 75, "covers": [ "eyes" ] }
   },
   {
     "type": "ARMOR",
@@ -3825,7 +3692,6 @@
     "name": { "str": "Nazi Uniform" },
     "weight": "6 g",
     "color": "dark_gray",
-    "covers": [ "leg_l", "leg_r", "torso" ],
     "to_hit": 4,
     "storage": 25,
     "symbol": "[",
@@ -3841,8 +3707,8 @@
     "encumberance": 0,
     "bashing": 0,
     "flags": [ "VARSIZE" ],
-    "coverage": 95,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r", "torso" ] }
   },
   {
     "type": "ARMOR",
@@ -3850,7 +3716,6 @@
     "name": { "str": "Jorts" },
     "weight": "6 g",
     "color": "brown",
-    "covers": [ "leg_l", "leg_r" ],
     "to_hit": 0,
     "storage": 12,
     "symbol": "[",
@@ -3866,8 +3731,8 @@
     "encumberance": 1,
     "bashing": 0,
     "flags": [ "VARSIZE" ],
-    "coverage": 95,
-    "material_thickness": 4
+    "material_thickness": 4,
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r" ] }
   },
   {
     "type": "ARMOR",
@@ -3875,7 +3740,6 @@
     "name": { "str": "Rhinestone Jumpsuit" },
     "weight": "6 g",
     "color": "yellow",
-    "covers": [ "leg_l", "leg_r", "torso" ],
     "to_hit": 3,
     "storage": 8,
     "symbol": "[",
@@ -3891,8 +3755,8 @@
     "encumberance": 0,
     "bashing": 0,
     "flags": [ "VARSIZE" ],
-    "coverage": 95,
-    "material_thickness": 5
+    "material_thickness": 5,
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r", "torso" ] }
   },
   {
     "type": "ARMOR",
@@ -3900,7 +3764,6 @@
     "name": { "str": "Fedora" },
     "weight": "1 g",
     "color": "dark_gray",
-    "covers": [ "head" ],
     "to_hit": 0,
     "storage": 10,
     "symbol": "[",
@@ -3915,7 +3778,7 @@
     "rarity": 45,
     "encumberance": 0,
     "bashing": 0,
-    "coverage": 75,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 75, "covers": [ "head" ] }
   }
 ]

--- a/workshop/More_Armor/armor.json
+++ b/workshop/More_Armor/armor.json
@@ -14,12 +14,14 @@
     "symbol": "[",
     "color": "light_gray",
     "looks_like": "armor_lightplate",
-    "covers": [ "torso", "head", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "warmth": 20,
     "material_thickness": 4,
-    "flags": [ "VARSIZE", "OUTER", "STURDY", "ELECTRIC_IMMUNE" ]
+    "flags": [ "VARSIZE", "OUTER", "STURDY", "ELECTRIC_IMMUNE" ],
+    "armor": {
+      "coverage": 95,
+      "covers": [ "torso", "head", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 20
+    }
   },
   {
     "id": "chainmail_suit_faraday",
@@ -35,11 +37,13 @@
     "symbol": "[",
     "color": "light_red",
     "looks_like": "chainmail_suit",
-    "covers": [ "torso", "head", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "coverage": 95,
-    "encumbrance": 20,
     "material_thickness": 4,
-    "flags": [ "VARSIZE", "STURDY", "HELMET_COMPAT", "ELECTRIC_IMMUNE" ]
+    "flags": [ "VARSIZE", "STURDY", "HELMET_COMPAT", "ELECTRIC_IMMUNE" ],
+    "armor": {
+      "coverage": 95,
+      "covers": [ "torso", "head", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+      "encumbrance": 20
+    }
   },
   {
     "id": "jumpsuit_leather",
@@ -54,13 +58,11 @@
     "symbol": "[",
     "color": "dark_gray",
     "looks_like": "touring_suit",
-    "covers": [ "leg_l", "leg_r", "arm_l", "arm_r", "torso" ],
-    "coverage": 95,
-    "encumbrance": 8,
     "storage": 8,
     "warmth": 15,
     "material_thickness": 3,
-    "flags": [ "VARSIZE", "POCKETS" ]
+    "flags": [ "VARSIZE", "POCKETS" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r", "arm_l", "arm_r", "torso" ], "encumbrance": 8 }
   },
   {
     "id": "jumpsuit_xlleather",
@@ -75,13 +77,11 @@
     "symbol": "[",
     "color": "dark_gray",
     "looks_like": "touring_suit",
-    "covers": [ "leg_l", "leg_r", "arm_l", "arm_r", "torso" ],
-    "coverage": 95,
-    "encumbrance": 8,
     "storage": 10,
     "warmth": 15,
     "material_thickness": 2,
-    "flags": [ "POCKETS", "OVERSIZE" ]
+    "flags": [ "POCKETS", "OVERSIZE" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r", "arm_l", "arm_r", "torso" ], "encumbrance": 8 }
   },
   {
     "id": "jumpsuit_leather_mod",
@@ -96,13 +96,11 @@
     "symbol": "[",
     "color": "dark_gray",
     "looks_like": "touring_suit",
-    "covers": [ "leg_l", "leg_r", "arm_l", "arm_r", "torso" ],
-    "coverage": 95,
-    "encumbrance": 12,
     "storage": 8,
     "warmth": 15,
     "material_thickness": 3,
-    "flags": [ "VARSIZE", "POCKETS" ]
+    "flags": [ "VARSIZE", "POCKETS" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r", "arm_l", "arm_r", "torso" ], "encumbrance": 12 }
   },
   {
     "id": "jumpsuit_xlleather_mod",
@@ -117,13 +115,11 @@
     "symbol": "[",
     "color": "dark_gray",
     "looks_like": "touring_suit",
-    "covers": [ "leg_l", "leg_r", "arm_l", "arm_r", "torso" ],
-    "coverage": 95,
-    "encumbrance": 12,
     "storage": 10,
     "warmth": 15,
     "material_thickness": 2,
-    "flags": [ "POCKETS", "OVERSIZE" ]
+    "flags": [ "POCKETS", "OVERSIZE" ],
+    "armor": { "coverage": 95, "covers": [ "leg_l", "leg_r", "arm_l", "arm_r", "torso" ], "encumbrance": 12 }
   },
   {
     "id": "armguard_xllarmor",
@@ -705,12 +701,10 @@
     "symbol": "[",
     "color": "dark_gray",
     "looks_like": "cuirass_lightplate",
-    "covers": [ "torso", "arm_l", "arm_r" ],
-    "coverage": 80,
-    "encumbrance": 30,
     "warmth": 5,
     "material_thickness": 10,
-    "flags": [ "BELTED" ]
+    "flags": [ "BELTED" ],
+    "armor": { "coverage": 80, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 30 }
   },
   {
     "id": "armor_xltire",
@@ -737,13 +731,11 @@
     "symbol": "[",
     "color": "dark_gray",
     "looks_like": "cuirass_lightplate",
-    "covers": [ "torso" ],
-    "coverage": 80,
-    "encumbrance": 10,
     "warmth": 20,
     "material_thickness": 4,
     "environmental_protection": 1,
-    "flags": [ "BELTED", "WATER_FRIENDLY" ]
+    "flags": [ "BELTED", "WATER_FRIENDLY" ],
+    "armor": { "coverage": 80, "covers": [ "torso" ], "encumbrance": 10 }
   },
   {
     "id": "conductive_suit",
@@ -758,12 +750,14 @@
     "symbol": "[",
     "color": "light_gray",
     "looks_like": "chainmail_suit",
-    "covers": [ "torso", "head", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r" ],
-    "coverage": 100,
-    "encumbrance": 15,
     "warmth": 15,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "HELMET_COMPAT", "ELECTRIC_IMMUNE" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "HELMET_COMPAT", "ELECTRIC_IMMUNE" ],
+    "armor": {
+      "coverage": 100,
+      "covers": [ "torso", "head", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r" ],
+      "encumbrance": 15
+    }
   },
   {
     "id": "backpack_floating",
@@ -773,7 +767,7 @@
     "description": "A small backpack with a special rail system designed to reduce the load felt by the wearer when moving up and down.  Good storage for very little encumbrance.",
     "weight": "833 g",
     "price": 7800,
-    "encumbrance": 7
+    "armor": { "encumbrance": 7 }
   },
   {
     "id": "rucksack_floating",
@@ -783,6 +777,6 @@
     "description": "A huge military rucksack with a special rail system designed to reduce the load felt by the wearer when moving up and down, provides a lot of storage for moderate encumbrance.",
     "weight": "1440 g",
     "price": 18400,
-    "encumbrance": 14
+    "armor": { "encumbrance": 14 }
   }
 ]

--- a/workshop/Wilderness_Overhaul/items/armor_bundles.json
+++ b/workshop/Wilderness_Overhaul/items/armor_bundles.json
@@ -11,17 +11,15 @@
     "description": "A bundle of crude atlatl darts, bound up with a rope for easy carrying.",
     "price": 6500,
     "material": [ "wood" ],
-    "covers": [ "torso" ],
     "volume": "3750 ml",
     "cutting": 0,
     "bashing": 4,
     "warmth": 0,
     "phase": "solid",
     "environmental_protection": 0,
-    "encumbrance": 0,
-    "coverage": 15,
     "material_thickness": 1,
-    "flags": [ "BELTED", "OVERSIZE" ]
+    "flags": [ "BELTED", "OVERSIZE" ],
+    "armor": { "coverage": 15, "covers": [ "torso" ], "encumbrance": 0 }
   },
   {
     "type": "ARMOR",
@@ -35,16 +33,14 @@
     "description": "A bundle of atlatl darts, bound up with a rope for easy carrying.",
     "price": 6500,
     "material": [ "wood" ],
-    "covers": [ "torso" ],
     "volume": "3750 ml",
     "cutting": 0,
     "bashing": 4,
     "warmth": 0,
     "phase": "solid",
     "environmental_protection": 0,
-    "encumbrance": 0,
-    "coverage": 15,
     "material_thickness": 1,
-    "flags": [ "BELTED", "OVERSIZE" ]
+    "flags": [ "BELTED", "OVERSIZE" ],
+    "armor": { "coverage": 15, "covers": [ "torso" ], "encumbrance": 0 }
   }
 ]

--- a/workshop/XStuff/items/armor.json
+++ b/workshop/XStuff/items/armor.json
@@ -5,7 +5,6 @@
     "name": { "str": "modular helmet" },
     "weight": "1844 g",
     "color": "dark_gray",
-    "covers": [ "head", "mouth", "eyes" ],
     "techniques": [ "WBLOCK_1" ],
     "to_hit": -2,
     "storage": 0,
@@ -18,11 +17,10 @@
     "warmth": 12,
     "phase": "solid",
     "environmental_protection": 3,
-    "encumbrance": 2,
     "bashing": 8,
-    "coverage": 95,
     "material_thickness": 4,
-    "flags": [ "SUN_GLASSES" ]
+    "flags": [ "SUN_GLASSES" ],
+    "armor": { "coverage": 95, "covers": [ "head", "mouth", "eyes" ], "encumbrance": 2 }
   },
   {
     "type": "ARMOR",
@@ -30,7 +28,6 @@
     "name": { "str": "motorcycle armor" },
     "weight": "2125 g",
     "color": "dark_gray",
-    "covers": [ "torso", "arm_l", "arm_r" ],
     "to_hit": 0,
     "storage": 2,
     "symbol": "[",
@@ -42,11 +39,10 @@
     "warmth": 6,
     "phase": "solid",
     "environmental_protection": 2,
-    "encumbrance": 0,
     "bashing": 8,
-    "coverage": 95,
     "material_thickness": 4,
-    "flags": [ "VARSIZE" ]
+    "flags": [ "VARSIZE" ],
+    "armor": { "coverage": 95, "covers": [ "torso", "arm_l", "arm_r" ], "encumbrance": 0 }
   },
   {
     "type": "ARMOR",
@@ -54,7 +50,6 @@
     "name": { "str": "motorcycle pants" },
     "weight": "1340 g",
     "color": "dark_gray",
-    "covers": [ "leg_l", "leg_r" ],
     "to_hit": 0,
     "storage": 0,
     "symbol": "[",
@@ -66,10 +61,9 @@
     "warmth": 6,
     "phase": "solid",
     "environmental_protection": 2,
-    "encumbrance": 0,
     "bashing": 0,
-    "coverage": 100,
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 100, "covers": [ "leg_l", "leg_r" ], "encumbrance": 0 }
   },
   {
     "type": "ARMOR",
@@ -77,7 +71,6 @@
     "name": { "str": "motorcycle boots" },
     "weight": "2125 g",
     "color": "dark_gray",
-    "covers": [ "foot_l", "foot_r" ],
     "to_hit": 0,
     "storage": 0,
     "symbol": "[",
@@ -89,11 +82,10 @@
     "warmth": 6,
     "phase": "solid",
     "environmental_protection": 3,
-    "encumbrance": 2,
     "bashing": 5,
-    "coverage": 100,
     "material_thickness": 4,
-    "flags": [ "VARSIZE" ]
+    "flags": [ "VARSIZE" ],
+    "armor": { "coverage": 100, "covers": [ "foot_l", "foot_r" ], "encumbrance": 2 }
   },
   {
     "type": "ARMOR",
@@ -101,7 +93,6 @@
     "name": { "str": "E&T shirt" },
     "weight": "110 g",
     "color": "white",
-    "covers": [ "torso" ],
     "to_hit": 0,
     "storage": 1,
     "symbol": "[",
@@ -113,11 +104,10 @@
     "warmth": 11,
     "phase": "solid",
     "environmental_protection": 1,
-    "encumbrance": 0,
     "bashing": 0,
     "flags": [ "VARSIZE" ],
-    "coverage": 90,
-    "material_thickness": 1
+    "material_thickness": 1,
+    "armor": { "coverage": 90, "covers": [ "torso" ], "encumbrance": 0 }
   },
   {
     "type": "ARMOR",
@@ -125,7 +115,6 @@
     "name": { "str": "E&T pants" },
     "weight": "450 g",
     "color": "brown",
-    "covers": [ "leg_l", "leg_r" ],
     "to_hit": 0,
     "storage": 4,
     "symbol": "[",
@@ -137,11 +126,10 @@
     "warmth": 20,
     "phase": "solid",
     "environmental_protection": 2,
-    "encumbrance": 0,
     "bashing": 0,
     "flags": [ "VARSIZE", "POCKETS" ],
-    "coverage": 90,
-    "material_thickness": 2
+    "material_thickness": 2,
+    "armor": { "coverage": 90, "covers": [ "leg_l", "leg_r" ], "encumbrance": 0 }
   },
   {
     "type": "ARMOR",
@@ -149,7 +137,6 @@
     "name": { "str": "face rags" },
     "weight": "220 g",
     "color": "dark_gray",
-    "covers": [ "head", "mouth" ],
     "to_hit": -2,
     "storage": 0,
     "symbol": "[",
@@ -161,9 +148,8 @@
     "warmth": 8,
     "phase": "solid",
     "environmental_protection": 4,
-    "encumbrance": 0,
     "bashing": 0,
-    "coverage": 65,
-    "material_thickness": 3
+    "material_thickness": 3,
+    "armor": { "coverage": 65, "covers": [ "head", "mouth" ], "encumbrance": 0 }
   }
 ]


### PR DESCRIPTION
There is a trend in Cataclysm-DDA (https://github.com/CleverRaven/Cataclysm-DDA/pull/49679 and similar) to use `"armor"` instead of explicitly declaring the different parts. 

This is the same as #128, just in a new PR to avoid dealing with merge conflicts.
This is a draft because I haven't playtested yet - it should work fine, but after the last tooling mistakes, I want to make sure.