### PR TITLE
[Experimental] Advanced Gear Technologies - Update to vanilla requirements base + mod additions

### DIFF
--- a/data/Unleash_The_Mods/Working_mods/Advanced_Gear_Technologies/requirement_overrides.json
+++ b/data/Unleash_The_Mods/Working_mods/Advanced_Gear_Technologies/requirement_overrides.json
@@ -4,13 +4,14 @@
     "type": "requirement",
     "//": "Crafting or repair of steel items or installation of vehicle parts",
     "qualities": [ { "id": "GLARE", "level": 1 } ],
-    "tools": [ [ [ "welder", 10 ], [ "welder_crude", 15 ], [ "toolset", 15 ], [ "oxy_torch", 2 ], [ "nanite_multitool_weld", -1 ] ] ]
+    "tools": [ [ [ "welder", 10 ], [ "welder_crude", 15 ], [ "toolset", 15 ], [ "oxy_torch", 2 ], [ "nanite_multitool_weld", -1 ] ] ],
+    "components": [ [ [ "welding_rod_steel", 3 ], [ "welding_wire_steel", 3 ], [ "brazing_rod_bronze", 3 ] ] ]
   },
   {
     "id": "forging_standard",
     "type": "requirement",
     "//": "Forging of steel items (per steel chunk), charcoal forge is already a substitute for forge",
-    "tools": [ [ [ "forge", 20 ], [ "oxy_torch", 20 ], [ "nanite_multitool_weld", -1 ] ] ]
+    "tools": [ [ [ "forge", 20 ], [ "oxy_torch", 20 ], [ "fake_arc_furnace", 10 ], [ "nanite_multitool_weld", -1 ] ] ]
   },
   {
     "id": "surface_heat",
@@ -18,6 +19,8 @@
     "//": "Heat usable for heating a surface - for example a pot or frying pan.",
     "tools": [
       [
+        [ "propane_cooker", 1 ],
+        [ "fake_oven", 1 ],
         [ "hotplate", 1 ],
         [ "multi_cooker", 1 ],
         [ "char_smoker", 1 ],
@@ -33,6 +36,8 @@
     "//": "Tools usable for providing heat usable for boiling water, but not necessarily for anything else.",
     "tools": [
       [
+        [ "propane_cooker", 1 ],
+        [ "fake_oven", 1 ],
         [ "hotplate", 1 ],
         [ "multi_cooker", 1 ],
         [ "char_smoker", 1 ],
@@ -60,8 +65,9 @@
         [ "hacksaw", -1 ],
         [ "multitool", -1 ],
         [ "boltcutters", -1 ],
+        [ "small_repairkit", -1 ], 
+        [ "large_repairkit", -1 ],
         [ "toolset", -1 ],
-        [ "toolbox", -1 ],
         [ "survivor_belt", -1 ],
         [ "nanite_multitool_small", -1 ]
       ]

--- a/data/Unleash_The_Mods/Working_mods/Advanced_Gear_Technologies/requirement_overrides.json
+++ b/data/Unleash_The_Mods/Working_mods/Advanced_Gear_Technologies/requirement_overrides.json
@@ -65,7 +65,7 @@
         [ "hacksaw", -1 ],
         [ "multitool", -1 ],
         [ "boltcutters", -1 ],
-        [ "small_repairkit", -1 ], 
+        [ "small_repairkit", -1 ],
         [ "large_repairkit", -1 ],
         [ "toolset", -1 ],
         [ "survivor_belt", -1 ],


### PR DESCRIPTION
This updates the base requirements to vanilla DDA standards + mod additions as seems to have been the original intention. The only thing I'm uncertain of is the "survivor_belt" in wire cutting...I think that's handled differently now, but I'm not certain. And I left the toolset in wire cutting because it makes sense. All else is vanilla + the original mod.

---
name: Pull request template
about: Create a pull request template.
title: "[Experimental]"
labels: Experimental F, bug
assignees: TheGoatGod

---

<!---
**Tags**
`put one of these in the title`
[Experimental] - normal tags
[E-3] - only for E Stable
[BrightNights] - only for Bright nights
[SoundPacks] - only for Sound Packs
[Fonts] - only for Fonts
[Documentation] - only for Documentation
--->

**Name the mod added to the compilation or fixed.**
Put the name of the mod(s) that you have added here and continue the number.

1. [Advanced Gear Technologies]
 a. [Update base requirements to include vanilla changes since mod creation.

**fixes and tweeks.**
add all the mods you fixed here, with there fixes and tweaks. generalized.

1. [mod name]
a. [what did you fix]
b. [what did you fix]
c. [what did you fix]
