### PR TITLE
Change required GLARE PROTECTION tool quality

### DIFF
--- a/data/Unleash_The_Mods/Working_mods/Advanced_Gear_Technologies/requirement_overrides.json
+++ b/data/Unleash_The_Mods/Working_mods/Advanced_Gear_Technologies/requirement_overrides.json
@@ -3,7 +3,7 @@
     "id": "welding_standard",
     "type": "requirement",
     "//": "Crafting or repair of steel items or installation of vehicle parts",
-    "qualities": [ { "id": "GLARE", "level": 2 } ],
+    "qualities": [ { "id": "GLARE", "level": 1 } ],
     "tools": [ [ [ "welder", 10 ], [ "welder_crude", 15 ], [ "toolset", 15 ], [ "oxy_torch", 2 ], [ "nanite_multitool_weld", -1 ] ] ]
   },
   {


### PR DESCRIPTION
Required GLARE PROTECTION tool quality should be set to 1, as in the current experimental build there are no tools with GLARE PROTECTION 2 and in vanilla toolsets.json file it is now set to 1.

---
name: Pull request template
about: Create a pull request template.
title: "[Experimental]"
labels: Experimental F, bug
assignees: TheGoatGod

---

<!---
**Tags**
`put one of these in the title`
[Experimental] - normal tags
[E-3] - only for E Stable
[BrightNights] - only for Bright nights
[SoundPacks] - only for Sound Packs
[Fonts] - only for Fonts
[Documentation] - only for Documentation
--->

**Name the mod added to the compilation or fixed.**
Put the name of the mod(s) that you have added here and continue the number.

1. Advanced Gear and Technology

**fixes and tweeks.**
add all the mods you fixed here, with there fixes and tweaks. generalized.

1. Advanced Gear and Technology
a. GLARE PROTECTION level in requirements override
