### PR TITLE
[Experimental] [Mutant_Animals] Extend eggs_bird instead of overwrite

### DIFF
--- a/data/Unleash_The_Mods/Working_mods/Mutant_Animals/cooking_components.json
+++ b/data/Unleash_The_Mods/Working_mods/Mutant_Animals/cooking_components.json
@@ -2,22 +2,12 @@
   {
     "id": "eggs_bird",
     "type": "requirement",
-    "components": [
-      [
-        [ "egg_bird", 1 ],
-        [ "egg_chicken", 1 ],
-        [ "egg_grouse", 1 ],
-        [ "egg_crow", 1 ],
-        [ "egg_duck", 1 ],
-        [ "egg_goose_canadian", 1 ],
-        [ "egg_turkey", 1 ],
-        [ "egg_pheasant", 1 ],
-        [ "egg_cockatrice", 1 ],
-        [ "egg_songbird", 1 ],
+    "extend": {
+      "components": [
         [ "egg_bird_mutant_vultch", 1 ],
         [ "egg_bird_mutant_iridescent", 1 ],
         [ "egg_bird_mutant_elephant", 1 ]
-      ]
-    ]
+       ]
+     }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Mutant_Animals/cooking_components.json
+++ b/data/Unleash_The_Mods/Working_mods/Mutant_Animals/cooking_components.json
@@ -3,11 +3,11 @@
     "id": "eggs_bird",
     "type": "requirement",
     "extend": {
-      "components": [
+      "components": [ [
         [ "egg_bird_mutant_vultch", 1 ],
         [ "egg_bird_mutant_iridescent", 1 ],
         [ "egg_bird_mutant_elephant", 1 ]
-       ]
+       ] ]
      }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/Mutant_Animals/cooking_components.json
+++ b/data/Unleash_The_Mods/Working_mods/Mutant_Animals/cooking_components.json
@@ -3,11 +3,7 @@
     "id": "eggs_bird",
     "type": "requirement",
     "extend": {
-      "components": [ [
-        [ "egg_bird_mutant_vultch", 1 ],
-        [ "egg_bird_mutant_iridescent", 1 ],
-        [ "egg_bird_mutant_elephant", 1 ]
-       ] ]
-     }
+      "components": [ [ [ "egg_bird_mutant_vultch", 1 ], [ "egg_bird_mutant_iridescent", 1 ], [ "egg_bird_mutant_elephant", 1 ] ] ]
+    }
   }
 ]


### PR DESCRIPTION
This damn mod broke my eggs and made me spend 30 minutes tracking it down, thought I'd share the fix. I hope this repo is still maintained, not sure who's doing what anymore. I hope I followed the instructions correctly...

---
name: Pull request template
about: Create a pull request template.
title: "[Experimental]"
labels: Experimental F, bug
assignees: TheGoatGod

---

<!---
**Tags**
`put one of these in the title`
[Experimental] - normal tags
[E-3] - only for E Stable
[BrightNights] - only for Bright nights
[SoundPacks] - only for Sound Packs
[Fonts] - only for Fonts
[Documentation] - only for Documentation
--->

**Name the mod added to the compilation or fixed.**
Put the name of the mod(s) that you have added here and continue the number.

1. [mod name]

**fixes and tweeks.**
add all the mods you fixed here, with there fixes and tweaks. generalized.

1. [Mutant Animals]
a. [Changed egg cooking_components to extend instead of overwrite]
b. [what did you fix]
c. [what did you fix]
