### PR TITLE
[Experimental] Updates CBM Arms 

### DIFF
--- a/data/Unleash_The_Mods/Working_mods/CBM_Arms/cbma_armors.json
+++ b/data/Unleash_The_Mods/Working_mods/CBM_Arms/cbma_armors.json
@@ -72,41 +72,13 @@
   },
   {
     "id": "cbma_enhanced_armor_on",
+    "copy-from": "cbma_enhanced_armor",
+    "repairs_like": "cbma_enhanced_armor",
     "type": "TOOL_ARMOR",
-    "category": "armor",
     "name": { "str": "enhanced bionic armor (on)" },
-    "description": "A tough and lightweight protective suit that combines superalloys and Kevlar, this is a gem that should be called Survivor Power Armor. The built-in mechanism that is activated strengthens the cardiopulmonary function and can exert greater power than usual.",
-    "weight": "4100 g",
-    "volume": "10500 ml",
     "turns_per_charge": 20,
-    "ammo": [ "battery" ],
-    "price": "28500 USD",
-    "material": [ "kevlar", "refinedalloy" ],
-    "symbol": "[",
-    "color": "dark_gray",
-    "looks_like": "survivor_suit",
-    "armor": [ { "encumbrance": 6, "coverage": 100, "covers": [ "torso" ] } ],
-    "pocket_data": [
-      { "pocket_type": "CONTAINER", "max_contains_volume": "2400 ml", "max_contains_weight": "7 kg", "moves": 65 },
-      { "pocket_type": "CONTAINER", "max_contains_volume": "2400 ml", "max_contains_weight": "7 kg", "moves": 65 },
-      { "pocket_type": "CONTAINER", "max_contains_volume": "640 ml", "max_contains_weight": "2 kg", "moves": 75 },
-      { "pocket_type": "CONTAINER", "max_contains_volume": "640 ml", "max_contains_weight": "2 kg", "moves": 75 },
-      { "pocket_type": "CONTAINER", "max_contains_volume": "1700 ml", "max_contains_weight": "4 kg", "moves": 110 },
-      { "pocket_type": "CONTAINER", "max_contains_volume": "1700 ml", "max_contains_weight": "4 kg", "moves": 110 },
-      {
-        "magazine_well": "250 ml",
-        "pocket_type": "MAGAZINE_WELL",
-        "holster": true,
-        "max_contains_volume": "20 L",
-        "max_contains_weight": "20 kg",
-        "item_restriction": [ "heavy_battery_cell", "heavy_plus_battery_cell", "heavy_atomic_battery_cell", "heavy_disposable_cell" ]
-      }
-    ],
-    "warmth": 15,
-    "material_thickness": 6,
-    "environmental_protection": 15,
-    "flags": [ "VARSIZE", "WATERPROOF", "WATER_FRIENDLY", "RAINPROOF", "STURDY", "OVERSIZE", "TRADER_AVOID", "NO_UNLOAD" ],
-    "use_action": { "type": "transform", "msg": "Your %s deactivates.", "target": "cbma_enhanced_armor" },
+    "armor": [ { "encumbrance": 0, "coverage": 100, "covers": [ "torso" ] } ],
+    "use_action": { "type": "transform", "msg": "Your %s deactivates.", "target": "cbma_enhanced_armor", "menu_text": "Turn off" },
     "relic_data": {
       "passive_effects": [
         {
@@ -130,8 +102,6 @@
     "weight": "856 g",
     "volume": "2500 ml",
     "price": "960 USD",
-    "to_hit": -1,
-    "bashing": 10,
     "material": [ "kevlar", "superalloy" ],
     "symbol": "[",
     "color": "dark_gray",
@@ -151,8 +121,6 @@
     "weight": "856 g",
     "volume": "2500 ml",
     "price": "960 USD",
-    "to_hit": -1,
-    "bashing": 10,
     "material": [ "kevlar", "superalloy" ],
     "symbol": "[",
     "color": "dark_gray",
@@ -183,8 +151,6 @@
     ],
     "ammo": [ "battery" ],
     "price": "960 USD",
-    "to_hit": -1,
-    "bashing": 10,
     "material": [ "kevlar", "refinedalloy" ],
     "symbol": "[",
     "color": "dark_gray",
@@ -217,37 +183,13 @@
   },
   {
     "id": "cbma_enhanced_helmet_on",
+    "copy-from": "cbma_enhanced_helmet",
+    "repairs_like": "cbma_enhanced_helmet",
     "type": "TOOL_ARMOR",
-    "category": "armor",
     "name": { "str": "enhanced bionic helmet (on)" },
-    "description": "A tough and lightweight protective helmet that combines superalloys and Kevlar, it is a gem that should be called Survivor Power Armor. It operates the built-in expansion system and is capable of aiming assistance, loud protection, and underwater activities.",
-    "weight": "856 g",
-    "volume": "2500 ml",
     "turns_per_charge": 20,
-    "ammo": [ "battery" ],
-    "pocket_data": [
-      {
-        "magazine_well": "250 ml",
-        "pocket_type": "MAGAZINE_WELL",
-        "holster": true,
-        "max_contains_volume": "20 L",
-        "max_contains_weight": "20 kg",
-        "item_restriction": [ "heavy_battery_cell", "heavy_plus_battery_cell", "heavy_atomic_battery_cell", "heavy_disposable_cell" ]
-      }
-    ],
-    "price": "960 USD",
-    "to_hit": -1,
-    "bashing": 10,
-    "material": [ "kevlar", "refinedalloy" ],
-    "symbol": "[",
-    "color": "dark_gray",
-    "looks_like": "helmet_hsurvivor",
     "armor": [ { "encumbrance": 0, "coverage": 100, "covers": [ "head", "mouth", "eyes" ] } ],
-    "warmth": 15,
-    "material_thickness": 6,
-    "environmental_protection": 24,
-    "qualities": [ [ "GLARE", 2 ] ],
-    "use_action": { "type": "transform", "msg": "Your %s deactivates.", "target": "cbma_enhanced_helmet" },
+    "use_action": { "type": "transform", "msg": "Your %s deactivates.", "target": "cbma_enhanced_helmet", "menu_text": "Turn off" },
     "flags": [
       "VARSIZE",
       "WATERPROOF",
@@ -287,7 +229,6 @@
     "weight": "190 g",
     "volume": "1000 ml",
     "price": "380 USD",
-    "to_hit": 2,
     "material": [ "kevlar", "superalloy" ],
     "symbol": "[",
     "color": "dark_gray",
@@ -318,7 +259,6 @@
       }
     ],
     "price": "380 USD",
-    "to_hit": 2,
     "material": [ "kevlar", "refinedalloy" ],
     "symbol": "[",
     "color": "dark_gray",
@@ -339,36 +279,13 @@
   },
   {
     "id": "cbma_enhanced_gloves_on",
+    "copy-from": "cbma_enhanced_gloves",
+    "repairs_like": "cbma_enhanced_gloves",
     "type": "TOOL_ARMOR",
-    "category": "armor",
     "name": { "str": "enhanced bionic gloves (on)" },
-    "description": "A tough and lightweight pair of superalloys and Kevlar combined with a further improvement to the hand, this is a gem that should be called Survivor Power Armor. The embedded electronic auxiliary system enables accurate operation and does not disturb the operation at all.",
-    "weight": "190 g",
-    "volume": "1 L",
     "turns_per_charge": 20,
-    "ammo": [ "battery" ],
-    "pocket_data": [
-      {
-        "magazine_well": "250 ml",
-        "pocket_type": "MAGAZINE_WELL",
-        "holster": true,
-        "max_contains_volume": "20 L",
-        "max_contains_weight": "20 kg",
-        "item_restriction": [ "heavy_battery_cell", "heavy_plus_battery_cell", "heavy_atomic_battery_cell", "heavy_disposable_cell" ]
-      }
-    ],
-    "price": "380 USD",
-    "to_hit": 2,
-    "material": [ "kevlar", "refinedalloy" ],
-    "symbol": "[",
-    "color": "dark_gray",
-    "looks_like": "gloves_lsurvivor",
     "armor": [ { "encumbrance": 0, "coverage": 100, "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ] } ],
-    "warmth": 15,
-    "material_thickness": 6,
-    "environmental_protection": 15,
-    "use_action": { "type": "transform", "msg": "Your %s deactivates.", "target": "cbma_enhanced_gloves" },
-    "flags": [ "VARSIZE", "WATERPROOF", "WATER_FRIENDLY", "STURDY", "OVERSIZE", "TRADER_AVOID" ]
+    "use_action": { "type": "transform", "msg": "Your %s deactivates.", "target": "cbma_enhanced_gloves", "menu_text": "Turn off" }
   },
   {
     "id": "cbma_bionic_boots",
@@ -379,8 +296,6 @@
     "weight": "800 g",
     "volume": "3 L",
     "price": "500 USD",
-    "to_hit": -1,
-    "bashing": 1,
     "material": [ "kevlar", "superalloy" ],
     "symbol": "[",
     "color": "dark_gray",
@@ -411,8 +326,6 @@
       }
     ],
     "price": "500 USD",
-    "to_hit": -1,
-    "bashing": 1,
     "material": [ "kevlar", "refinedalloy" ],
     "symbol": "[",
     "color": "dark_gray",
@@ -433,37 +346,13 @@
   },
   {
     "id": "cbma_enhanced_boots_on",
+    "copy-from": "cbma_enhanced_boots",
+    "repairs_like": "cbma_enhanced_boots",
     "type": "TOOL_ARMOR",
-    "category": "armor",
     "name": { "str": "enhanced bionic boots (on)" },
-    "description": "A tough and lightweight protective boot that combines superalloys and Kevlar, it is a gem that should be called Survivor Power Armor. The lower-limb aiding device is in operation and helps more accurate avoidance and positioning.",
-    "weight": "800 g",
-    "volume": "3 L",
     "turns_per_charge": 20,
-    "ammo": [ "battery" ],
-    "pocket_data": [
-      {
-        "magazine_well": "250 ml",
-        "pocket_type": "MAGAZINE_WELL",
-        "holster": true,
-        "max_contains_volume": "20 L",
-        "max_contains_weight": "20 kg",
-        "item_restriction": [ "heavy_battery_cell", "heavy_plus_battery_cell", "heavy_atomic_battery_cell", "heavy_disposable_cell" ]
-      }
-    ],
-    "price": "500 USD",
-    "to_hit": -1,
-    "bashing": 1,
-    "material": [ "kevlar", "refinedalloy" ],
-    "symbol": "[",
-    "color": "dark_gray",
-    "looks_like": "boots_plate",
-    "armor": [ { "encumbrance": 6, "coverage": 100, "covers": [ "leg_l", "leg_r", "foot_l", "foot_r" ] } ],
-    "warmth": 15,
-    "material_thickness": 6,
-    "environmental_protection": 15,
-    "flags": [ "VARSIZE", "WATERPROOF", "WATER_FRIENDLY", "STURDY", "OVERSIZE", "TRADER_AVOID" ],
-    "use_action": { "type": "transform", "msg": "Your %s deactivates.", "target": "cbma_enhanced_boots" },
+    "armor": [ { "encumbrance": 0, "coverage": 100, "covers": [ "leg_l", "leg_r", "foot_l", "foot_r" ] } ],
+    "use_action": { "type": "transform", "msg": "Your %s deactivates.", "target": "cbma_enhanced_boots", "menu_text": "Turn off" },
     "relic_data": {
       "passive_effects": [
         {
@@ -487,7 +376,6 @@
     "weight": "960 g",
     "volume": "7 L",
     "price": "400 USD",
-    "to_hit": -1,
     "material": [ "cotton", "kevlar" ],
     "symbol": "[",
     "color": "brown",
@@ -516,7 +404,6 @@
     "volume": "7 L",
     "ammo": [ "battery" ],
     "price": "400 USD",
-    "to_hit": -1,
     "material": [ "kevlar", "refinedalloy" ],
     "symbol": "[",
     "color": "brown",
@@ -565,54 +452,13 @@
   },
   {
     "id": "cbma_enhanced_duster_on",
+    "copy-from": "cbma_enhanced_duster",
+    "repairs_like": "cbma_enhanced_duster",
     "type": "TOOL_ARMOR",
-    "category": "armor",
     "name": { "str": "enhanced bionic duster (on)" },
-    "description": "A specially made coat that incorporates superalloy point armor and a whole-body dielectric device into the bionic coat. The dielectric device is activated and can protect the wearer from electrical damage.",
-    "weight": "960 g",
-    "volume": "7 L",
     "turns_per_charge": 20,
-    "ammo": [ "battery" ],
-    "price": "400 USD",
-    "to_hit": -1,
-    "material": [ "kevlar", "refinedalloy" ],
-    "symbol": "[",
-    "color": "brown",
-    "looks_like": "trenchcoat_survivor",
-    "armor": [ { "encumbrance": 10, "coverage": 85, "covers": [ "torso" ] } ],
-    "pocket_data": [
-      { "pocket_type": "CONTAINER", "max_contains_volume": "2400 ml", "max_contains_weight": "7 kg", "moves": 75 },
-      { "pocket_type": "CONTAINER", "max_contains_volume": "2400 ml", "max_contains_weight": "7 kg", "moves": 75 },
-      { "pocket_type": "CONTAINER", "max_contains_volume": "2400 ml", "max_contains_weight": "7 kg", "moves": 75 },
-      { "pocket_type": "CONTAINER", "max_contains_volume": "2400 ml", "max_contains_weight": "7 kg", "moves": 75 },
-      { "pocket_type": "CONTAINER", "max_contains_volume": "1400 ml", "max_contains_weight": "3 kg", "moves": 100 },
-      { "pocket_type": "CONTAINER", "max_contains_volume": "1400 ml", "max_contains_weight": "3 kg", "moves": 100 },
-      {
-        "magazine_well": "250 ml",
-        "pocket_type": "MAGAZINE_WELL",
-        "holster": true,
-        "max_contains_volume": "20 L",
-        "max_contains_weight": "20 kg",
-        "item_restriction": [ "heavy_battery_cell", "heavy_plus_battery_cell", "heavy_atomic_battery_cell", "heavy_disposable_cell" ]
-      }
-    ],
-    "warmth": 0,
-    "material_thickness": 5,
-    "environmental_protection": 15,
-    "flags": [
-      "VARSIZE",
-      "POCKETS",
-      "HOOD",
-      "COLLAR",
-      "STURDY",
-      "WATERPROOF",
-      "WATER_FRIENDLY",
-      "RAINPROOF",
-      "OUTER",
-      "OVERSIZE",
-      "TRADER_AVOID"
-    ],
-    "use_action": { "type": "transform", "msg": "Your %s deactivates.", "target": "cbma_enhanced_duster" },
+    "armor": [ { "encumbrance": 0, "coverage": 85, "covers": [ "torso" ] } ],
+    "use_action": { "type": "transform", "msg": "Your %s deactivates.", "target": "cbma_enhanced_duster", "menu_text": "Turn off" },
     "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "ARMOR_ELEC", "add": 20 } ] } ] }
   },
   {
@@ -636,7 +482,6 @@
       }
     ],
     "price": "400 USD",
-    "to_hit": -10,
     "material": [ "steel", "superalloy" ],
     "symbol": "[",
     "color": "light_gray",
@@ -671,30 +516,11 @@
   },
   {
     "id": "cbma_carry_frame_on",
+    "copy-from": "cbma_carry_frame",
+    "repairs_like": "cbma_carry_frame",
     "type": "TOOL_ARMOR",
-    "category": "armor",
     "name": { "str": "bionic transport frame (on)" },
-    "description": "It is a modified version of the transport frame for Power Armor so that it can be used alone.",
-    "weight": "2500 g",
-    "volume": "7 L",
     "turns_per_charge": 20,
-    "pocket_data": [
-      { "pocket_type": "CONTAINER", "max_contains_volume": "40 L", "max_contains_weight": "50 kg", "moves": 1400 },
-      {
-        "magazine_well": "250 ml",
-        "pocket_type": "MAGAZINE_WELL",
-        "holster": true,
-        "max_contains_volume": "20 L",
-        "max_contains_weight": "20 kg",
-        "item_restriction": [ "heavy_battery_cell", "heavy_plus_battery_cell", "heavy_atomic_battery_cell", "heavy_disposable_cell" ]
-      }
-    ],
-    "price": "400 USD",
-    "to_hit": -10,
-    "material": [ "steel", "superalloy" ],
-    "symbol": "[",
-    "color": "light_gray",
-    "looks_like": "power_armor_frame",
     "armor": [
       {
         "encumbrance": 40,
@@ -702,10 +528,7 @@
         "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
       }
     ],
-    "warmth": 0,
-    "material_thickness": 7,
-    "flags": [ "STURDY", "WATERPROOF", "WATER_FRIENDLY", "RAINPROOF", "OUTER", "OVERSIZE", "TRADER_AVOID" ],
-    "use_action": { "type": "transform", "msg": "Your %s deactivates.", "target": "cbma_carry_frame" },
+    "use_action": { "type": "transform", "msg": "Your %s deactivates.", "target": "cbma_carry_frame", "menu_text": "Turn off" },
     "relic_data": {
       "passive_effects": [
         {
@@ -726,7 +549,6 @@
     "weight": "100 g",
     "volume": "4500 ml",
     "price": "400 USD",
-    "to_hit": -1,
     "material": [ "myomer" ],
     "symbol": "[",
     "color": "light_gray",
@@ -762,29 +584,11 @@
   },
   {
     "id": "cbma_inner_suite_on",
+    "copy-from": "cbma_inner_suit",
+    "repairs_like": "cbma_inner_suit",
     "type": "TOOL_ARMOR",
-    "category": "armor",
     "name": { "str": "inner armored suit (on)" },
-    "description": "A thin, strong Myamar inner suit covering the entire body. Electric power is supplied to the artificial muscles, and the original performance is exhibited.",
-    "weight": "100 g",
-    "volume": "4500 ml",
-    "price": "400 USD",
-    "to_hit": -1,
     "material": [ "myomer_on" ],
-    "symbol": "[",
-    "color": "light_gray",
-    "looks_like": "jumpsuit_xl",
-    "ammo": [ "battery" ],
-    "pocket_data": [
-      {
-        "magazine_well": "250 ml",
-        "pocket_type": "MAGAZINE_WELL",
-        "holster": true,
-        "max_contains_volume": "20 L",
-        "max_contains_weight": "20 kg",
-        "item_restriction": [ "heavy_battery_cell", "heavy_plus_battery_cell", "heavy_atomic_battery_cell", "heavy_disposable_cell" ]
-      }
-    ],
     "turns_per_charge": 20,
     "armor": [
       {
@@ -793,8 +597,6 @@
         "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
       }
     ],
-    "warmth": 0,
-    "material_thickness": 1,
     "environmental_protection": 20,
     "flags": [
       "WATERPROOF",
@@ -807,7 +609,7 @@
       "CLIMATE_CONTROL",
       "STURDY"
     ],
-    "use_action": { "type": "transform", "msg": "Your %s deactivates.", "target": "cbma_inner_suite" },
+    "use_action": { "type": "transform", "msg": "Your %s deactivates.", "target": "cbma_inner_suite", "menu_text": "Turn off" },
     "relic_data": {
       "passive_effects": [
         {
@@ -827,11 +629,10 @@
     "id": "cbma_enhanced_armor_ups",
     "type": "TOOL_ARMOR",
     "category": "armor",
-    "name": { "str": "enhanced bionic armor (off) (UPS)" },
+    "name": { "str": "enhanced bionic armor (off)" },
     "description": "A tough and lightweight protective suit that combines superalloys and Kevlar, this is a gem that should be called Survivor Power Armor. Power for normal operation is supplied by Solar and Ratchet. It has been modified so that UPS can supply power.",
     "weight": "4100 g",
     "volume": "10500 ml",
-    "charges_per_use": 1,
     "ammo": [ "battery" ],
     "price": "28500 USD",
     "material": [ "kevlar", "refinedalloy" ],
@@ -873,69 +674,46 @@
   },
   {
     "id": "cbma_enhanced_armor_ups_on",
+    "copy-from": "cbma_enhanced_armor_ups",
+    "repairs_like": "cbma_enhanced_armor_ups",
     "type": "TOOL_ARMOR",
-    "category": "armor",
-    "name": { "str": "enhanced bionic armor (on) (UPS)" },
-    "description": "A tough and lightweight protective suit that combines superalloys and Kevlar, this is a gem that should be called Survivor Power Armor. The built-in mechanism that is activated strengthens the cardiopulmonary function and can exert greater power than usual. It has been modified so that the UPS can supply power.",
-    "weight": "4100 g",
-    "volume": "10500 ml",
-    "turns_per_charge": 10,
-    "ammo": [ "battery" ],
-    "price": "28500 USD",
-    "material": [ "kevlar", "refinedalloy" ],
-    "symbol": "[",
-    "color": "dark_gray",
-    "looks_like": "survivor_suit",
-    "armor": [ { "encumbrance": 6, "coverage": 100, "covers": [ "torso" ] } ],
-    "pocket_data": [
-      { "pocket_type": "CONTAINER", "max_contains_volume": "2400 ml", "max_contains_weight": "7 kg", "moves": 65 },
-      { "pocket_type": "CONTAINER", "max_contains_volume": "2400 ml", "max_contains_weight": "7 kg", "moves": 65 },
-      { "pocket_type": "CONTAINER", "max_contains_volume": "640 ml", "max_contains_weight": "2 kg", "moves": 75 },
-      { "pocket_type": "CONTAINER", "max_contains_volume": "640 ml", "max_contains_weight": "2 kg", "moves": 75 },
-      { "pocket_type": "CONTAINER", "max_contains_volume": "1700 ml", "max_contains_weight": "4 kg", "moves": 110 },
-      { "pocket_type": "CONTAINER", "max_contains_volume": "1700 ml", "max_contains_weight": "4 kg", "moves": 110 }
-    ],
-    "warmth": 15,
-    "material_thickness": 6,
-    "environmental_protection": 15,
+    "name": { "str": "enhanced bionic armor (on)" },
+    "turns_per_charge": 20,
     "revert_to": "cbma_enhanced_armor_ups",
-    "flags": [
-      "VARSIZE",
-      "WATERPROOF",
-      "WATER_FRIENDLY",
-      "RAINPROOF",
-      "STURDY",
-      "OVERSIZE",
-      "TRADER_AVOID",
-      "NO_UNLOAD",
-      "USE_UPS",
-      "NO_RELOAD"
-    ],
-    "use_action": { "type": "transform", "msg": "Your %s deactivates.", "target": "cbma_enhanced_armor_ups" },
-    "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "STRENGTH", "add": 3 } ] } ] }
+    "use_action": { "type": "transform", "msg": "Your %s deactivates.", "target": "cbma_enhanced_armor_ups", "menu_text": "Turn off" },
+    "armor": [ { "encumbrance": 0, "coverage": 100, "covers": [ "torso" ] } ],
+    "relic_data": {
+      "passive_effects": [
+        {
+          "has": "WORN",
+          "condition": "ALWAYS",
+          "values": [
+            { "value": "STRENGTH", "add": 3 },
+            { "value": "ATTACK_SPEED", "multiply": 0.015 },
+            { "value": "METABOLISM", "multiply": 0.01 }
+          ]
+        }
+      ]
+    }
   },
   {
     "id": "cbma_enhanced_helmet_ups",
     "type": "TOOL_ARMOR",
     "category": "armor",
-    "name": { "str": "enhanced helmet (off) (UPS)" },
+    "name": { "str": "enhanced bionic helmet (off)" },
     "description": "A tough and lightweight protective helmet that combines superalloys and Kevlar, it is a gem that should be called Survivor Power Armor. By activating various expansion systems installed inside, it is possible to operate under various environments. It has been modified so that the UPS can supply power.",
     "weight": "856 g",
     "volume": "2500 ml",
-    "charges_per_use": 1,
     "ammo": [ "battery" ],
     "price": "960 USD",
-    "to_hit": -1,
-    "bashing": 10,
     "material": [ "kevlar", "refinedalloy" ],
+    "looks_like": "power_armor_helmet_basic",
     "symbol": "[",
     "color": "dark_gray",
-    "looks_like": "helmet_hsurvivor",
     "armor": [ { "encumbrance": 12, "coverage": 100, "covers": [ "head", "mouth", "eyes" ] } ],
     "warmth": 15,
     "material_thickness": 6,
     "environmental_protection": 24,
-    "techniques": [ "WBLOCK_1" ],
     "qualities": [ [ "GLARE", 2 ] ],
     "use_action": {
       "type": "transform",
@@ -958,43 +736,18 @@
       "NO_UNLOAD",
       "USE_UPS",
       "NO_RELOAD"
-    ],
-    "pocket_data": [
-      {
-        "magazine_well": "250 ml",
-        "pocket_type": "MAGAZINE_WELL",
-        "holster": true,
-        "max_contains_volume": "10 L",
-        "max_contains_weight": "10 kg",
-        "item_restriction": [ "light_plus_battery_cell", "light_battery_cell", "light_atomic_battery_cell", "light_disposable_cell" ]
-      }
     ]
   },
   {
     "id": "cbma_enhanced_helmet_ups_on",
+    "copy-from": "cbma_enhanced_helmet_ups",
+    "repairs_like": "cbma_enhanced_helmet_ups",
     "type": "TOOL_ARMOR",
-    "category": "armor",
-    "name": { "str": "enhanced bionic helmet (on) (UPS)" },
-    "description": "A tough and lightweight protective helmet that combines superalloys and Kevlar, it is a gem that should be called Survivor Power Armor. It operates the built-in expansion system and is capable of aiming assistance, loud protection, and underwater activities. It has been modified so that the UPS can supply power.",
-    "weight": "856 g",
-    "volume": "2500 ml",
-    "turns_per_charge": 10,
-    "ammo": [ "battery" ],
-    "price": "960 USD",
-    "to_hit": -1,
-    "bashing": 10,
-    "material": [ "kevlar", "refinedalloy" ],
-    "symbol": "[",
-    "color": "dark_gray",
-    "looks_like": "helmet_hsurvivor",
+    "name": { "str": "enhanced bionic helmet (on)" },
+    "turns_per_charge": 20,
     "armor": [ { "encumbrance": 0, "coverage": 100, "covers": [ "head", "mouth", "eyes" ] } ],
-    "warmth": 15,
-    "material_thickness": 6,
-    "environmental_protection": 24,
     "revert_to": "cbma_enhanced_helmet_ups",
-    "techniques": [ "WBLOCK_1" ],
-    "qualities": [ [ "GLARE", 2 ] ],
-    "use_action": { "type": "transform", "msg": "Your %s deactivates.", "target": "cbma_enhanced_helmet_ups" },
+    "use_action": { "type": "transform", "msg": "Your %s deactivates.", "target": "cbma_enhanced_helmet_ups", "menu_text": "Turn off" },
     "flags": [
       "VARSIZE",
       "WATERPROOF",
@@ -1013,30 +766,18 @@
       "USE_UPS",
       "NO_RELOAD"
     ],
-    "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "PERCEPTION", "add": 3 } ] } ] },
-    "pocket_data": [
-      {
-        "magazine_well": "250 ml",
-        "pocket_type": "MAGAZINE_WELL",
-        "holster": true,
-        "max_contains_volume": "10 L",
-        "max_contains_weight": "10 kg",
-        "item_restriction": [ "light_plus_battery_cell", "light_battery_cell", "light_atomic_battery_cell", "light_disposable_cell" ]
-      }
-    ]
+    "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "PERCEPTION", "add": 3 } ] } ] }
   },
   {
     "id": "cbma_enhanced_gloves_ups",
     "type": "TOOL_ARMOR",
     "category": "armor",
-    "name": { "str": "enhanced bionic gloves (off) (UPS)" },
+    "name": { "str": "enhanced bionic gloves (off)" },
     "description": "A tough and lightweight pair of superalloys and Kevlar combined with a further improvement to the hand, this is a gem that should be called Survivor Power Armor. It has been modified so that the UPS can supply power.",
     "weight": "190 g",
     "volume": "1 L",
-    "charges_per_use": 1,
     "ammo": [ "battery" ],
     "price": "380 USD",
-    "to_hit": 2,
     "material": [ "kevlar", "refinedalloy" ],
     "symbol": "[",
     "color": "dark_gray",
@@ -1053,65 +794,30 @@
       "need_charges": 1,
       "need_charges_msg": "The system started for a moment... and then went silent."
     },
-    "flags": [ "VARSIZE", "WATERPROOF", "WATER_FRIENDLY", "STURDY", "OVERSIZE", "TRADER_AVOID", "USE_UPS", "NO_UNLOAD", "NO_RELOAD" ],
-    "pocket_data": [
-      {
-        "magazine_well": "250 ml",
-        "pocket_type": "MAGAZINE_WELL",
-        "holster": true,
-        "max_contains_volume": "10 L",
-        "max_contains_weight": "10 kg",
-        "item_restriction": [ "light_plus_battery_cell", "light_battery_cell", "light_atomic_battery_cell", "light_disposable_cell" ]
-      }
-    ]
+    "flags": [ "VARSIZE", "WATERPROOF", "WATER_FRIENDLY", "STURDY", "OVERSIZE", "TRADER_AVOID", "USE_UPS", "NO_UNLOAD", "NO_RELOAD" ]
   },
   {
     "id": "cbma_enhanced_gloves_ups_on",
+    "copy-from": "cbma_enhanced_gloves_ups",
+    "repairs_like": "cbma_enhanced_gloves_ups",
     "type": "TOOL_ARMOR",
-    "category": "armor",
-    "name": { "str": "enhanced bionic gloves (on) (UPS)" },
-    "description": "A tough and lightweight pair of superalloys and Kevlar combined with a further improvement to the hand, this is a gem that should be called Survivor Power Armor. The embedded electronic auxiliary system enables accurate operation and does not disturb the operation at all. It has been modified so that the UPS can supply power.",
-    "weight": "190 g",
-    "volume": "1 L",
-    "turns_per_charge": 10,
+    "name": { "str": "enhanced bionic gloves (on)" },
+    "turns_per_charge": 20,
     "ammo": [ "battery" ],
-    "price": "380 USD",
-    "to_hit": 2,
-    "material": [ "kevlar", "refinedalloy" ],
-    "symbol": "[",
-    "color": "dark_gray",
-    "looks_like": "gloves_lsurvivor",
     "armor": [ { "encumbrance": 0, "coverage": 100, "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ] } ],
-    "warmth": 15,
-    "material_thickness": 6,
-    "environmental_protection": 15,
     "revert_to": "cbma_enhanced_gloves_ups",
-    "use_action": { "type": "transform", "msg": "Your %s deactivates.", "target": "cbma_enhanced_gloves_ups" },
-    "flags": [ "VARSIZE", "WATERPROOF", "WATER_FRIENDLY", "STURDY", "OVERSIZE", "TRADER_AVOID", "USE_UPS", "NO_UNLOAD", "NO_RELOAD" ],
-    "pocket_data": [
-      {
-        "magazine_well": "250 ml",
-        "pocket_type": "MAGAZINE_WELL",
-        "holster": true,
-        "max_contains_volume": "10 L",
-        "max_contains_weight": "10 kg",
-        "item_restriction": [ "light_plus_battery_cell", "light_battery_cell", "light_atomic_battery_cell", "light_disposable_cell" ]
-      }
-    ]
+    "use_action": { "type": "transform", "msg": "Your %s deactivates.", "target": "cbma_enhanced_gloves_ups", "menu_text": "Turn off" }
   },
   {
     "id": "cbma_enhanced_boots_ups",
     "type": "TOOL_ARMOR",
     "category": "armor",
-    "name": { "str": "enhanced bionic boots (off) (UPS)" },
+    "name": { "str": "enhanced bionic boots (off)" },
     "description": "A tough and lightweight protective boot that combines superalloys and Kevlar, it is a gem that should be called Survivor Power Armor. When activated, it activates the lower limb operation support device. It has been modified so that the UPS can supply power.",
     "weight": "800 g",
     "volume": "3 L",
-    "charges_per_use": 1,
     "ammo": [ "battery" ],
     "price": "500 USD",
-    "to_hit": -1,
-    "bashing": 1,
     "material": [ "kevlar", "refinedalloy" ],
     "symbol": "[",
     "color": "dark_gray",
@@ -1128,66 +834,31 @@
       "active": true,
       "need_charges": 1,
       "need_charges_msg": "The system started for a moment... and then went silent."
-    },
-    "pocket_data": [
-      {
-        "magazine_well": "250 ml",
-        "pocket_type": "MAGAZINE_WELL",
-        "holster": true,
-        "max_contains_volume": "10 L",
-        "max_contains_weight": "10 kg",
-        "item_restriction": [ "light_plus_battery_cell", "light_battery_cell", "light_atomic_battery_cell", "light_disposable_cell" ]
-      }
-    ]
+    }
   },
   {
     "id": "cbma_enhanced_boots_ups_on",
+    "copy-from": "cbma_enhanced_boots_ups",
+    "repairs_like": "cbma_enhanced_boots_ups",
     "type": "TOOL_ARMOR",
-    "category": "armor",
-    "name": { "str": "enhanced bionic boots (on) (UPS)" },
-    "description": "A tough and lightweight protective boot that combines superalloys and Kevlar, it is a gem to be called Survivor Power Armor. The lower-limb aiding device is in operation and helps more accurate avoidance and positioning. It has been modified so that the UPS can supply power.",
-    "weight": "800 g",
-    "volume": "3 L",
-    "turns_per_charge": 10,
+    "name": { "str": "enhanced bionic boots (on)" },
+    "turns_per_charge": 20,
     "ammo": [ "battery" ],
-    "price": "500 USD",
-    "to_hit": -1,
-    "bashing": 1,
-    "material": [ "kevlar", "refinedalloy" ],
-    "symbol": "[",
-    "color": "dark_gray",
-    "looks_like": "boots_plate",
-    "armor": [ { "encumbrance": 6, "coverage": 100, "covers": [ "leg_l", "leg_r", "foot_l", "foot_r" ] } ],
-    "warmth": 15,
-    "material_thickness": 6,
-    "environmental_protection": 15,
+    "armor": [ { "encumbrance": 0, "coverage": 100, "covers": [ "leg_l", "leg_r", "foot_l", "foot_r" ] } ],
     "revert_to": "cbma_enhanced_boots_ups",
-    "flags": [ "VARSIZE", "WATERPROOF", "WATER_FRIENDLY", "STURDY", "OVERSIZE", "TRADER_AVOID", "USE_UPS", "NO_UNLOAD", "NO_RELOAD" ],
-    "use_action": { "type": "transform", "msg": "Your %s deactivates.", "target": "cbma_enhanced_boots_ups" },
-    "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "DEXTERITY", "add": 3 } ] } ] },
-    "pocket_data": [
-      {
-        "magazine_well": "250 ml",
-        "pocket_type": "MAGAZINE_WELL",
-        "holster": true,
-        "max_contains_volume": "10 L",
-        "max_contains_weight": "10 kg",
-        "item_restriction": [ "light_plus_battery_cell", "light_battery_cell", "light_atomic_battery_cell", "light_disposable_cell" ]
-      }
-    ]
+    "use_action": { "type": "transform", "msg": "Your %s deactivates.", "target": "cbma_enhanced_boots_ups", "menu_text": "Turn off" },
+    "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "DEXTERITY", "add": 3 } ] } ] }
   },
   {
     "id": "cbma_enhanced_duster_ups",
     "type": "TOOL_ARMOR",
     "category": "armor",
-    "name": { "str": "enhanced bionic duster (off) (UPS)" },
+    "name": { "str": "enhanced bionic duster (off)" },
     "description": "A specially made coat that incorporates superalloy point armor and a whole-body dielectric device into the bionic coat. By activating the dielectric device, the wearer can be protected from electrical damage. It has been modified so that the UPS can supply power.",
     "weight": "960 g",
     "volume": "7 L",
-    "charges_per_use": 1,
     "ammo": [ "battery" ],
     "price": "400 USD",
-    "to_hit": -1,
     "material": [ "kevlar", "refinedalloy" ],
     "symbol": "[",
     "color": "brown",
@@ -1218,7 +889,8 @@
       "TRADER_AVOID",
       "USE_UPS",
       "NO_UNLOAD",
-      "NO_RELOAD"
+      "NO_RELOAD",
+      "SOFT"
     ],
     "use_action": {
       "type": "transform",
@@ -1231,67 +903,30 @@
   },
   {
     "id": "cbma_enhanced_duster_ups_on",
+    "copy-from": "cbma_enhanced_duster_ups",
+    "repairs_like": "cbma_enhanced_duster_ups",
     "type": "TOOL_ARMOR",
-    "category": "armor",
-    "name": { "str": "enhanced bionic duster (on) (UPS)" },
-    "description": "A specially made coat that incorporates superalloy point armor and a whole-body dielectric device into the bionic coat. The dielectric device is activated and can protect the wearer from electrical damage. It has been modified so that the UPS can supply power.",
-    "weight": "960 g",
-    "volume": "7 L",
-    "turns_per_charge": 10,
+    "name": { "str": "enhanced bionic duster (on)" },
+    "turns_per_charge": 20,
     "ammo": [ "battery" ],
-    "price": "400 USD",
-    "to_hit": -1,
-    "material": [ "kevlar", "refinedalloy" ],
-    "symbol": "[",
-    "color": "brown",
-    "looks_like": "trenchcoat_survivor",
-    "armor": [ { "encumbrance": 10, "coverage": 85, "covers": [ "torso" ] } ],
-    "pocket_data": [
-      { "pocket_type": "CONTAINER", "max_contains_volume": "2400 ml", "max_contains_weight": "7 kg", "moves": 75 },
-      { "pocket_type": "CONTAINER", "max_contains_volume": "2400 ml", "max_contains_weight": "7 kg", "moves": 75 },
-      { "pocket_type": "CONTAINER", "max_contains_volume": "2400 ml", "max_contains_weight": "7 kg", "moves": 75 },
-      { "pocket_type": "CONTAINER", "max_contains_volume": "2400 ml", "max_contains_weight": "7 kg", "moves": 75 },
-      { "pocket_type": "CONTAINER", "max_contains_volume": "1400 ml", "max_contains_weight": "3 kg", "moves": 100 },
-      { "pocket_type": "CONTAINER", "max_contains_volume": "1400 ml", "max_contains_weight": "3 kg", "moves": 100 }
-    ],
-    "warmth": 0,
-    "material_thickness": 5,
-    "environmental_protection": 15,
+    "armor": [ { "encumbrance": 0, "coverage": 85, "covers": [ "torso" ] } ],
     "revert_to": "cbma_enhanced_duster_ups",
-    "flags": [
-      "VARSIZE",
-      "POCKETS",
-      "HOOD",
-      "COLLAR",
-      "STURDY",
-      "WATERPROOF",
-      "WATER_FRIENDLY",
-      "RAINPROOF",
-      "OUTER",
-      "OVERSIZE",
-      "TRADER_AVOID",
-      "USE_UPS",
-      "NO_UNLOAD",
-      "NO_RELOAD"
-    ],
-    "use_action": { "type": "transform", "msg": "Your %s deactivates.", "target": "cbma_enhanced_duster_ups" },
+    "use_action": { "type": "transform", "msg": "Your %s deactivates.", "target": "cbma_enhanced_duster_ups", "menu_text": "Turn off" },
     "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "ARMOR_ELEC", "add": 20 } ] } ] }
   },
   {
     "id": "cbma_inner_suite_ups",
     "type": "TOOL_ARMOR",
     "category": "armor",
-    "name": { "str": "inner armored suit (off) (UPS)" },
+    "name": { "str": "inner armored suit (off)" },
     "description": "A thin and strong inner cover made of Myamar fiber that covers the entire body so that it can be fed by UPS. The artificial muscles are not powered and do not perform as expected. Power supply is started by starting up.",
     "weight": "100 g",
     "volume": "4500 ml",
     "price": "400 USD",
-    "to_hit": -1,
     "material": [ "myomer" ],
     "symbol": "[",
     "color": "light_gray",
     "looks_like": "union_suit",
-    "charges_per_use": 1,
     "ammo": [ "battery" ],
     "armor": [
       {
@@ -1322,33 +957,15 @@
         "need_charges": 1,
         "need_charges_msg": "The system started for a moment... and then went silent."
       }
-    ],
-    "pocket_data": [
-      {
-        "magazine_well": "250 ml",
-        "pocket_type": "MAGAZINE_WELL",
-        "holster": true,
-        "max_contains_volume": "10 L",
-        "max_contains_weight": "10 kg",
-        "item_restriction": [ "light_plus_battery_cell", "light_battery_cell", "light_atomic_battery_cell", "light_disposable_cell" ]
-      }
     ]
   },
   {
     "id": "cbma_inner_suite_ups_on",
+    "copy-from": "cbma_inner_suite_ups",
+    "repairs_like": "cbma_inner_suit_ups",
     "type": "TOOL_ARMOR",
-    "category": "armor",
-    "name": { "str": "inner armored suit (on) (UPS)" },
-    "description": "A thin and strong inner cover made of Myamar fiber that covers the entire body so that it can be fed by UPS. Electric power is supplied to the artificial muscles, and the original performance is exhibited.",
-    "weight": "100 g",
-    "volume": "4500 ml",
-    "price": "400 USD",
-    "to_hit": -1,
-    "material": [ "myomer_on" ],
-    "symbol": "[",
-    "color": "light_gray",
-    "looks_like": "jumpsuit_xl",
-    "turns_per_charge": 10,
+    "name": { "str": "inner armored suit (on)" },
+    "turns_per_charge": 20,
     "ammo": [ "battery" ],
     "armor": [
       {
@@ -1357,7 +974,7 @@
         "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
       }
     ],
-    "warmth": 0,
+    "material": [ "myomer_on" ],
     "material_thickness": 1,
     "environmental_protection": 20,
     "revert_to": "cbma_inner_suite_ups",
@@ -1374,7 +991,7 @@
       "NO_RELOAD",
       "STURDY"
     ],
-    "use_action": { "type": "transform", "msg": "Your %s deactivates.", "target": "cbma_inner_suite_ups" },
+    "use_action": { "type": "transform", "msg": "Your %s deactivates.", "target": "cbma_inner_suite_ups", "menu_text": "Turn off" },
     "relic_data": {
       "passive_effects": [
         {
@@ -1388,16 +1005,6 @@
           ]
         }
       ]
-    },
-    "pocket_data": [
-      {
-        "magazine_well": "250 ml",
-        "pocket_type": "MAGAZINE_WELL",
-        "holster": true,
-        "max_contains_volume": "10 L",
-        "max_contains_weight": "10 kg",
-        "item_restriction": [ "light_plus_battery_cell", "light_battery_cell", "light_atomic_battery_cell", "light_disposable_cell" ]
-      }
-    ]
+    }
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/CBM_Arms/cbma_recipe_deconstruction.json
+++ b/data/Unleash_The_Mods/Working_mods/CBM_Arms/cbma_recipe_deconstruction.json
@@ -6,7 +6,7 @@
     "skill_used": "electronics",
     "difficulty": 7,
     "skills_required": [ "firstaid", 5 ],
-    "time": 50000,
+    "time": "50000 s",
     "using": [ [ "soldering_standard", 20 ] ],
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "components": [ [ [ "burnt_out_bionic", 1 ] ], [ [ "cbma_monoblade_part", 2 ] ] ]
@@ -18,7 +18,7 @@
     "skill_used": "electronics",
     "difficulty": 7,
     "skills_required": [ "firstaid", 5 ],
-    "time": 50000,
+    "time": "50000 s",
     "using": [ [ "soldering_standard", 20 ] ],
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "components": [ [ [ "burnt_out_bionic", 1 ] ], [ [ "cbma_myomer_fiber", 2 ] ] ]
@@ -29,7 +29,7 @@
     "type": "uncraft",
     "skill_used": "firstaid",
     "difficulty": 5,
-    "time": 1000,
+    "time": "1000 s",
     "components": [ [ [ "flask_glass", 1 ] ], [ [ "cbma_myomer_fiber", 1 ] ] ]
   }
 ]

--- a/data/Unleash_The_Mods/Working_mods/CBM_Arms/mod_tileset/mod_tileset.json
+++ b/data/Unleash_The_Mods/Working_mods/CBM_Arms/mod_tileset/mod_tileset.json
@@ -36,18 +36,6 @@
             ],
             "fg": 1,
             "rotates": false
-          },
-          {
-            "id": [
-              "overlay_worn_cbma_bionic_helmet",
-              "overlay_worn_cbma_bionic_mask",
-              "overlay_worn_cbma_enhanced_helmet",
-              "overlay_worn_cbma_enhanced_helmet_on",
-              "overlay_worn_cbma_enhanced_helmet_ups",
-              "overlay_worn_cbma_enhanced_helmet_ups_on"
-            ],
-            "fg": 2,
-            "rotates": false
           }
         ]
       }


### PR DESCRIPTION
---
name: [Experimental] Updates CBM Arms 
about: Updates CBM Arms to current experimental.
title: "[Experimental]"
labels: Experimental G, bug
assignees: TheGoatGod

---

<!---
**Tags**
`put one of these in the title`
[Experimental] - normal tags
[E-3] - only for E Stable
[BrightNights] - only for Bright nights
[SoundPacks] - only for Sound Packs
[Fonts] - only for Fonts
[Documentation] - only for Documentation
--->

**Name the mod added to the compilation or fixed.**
Put the name of the mod(s) that you have added here and continue the number.

1. CBM Arms 

**fixes and tweeks.**
add all the mods you fixed here, with there fixes and tweaks. generalized.

1. CBM Arms 
a. Removes tileset assignment without assigned graphic (causes invisible helmet when worn)
b. Overhauled the ups armor version to no longer be destroyed when activating them, matched their stats to the non-ups versions, removed unnecessary duplications using the "copy-from" keyword based on off ups version, removed their inaccessible and unnecessary battery magazine slots
c. General reformatting of items such as using "copy-from" when dealing with on / off variations, removed melee stats from armor pieces (ie the helmet no longer gives a blocking technique when wielded in hands)
d. Fixed time to be represented with a string rather than int
e. Note, relic data appears to be broken for items that transform into other items (such as power armor that turns on and off), which means that the bionic armor does not give stats it is intended to.  I was unable to discover any workaround to enable this functionality.
